### PR TITLE
Add support for 2x apps

### DIFF
--- a/tronbyt_server/models/app.py
+++ b/tronbyt_server/models/app.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional, Required, TypedDict
 
 
 class App(TypedDict, total=False):
+    id: str
     iname: Required[str]
     name: Required[str]
     uinterval: int
@@ -30,3 +31,4 @@ class AppMetadata(TypedDict, total=False):
     fileName: Optional[str]
     packageName: Optional[str]
     preview: Optional[str]
+    supports2x: bool

--- a/tronbyt_server/models/device.py
+++ b/tronbyt_server/models/device.py
@@ -6,6 +6,8 @@ from tronbyt_server.models.app import App
 
 DEFAULT_DEVICE_TYPE = "tidbyt_gen1"
 
+TWO_X_CAPABLE_DEVICE_TYPES = ["tronbyt_s3_wide"]
+
 
 class Location(TypedDict, total=False):
     name: str
@@ -75,3 +77,13 @@ def validate_device_type(device_type: str) -> bool:
         "tronbyt_s3_wide",
         "other",
     ]
+
+
+def device_supports_2x(device: Device) -> bool:
+    """
+    Check if the device supports 2x apps.
+
+    :param device: The device to check.
+    :return: True if the device supports 2x apps, False otherwise.
+    """
+    return device.get("type") in TWO_X_CAPABLE_DEVICE_TYPES


### PR DESCRIPTION
With this change, apps can indicate in their manifests whether they support rendering at 2x the normal canvas size (128x64 instead of 64x32). When a 2x app is rendered for a wide device, the app produces a larger image instead of scaling up the regular size.