### PR TITLE
use new scale for percentage brightness in new firmware.

### DIFF
--- a/tronbyt_server/db.py
+++ b/tronbyt_server/db.py
@@ -209,9 +209,28 @@ def get_night_mode_is_active(device: Device) -> bool:
     return False
 
 
-# selectable range is 0 - 5, lowest actually visible value returned should be 3, so 0 = 0, 1 = 3, etc.
+# selectable range is 0 - 5 new brightness scale based on percentage value sent to firmware
+# new lookup lowest visible value should be 1 (percent brightness)
 def get_device_brightness_8bit(device: Device) -> int:
-    lookup = {0: 0, 1: 3, 2: 5, 3: 10, 4: 50, 5: 100}
+    lookup = {
+        0: 0,
+        1: 1,
+        2: 5,
+        3: 10,
+        4: 25,
+        5: 50,
+    }
+    # old_lookup : lowest  visible value returned should be 3
+    if "legacy_brightness" in device.get("notes", ""):
+        lookup = {
+            0: 0,
+            1: 3,
+            2: 5,
+            3: 10,
+            4: 50,
+            5: 100,
+        }
+
     if get_night_mode_is_active(device):
         b = device.get("night_brightness", 1)
     else:

--- a/tronbyt_server/templates/manager/update.html
+++ b/tronbyt_server/templates/manager/update.html
@@ -122,6 +122,7 @@
 
     <div class="form-group">
       <label for="brightness">{{ _('Brightness') }}</label>
+      <span class="tooltip-icon" title="{{ _('If your device stays dark at level 1, add legacy_brightness to the Notes field') }}">ⓘ</span>
       <output>{{ device['brightness'] }}</output>
       <input type="range" name="brightness" id="brightness" min="0" max="5" value="{{ device['brightness'] }}"
         oninput="this.previousElementSibling.value = this.value">

--- a/tronbyt_server/translations/de/LC_MESSAGES/messages.po
+++ b/tronbyt_server/translations/de/LC_MESSAGES/messages.po
@@ -587,3 +587,11 @@ msgstr "Hochladen"
 msgid "Current files:"
 msgstr "Aktuelle Dateien:"
 
+#: tronbyt_server/templates/manager/create.html:21
+msgid "Brightness Level ( 0 - 5 )"
+msgstr "Helligkeitsstufe ( 0 - 5 )"
+
+#: tronbyt_server/templates/manager/create.html:21
+msgid "If your device stays dark at level 1, add legacy_brightness to the Notes field"
+msgstr "Wenn Ihr Gerät bei Stufe 1 dunkel bleibt, fügen Sie legacy_brightness zum Notizen-Feld hinzu"
+


### PR DESCRIPTION
add the option to put the string "legacy_brightness" in device notes fields to use the old scale.