### PR TITLE
Fix: Refine page title and H1 heading logic

### DIFF
--- a/tronbyt_server/templates/base.html
+++ b/tronbyt_server/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<title>{% block title %}{% endblock %}Tronbyt Manager</title>
+<title>{% if self.title() %}{% block title %}{% endblock %} - {% endif %}Tronbyt Manager</title>
 <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/w3.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">

--- a/tronbyt_server/templates/manager/adminindex.html
+++ b/tronbyt_server/templates/manager/adminindex.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block header %}
-<h1>{% block title %}{% endblock %}</h1>
+<h1>{{ _('Tronbyt Manager') }}</h1>
 
 {% endblock %}
 {% block content %}

--- a/tronbyt_server/templates/manager/index.html
+++ b/tronbyt_server/templates/manager/index.html
@@ -240,7 +240,7 @@
     }
   }
 </script>
-<h1>{% block title %}{% endblock %}</h1>
+<h1>{{ _('Tronbyt Manager') }}</h1>
 {% endblock %}
 {% block content %}
 {% if g.user %}


### PR DESCRIPTION
- Modified `base.html` to conditionally add a separator to the page title. If a page defines a specific title, it will be shown as "Page Title - Tronbyt Manager". If a page has no specific title, the browser title will be just "Tronbyt Manager".

- Adjusted `manager/index.html` and `manager/adminindex.html` to explicitly set their main `<h1>` heading to "Tronbyt Manager". This ensures they have a visible heading while their browser tab title correctly defaults to "Tronbyt Manager".

This addresses the issue where some pages had concatenated titles (e.g., "LoginTronbyt Manager") and ensures that main index pages have appropriate titles and headings.

Fixes #275