### PR TITLE
Look for `.env` in the current working directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ That said, the recommended installation method uses Docker Compose with a config
 2. Copy the [example environment file](https://raw.githubusercontent.com/tronbyt/server/refs/heads/main/.env.example) and modify it as needed:
 
    ```sh
-   curl https://raw.githubusercontent.com/tronbyt/server/refs/heads/main/.env.example > $(brew --prefix)/etc/tronbyt-server/.env
+   curl https://raw.githubusercontent.com/tronbyt/server/refs/heads/main/.env.example > $(brew --prefix)/var/tronbyt-server/.env
    ```
 
    You can further customize the server by editing the [Gunicorn settings](https://docs.gunicorn.org/en/latest/settings.html#settings) (listening address, TLS certificate, etc.) in `$(brew --prefix)/etc/tronbyt-server/gunicorn.conf.py`.

--- a/tronbyt_server/__init__.py
+++ b/tronbyt_server/__init__.py
@@ -8,7 +8,7 @@ from threading import Lock
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from babel.dates import format_timedelta
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 from flask import Flask, current_app, g, request
 from flask_babel import Babel, _
 from flask_sock import Sock
@@ -203,7 +203,8 @@ def get_locale() -> Optional[str]:
 
 
 def create_app(test_config: Optional[Dict[str, Any]] = None) -> Flask:
-    load_dotenv()
+    if dotenv_path := find_dotenv(usecwd=True):
+        load_dotenv(dotenv_path)
 
     # create and configure the app
     app = Flask(__name__, instance_relative_config=True)


### PR DESCRIPTION
This is a no-op for Docker Compose where the `.env` file is read by Compose itself, but it is useful for local development and bare metal deployments where the `.env` file may not be in the same directory hierarchy as the source code.