### PR TITLE
Separate dynamic from static data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,10 +12,8 @@
 .vscode
 Caddyfile
 Dockerfile
+data
 docker-compose*.yaml
-system-apps
-tronbyt_server/static/apps
-tronbyt_server/webp
 tests
 users
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -4,15 +4,13 @@
 **/*.log
 .coverage
 .env
+.pdm-python
 certs
+data
 dist
 env
 junit
-system-apps
-system-apps.json
 tests/webp
-tronbyt_server/static/apps
-tronbyt_server/webp
 !tronbyt_server/webp/README
 users
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,9 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Create the directories for dynamic content ahead of time so that they are
 # owned by the non-root user (newly created named volumes are owned by root,
 # if their target doesn't exist).
-RUN touch /app/system-apps.json && \
-    mkdir -p /app/system-apps /app/tronbyt_server/static/apps /app/tronbyt_server/webp /app/users && \
-    chown -R tronbyt:tronbyt /app/system-apps.json /app/system-apps /app/tronbyt_server/static/apps /app/tronbyt_server/webp /app/users && \
-    chmod -R 755 /app/system-apps /app/tronbyt_server/static/apps /app/tronbyt_server/webp /app/users
+RUN mkdir -p /app/data /app/users && \
+    chown -R tronbyt:tronbyt /app/data /app/users && \
+    chmod -R 755 /app/data /app/users
 
 # Set the user to non-root (disabled for a while to support legacy setups which ran as root)
 #USER tronbyt

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -9,6 +9,7 @@ services:
     volumes:
       - ./tronbyt_server:/app/tronbyt_server # for development
       - ./users:/app/users # for development
+      - ./data:/app/data # for development
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
     environment:
       - SERVER_HOSTNAME=${SERVER_HOSTNAME_OR_IP:?SERVER_HOSTNAME_OR_IP MUST BE SET IN .env FILE !!!!!!!!!!!!!!!!!.}

--- a/docker-compose.https.yaml
+++ b/docker-compose.https.yaml
@@ -7,8 +7,7 @@ services:
     volumes:
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users
-      - webp:/app/tronbyt_server/webp
-      - apps:/app/system-apps
+      - data:/app/data
     environment:
       - SERVER_PROTOCOL=https
       - SERVER_HOSTNAME=${SERVER_HOSTNAME_OR_IP:?SERVER_HOSTNAME_OR_IP MUST BE SET IN .env FILE !!!!!!!!!!!!!!!!!.}
@@ -37,5 +36,4 @@ services:
       - web
 volumes:
   users:
-  webp:
-  apps:
+  data:

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -9,7 +9,7 @@ services:
     volumes:
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users
-      - webp:/app/tronbyt_server/webp
+      - data:/app/data
     environment:
       - SERVER_HOSTNAME=${SERVER_HOSTNAME_OR_IP:?SERVER_HOSTNAME_OR_IP MUST BE SET IN .env FILE !!!!!!!!!!!!!!!!!.}
       - SERVER_PORT
@@ -24,7 +24,7 @@ services:
     depends_on:
       - redis
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
     restart: unless-stopped
     volumes:
       - redis:/data
@@ -34,6 +34,5 @@ services:
       timeout: 3s
       retries: 3
 volumes:
-  users:
-  webp:
+  data:
   redis:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,7 @@ services:
     volumes:
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users
-      - webp:/app/tronbyt_server/webp
-      - system-apps:/app/system-apps
+      - data:/app/data
     environment:
       - SERVER_HOSTNAME=${SERVER_HOSTNAME_OR_IP:?SERVER_HOSTNAME_OR_IP MUST BE SET IN .env FILE !!!!!!!!!!!!!!!!!.}
       - SERVER_PORT
@@ -24,5 +23,4 @@ services:
       start_period: 10s
 volumes:
   users:
-  webp:
-  system-apps:
+  data:

--- a/tronbyt_server/__init__.py
+++ b/tronbyt_server/__init__.py
@@ -205,11 +205,6 @@ def get_locale() -> Optional[str]:
 def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
     load_dotenv()
 
-    # The reloader will run this code twice, once in the main process and once in the child process.
-    # This is a workaround to avoid running the update_system_repo() function twice.
-    if not is_running_from_reloader():
-        system_apps.update_system_repo()
-
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)
     if test_config is None:
@@ -220,6 +215,7 @@ def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
             SERVER_PROTOCOL=os.getenv("SERVER_PROTOCOL", "http"),
             MAIN_PORT=os.getenv("SERVER_PORT", "8000"),
             USERS_DIR="users",
+            DATA_DIR=os.getenv("DATA_DIR", "data"),
             PRODUCTION=os.getenv("PRODUCTION", "1"),
             DB_FILE="users/usersdb.sqlite",
             LANGUAGES=["en", "de"],
@@ -241,6 +237,7 @@ def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
             SERVER_HOSTNAME="localhost",
             MAIN_PORT=os.getenv("SERVER_PORT", "8000"),
             USERS_DIR="tests/users",
+            DATA_DIR=os.getenv("DATA_DIR", "data"),
             PRODUCTION="0",
             TESTING=True,
         )
@@ -255,6 +252,11 @@ def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
     # Initialize the database within the application context
     with app.app_context():
         db.init_db()
+
+        # The reloader will run this code twice, once in the main process and once in the child process.
+        # This is a workaround to avoid running the update_system_repo() function twice.
+        if not is_running_from_reloader():
+            system_apps.update_system_repo(db.get_data_dir())
 
     from . import auth
 

--- a/tronbyt_server/db.py
+++ b/tronbyt_server/db.py
@@ -1,5 +1,4 @@
 import json
-import os
 import shutil
 import sqlite3
 from datetime import datetime
@@ -304,9 +303,12 @@ def brightness_map_8bit_to_levels(brightness: int) -> int:
     return percent_to_ui_scale(brightness)
 
 
+def get_data_dir() -> Path:
+    return Path(current_app.config["DATA_DIR"]).absolute()
+
+
 def get_users_dir() -> Path:
-    # current_app.logger.debug(f"users dir : {current_app.config['USERS_DIR']}")
-    return Path(current_app.config["USERS_DIR"])
+    return Path(current_app.config["USERS_DIR"]).absolute()
 
 
 def get_user(username: str) -> Optional[User]:
@@ -414,10 +416,10 @@ def get_apps_list(user: str) -> List[AppMetadata]:
     app_list: List[AppMetadata] = list()
     # test for directory named dir and if not exist create it
     if user == "system" or user == "":
-        list_file = Path("system-apps.json")
+        list_file = get_data_dir() / "system-apps.json"
         if not list_file.exists():
             current_app.logger.info("Generating apps.json file...")
-            system_apps.update_system_repo()
+            system_apps.update_system_repo(get_data_dir())
             current_app.logger.debug("apps.json file generated.")
 
         with list_file.open("r") as f:
@@ -566,8 +568,7 @@ def get_device_by_name(user: User, name: str) -> Optional[Device]:
 
 
 def get_device_webp_dir(device_id: str, create: bool = True) -> Path:
-    base = os.getcwd()
-    path = Path(base) / "tronbyt_server" / "webp" / secure_filename(device_id)
+    path = get_data_dir() / "webp" / secure_filename(device_id)
     if not path.exists() and create:
         path.mkdir(parents=True, exist_ok=True)
     return path

--- a/tronbyt_server/system_apps.py
+++ b/tronbyt_server/system_apps.py
@@ -10,8 +10,8 @@ import yaml
 from tronbyt_server.models.app import AppMetadata
 
 
-def update_system_repo() -> None:
-    system_apps_path = Path("system-apps").absolute()  # Get absolute path
+def update_system_repo(base_path: Path) -> None:
+    system_apps_path = base_path / "system-apps"
     system_apps_repo = os.getenv(
         "SYSTEM_APPS_REPO", "https://github.com/tronbyt/apps.git"
     )
@@ -79,7 +79,7 @@ def update_system_repo() -> None:
     skip_count = 0
     new_previews = 0
     num_previews = 0
-    static_images_path = Path("tronbyt_server") / "static" / "apps"
+    static_images_path = base_path / "apps"
     os.makedirs(static_images_path, exist_ok=True)
     for app in apps:
         try:
@@ -152,9 +152,9 @@ def update_system_repo() -> None:
     print(f"skipped {skip_count} secrets.star using apps")
     print(f"copied {new_previews} new previews into static")
     print(f"total previews found {num_previews}")
-    with (Path("system-apps.json")).open("w") as f:
+    with (base_path / "system-apps.json").open("w") as f:
         json.dump(apps_array, f, indent=4)
 
 
 if __name__ == "__main__":
-    update_system_repo()
+    update_system_repo(Path(os.getcwd()))

--- a/tronbyt_server/webp/README
+++ b/tronbyt_server/webp/README
@@ -1,2 +1,0 @@
-rendered webps go in this directory
-each device has its own subdirectory


### PR DESCRIPTION
In order to distribute tronbyt-server as a package, the directory layout needs to be changed. The package will contain static data like code and templates and live in a read-only location, so we can no longer write data like rendered images, the system app repo, app metadata, and app previews to the same location.

This change moves the dynamic data to a consolidated location. In a container, this is mounted as `/app/data`, but it can be configured for bare-metal installations using the `DATA_DIR` environment variable. This move causes a small one-time discontinuity, but no data loss:
- the system apps repo will be cloned one again
- the app previews will be broken until each app is rendered again

Before:
- /app/system-apps: dynamic data (discardable)
- /app/system-apps.json: dynamic data (discardable)
- /app/tronbyt_server/webp: dynamic data (discardable)
- /app/tronbyt_server/static/apps: dynamic data (discardable)
- /app/users: user-generated data (should be preserved)
- /app (everything else): static data

After:
- /app/data: dynamic data (discardable)
- /app/users: user-generated data (should be preserved)
- /app (everything else): static data

The dynamic data is discardable because it will be regenerated, but it's still useful to preserve to speed up container restarts, for example.

This change also reduces the recommended number of Docker volumes from three (apps, users, webp) to two (users, data).