### PR TITLE
Fix large image files when using libpixlet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ PIXLET_SERVE_PORT1=5100
 PIXLET_SERVE_PORT2=5101 # add incremented port for each extra user past 2, or use host network mode in docker-compose file
 SYSTEM_APPS_REPO="https://github.com/tronbyt/apps.git"
 PRODUCTION=1
+LOG_LEVEL=WARNING

--- a/tronbyt_server/__init__.py
+++ b/tronbyt_server/__init__.py
@@ -39,7 +39,7 @@ def render_app(
     )
     if ret.length >= 0:
         data = ctypes.cast(
-            ret.data, ctypes.POINTER(ctypes.c_uint32 * ret.length)
+            ret.data, ctypes.POINTER(ctypes.c_byte * ret.length)
         ).contents
         buf = bytes(data)
         free_bytes(ret.data)
@@ -72,6 +72,9 @@ def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
             if app.config["SERVER_PROTOCOL"] == "https":
                 app.config["SESSION_COOKIE_SECURE"] = True
             app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+            app.logger.setLevel(os.getenv("LOG_LEVEL", "WARNING"))
+        else:
+            app.logger.setLevel(os.getenv("LOG_LEVEL", "INFO"))
     else:
         app.config.from_mapping(
             SECRET_KEY="lksdj;as987q3908475ukjhfgklauy983475iuhdfkjghairutyh",


### PR DESCRIPTION
The allocated buffer was 4x the needed size due to a wrong type (`* int32` instead of `* unsigned char`).