### PR TITLE
Remove websocket proxy for pixlet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM ghcr.io/tronbyt/pixlet:latest AS pixlet
 # build runtime image
 FROM debian:trixie-slim AS runtime
 
-# 8000 for main app, 5100, 5101 for pixlet serve iframe
-EXPOSE 8000 5100 5101
+# 8000 for main app
+EXPOSE 8000
 
 ENV PYTHONUNBUFFERED=1
 ENV PIXLET_PATH=/pixlet/pixlet
@@ -34,7 +34,6 @@ RUN apt-get update && \
         python3-flask \
         python3-flask-babel \
         python3-requests \
-        python3-websocket \
         python3-yaml \
         tzdata \
         tzdata-legacy && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ flask-babel
 gunicorn
 python-dotenv
 requests
-websocket-client

--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -28,7 +28,6 @@ from flask import (
     url_for,
 )
 from flask.typing import ResponseReturnValue
-from websocket import create_connection
 from werkzeug.utils import secure_filename
 
 import tronbyt_server.db as db
@@ -1087,18 +1086,6 @@ def pixlet_proxy(path: str) -> ResponseReturnValue:
         if name not in excluded_headers
     ]
     return Response(response.content, status=response.status_code, headers=headers)
-
-
-@bp.route("/pixlet/api/v1/ws/<path:url>")
-@login_required
-def proxy_ws(url: str) -> ResponseReturnValue:
-    user_render_port = db.get_user_render_port(g.user["username"])
-    pixlet_url = f"ws://localhost:{user_render_port}/pixlet/{url}"
-    ws = create_connection(pixlet_url)
-    ws.send(request.data)
-    response = ws.recv()
-    ws.close()
-    return Response(response, content_type="application/json")
 
 
 @bp.route("/<string:device_id>/<string:iname>/moveapp", methods=["GET", "POST"])


### PR DESCRIPTION
It didn't really work because there was no websocket server running. The websocket is used by Pixlet to watch for changes in the applet source files which isn't very useful within tronbyt-server. Apps could change within a container when refreshing a repository, but in that case, the configapp page should just be refreshed.

I looked into flask-sockets, but this is deprecated. The replacement flask-sock doesn't have a Debian package, so I don't think this is really worth it.