### PR TITLE
Empty last render

### DIFF
--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -527,7 +527,7 @@ def server_root() -> str:
         url += f":{port}"
     return url
 
-
+# render if necessary, returns false on failure or empty render, true for all else
 def possibly_render(user: User, device_id: str, app: App) -> bool:
     if "pushed" in app:
         current_app.logger.debug("Pushed App -- NO RENDER")
@@ -551,15 +551,17 @@ def possibly_render(user: User, device_id: str, app: App) -> bool:
 
     if now - app.get("last_render", 0) > int(app["uinterval"]) * 60:
         current_app.logger.debug(f"RENDERING -- {app_basename}")
-        # always update the config with the new last render time
-        app["last_render"] = now
-        db.save_user(user)
         device = user["devices"][device_id]
         config = load_app_config(app, config_path, device)
         success, empty = render_app(app_path, config, webp_path, device)
         if not success:
             current_app.logger.error(f"Error rendering {app_basename}")
-        return success and not empty
+        # set the empty flag in the app whilst keeping last render image
+        app["empty_last_render"] = empty
+        # always update the config with the new last render time
+        app["last_render"] = now
+        db.save_user(user)
+        return success # return false if error
 
     current_app.logger.debug(f"{app_basename} -- NO RENDER")
     return True
@@ -960,7 +962,8 @@ def next_app(
         current_app.logger.debug(f"{app['name']}-{app['iname']} is disabled")
         return next_app(device_id, last_app_index, recursion_depth + 1)
 
-    if not possibly_render(user, device_id, app):
+    # render if necessary, returns false on failure, true for all else
+    if not possibly_render(user, device_id, app) or app.get("empty_last_render", False):
         # try the next app if rendering failed or produced an empty result (no screens)
         return next_app(device_id, last_app_index, recursion_depth + 1)
 
@@ -978,14 +981,12 @@ def next_app(
     if webp_path.exists() and webp_path.stat().st_size > 0:
         response = send_file(webp_path, mimetype="image/webp")
         b = db.get_device_brightness_8bit(device)
-        current_app.logger.debug(f"sending brightness {b} -- ")
         response.headers["Tronbyt-Brightness"] = b
         s = app.get("display_time", 0)
         if s == 0:
             s = device.get("default_interval", 5)
-        current_app.logger.debug(f"sending dwell seconds {s} -- ")
         response.headers["Tronbyt-Dwell-Secs"] = s
-        current_app.logger.debug(f"app index is {last_app_index}")
+        current_app.logger.debug(f"brightness {b} -- dwell seconds {s} -- app index is {last_app_index}")
         db.save_last_app_index(device_id, last_app_index)
         return response
 

--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -528,7 +528,7 @@ def server_root() -> str:
     return url
 
 
-# render if necessary, returns false on failure or empty render, true for all else
+# render if necessary, returns false on failure, true for all else
 def possibly_render(user: User, device_id: str, app: App) -> bool:
     if "pushed" in app:
         current_app.logger.debug("Pushed App -- NO RENDER")

--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -527,6 +527,7 @@ def server_root() -> str:
         url += f":{port}"
     return url
 
+
 # render if necessary, returns false on failure or empty render, true for all else
 def possibly_render(user: User, device_id: str, app: App) -> bool:
     if "pushed" in app:
@@ -561,7 +562,7 @@ def possibly_render(user: User, device_id: str, app: App) -> bool:
         # always update the config with the new last render time
         app["last_render"] = now
         db.save_user(user)
-        return success # return false if error
+        return success  # return false if error
 
     current_app.logger.debug(f"{app_basename} -- NO RENDER")
     return True
@@ -986,7 +987,9 @@ def next_app(
         if s == 0:
             s = device.get("default_interval", 5)
         response.headers["Tronbyt-Dwell-Secs"] = s
-        current_app.logger.debug(f"brightness {b} -- dwell seconds {s} -- app index is {last_app_index}")
+        current_app.logger.debug(
+            f"brightness {b} -- dwell seconds {s} -- app index is {last_app_index}"
+        )
         db.save_last_app_index(device_id, last_app_index)
         return response
 

--- a/tronbyt_server/models/app.py
+++ b/tronbyt_server/models/app.py
@@ -16,3 +16,4 @@ class App(TypedDict, total=False):
     end_time: str
     days: List[str]
     config: Dict[str, Any]
+    empty_last_render: bool


### PR DESCRIPTION
add app field to indicate if the last render was empty and to not show the last non blank webp which will be shown in the device index but shouldn't be sent to the device.