### PR TITLE
Run the container as a non-root user to reduce attack surface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
+# Create a non-root user
+RUN groupadd -r -g 1000 tronbyt && useradd -r -u 1000 -g tronbyt tronbyt
+
 # copy pixlet library and python dependencies
 COPY --from=pixlet --chmod=755 /lib/libpixlet.so /usr/lib/libpixlet.so
 
@@ -41,6 +44,9 @@ RUN apt-get update && \
 
 COPY . /app
 RUN pybabel compile -d tronbyt_server/translations
+
+RUN chown -R tronbyt:tronbyt /app && chmod -R 755 /app
+USER tronbyt
 
 # start the app
 CMD ["./run"]


### PR DESCRIPTION
This can be overridden with the `--user` flag for the `docker` command or a `user` setting in a Compose file.