### PR TITLE
Ensure that libpixlet is loaded after forking worker processes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,10 @@ jobs:
         run: |
           curl -LO "https://github.com/tronbyt/pixlet/releases/download/${PIXLET_VERSION}/pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
           sudo tar -C /usr/local/bin -xvf "pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
+          sudo mv /usr/local/bin/libpixlet.so /usr/lib/libpixlet.so
           rm "pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
         env:
-          PIXLET_VERSION: v0.40.0
+          PIXLET_VERSION: v0.41.0
       - name: Test with pytest
         run: |
           pip install pytest

--- a/README.md
+++ b/README.md
@@ -133,15 +133,14 @@ loglevel = "info"
 accesslog = "-"
 access_log_format = "%(h)s %(l)s %(u)s %(t)s %(r)s %(s)s %(b)s %(f)s %(a)s"
 errorlog = "-"
-workers = 1
+workers = 4
 threads = 4
 timeout = 120
 worker_tmp_dir = "/dev/shm"
-preload_app = False
+preload_app = True
 reload = False
 keyfile = "/ssl/privkey.pem"
 certfile = "/ssl/fullchain.pem"
-ssl_version = "TLSv1_2"
 
 def ssl_context(conf, default_ssl_context_factory):
     import ssl

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -8,4 +8,5 @@ errorlog = "-"
 workers = 1
 threads = 4
 timeout = 120
-reload = True
+reload = False
+preload_app = True

--- a/run.development
+++ b/run.development
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# FLASK DEVELOPMENT
-FLASK_APP=tronbyt_server FLASK_DEBUG=1 flask run --host=0.0.0.0 --port=8000

--- a/tronbyt_server/runcmd
+++ b/tronbyt_server/runcmd
@@ -1,3 +1,0 @@
-export FLASK_APP=tronbyt_server
-export FLASK_DEBUG=1
-flask run --host=0.0.0.0 --port=8000


### PR DESCRIPTION
Opening the dynamic library pre-fork already runs static initialization Go code, causing post-fork calls to deadlock.

This allows using the `preload_app` option provided by unicorn which ensures that application init code is only run once in the parent process.

Fixes https://github.com/tronbyt/server/issues/176