### PR TITLE
Add user API key and devices list endpoint

### DIFF
--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,269 @@
+import secrets
+import string
+from unittest.mock import patch
+
+import pytest
+from flask.testing import FlaskClient
+
+from tronbyt_server import db
+from tronbyt_server.models.user import User
+
+from . import utils
+
+
+class TestApiKeyGeneration:
+    """Test cases for API key generation functionality"""
+
+    def test_migrate_user_api_keys_generates_key_for_user_without_key(self, client: FlaskClient) -> None:
+        """Test that migrate_user_api_keys generates API key for users without one"""
+        # Create a user without API key by directly manipulating the user data
+        client.post("/auth/register", data={"username": "testuser", "password": "password"})
+        user = db.get_user("testuser")
+        assert user is not None
+        
+        # Remove the API key to simulate old user without API key
+        if "api_key" in user:
+            del user["api_key"]
+        db.save_user(user)
+        
+        # Verify user has no API key
+        user_without_key = db.get_user("testuser")
+        assert user_without_key is not None
+        assert "api_key" not in user_without_key or user_without_key.get("api_key") is None
+        
+        # Run migration
+        db.migrate_user_api_keys()
+        
+        # Verify API key was generated
+        migrated_user = db.get_user("testuser")
+        assert migrated_user is not None
+        assert "api_key" in migrated_user
+        assert migrated_user["api_key"] is not None
+        assert len(migrated_user["api_key"]) == 32
+        
+        # Verify API key contains only alphanumeric characters
+        api_key = migrated_user["api_key"]
+        assert all(c in string.ascii_letters + string.digits for c in api_key)
+
+    def test_migrate_user_api_keys_preserves_existing_key(self, client: FlaskClient) -> None:
+        """Test that migrate_user_api_keys doesn't overwrite existing API keys"""
+        # Create a user (will automatically have API key)
+        client.post("/auth/register", data={"username": "testuser", "password": "password"})
+        user = db.get_user("testuser")
+        assert user is not None
+        
+        original_api_key = user.get("api_key")
+        assert original_api_key is not None
+        
+        # Run migration
+        db.migrate_user_api_keys()
+        
+        # Verify API key wasn't changed
+        user_after_migration = db.get_user("testuser")
+        assert user_after_migration is not None
+        assert user_after_migration["api_key"] == original_api_key
+
+    def test_migrate_user_api_keys_handles_multiple_users(self, client: FlaskClient) -> None:
+        """Test that migrate_user_api_keys handles multiple users correctly"""
+        # Create multiple users
+        client.post("/auth/register", data={"username": "user1", "password": "password"})
+        client.post("/auth/register", data={"username": "user2", "password": "password"})
+        
+        # Remove API key from one user
+        user1 = db.get_user("user1")
+        assert user1 is not None
+        if "api_key" in user1:
+            del user1["api_key"]
+        db.save_user(user1)
+        
+        # Keep API key for the other user
+        user2 = db.get_user("user2")
+        assert user2 is not None
+        original_key_user2 = user2.get("api_key")
+        
+        # Run migration
+        db.migrate_user_api_keys()
+        
+        # Verify first user got a new API key
+        user1_after = db.get_user("user1")
+        assert user1_after is not None
+        assert "api_key" in user1_after
+        assert user1_after["api_key"] is not None
+        assert len(user1_after["api_key"]) == 32
+        
+        # Verify second user's API key is unchanged
+        user2_after = db.get_user("user2")
+        assert user2_after is not None
+        assert user2_after["api_key"] == original_key_user2
+
+    def test_migrate_user_api_keys_generates_valid_key(self, client: FlaskClient) -> None:
+        """Test that migrate_user_api_keys generates a valid API key"""
+        # Create a user and remove their API key to simulate old user
+        client.post("/auth/register", data={"username": "testuser", "password": "password"})
+        user = db.get_user("testuser")
+        assert user is not None
+        
+        # Remove the API key to simulate old user without API key
+        if "api_key" in user:
+            del user["api_key"]
+        db.save_user(user)
+        
+        # Run migration
+        db.migrate_user_api_keys()
+        
+        # Verify a valid API key was generated
+        migrated_user = db.get_user("testuser")
+        assert migrated_user is not None
+        assert "api_key" in migrated_user
+        api_key = migrated_user["api_key"]
+        assert api_key is not None
+        assert len(api_key) == 32
+        
+        # Verify API key contains only alphanumeric characters
+        assert all(c in string.ascii_letters + string.digits for c in api_key)
+
+
+class TestApiKeyRetrieval:
+    """Test cases for API key retrieval functionality"""
+
+    def test_get_user_by_api_key_success(self, client: FlaskClient) -> None:
+        """Test successful user retrieval by API key"""
+        utils.load_test_data(client)
+        user = utils.get_testuser()
+        api_key = user["api_key"]
+        
+        # Retrieve user by API key
+        retrieved_user = db.get_user_by_api_key(api_key)
+        
+        assert retrieved_user is not None
+        assert retrieved_user["username"] == "testuser"
+        assert retrieved_user["api_key"] == api_key
+
+    def test_get_user_by_api_key_not_found(self, client: FlaskClient) -> None:
+        """Test user retrieval with non-existent API key"""
+        utils.load_test_data(client)
+        
+        # Try to retrieve user with invalid API key
+        retrieved_user = db.get_user_by_api_key("nonexistent_key")
+        
+        assert retrieved_user is None
+
+    def test_get_user_by_api_key_empty_string(self, client: FlaskClient) -> None:
+        """Test user retrieval with empty API key"""
+        utils.load_test_data(client)
+        
+        # Try to retrieve user with empty API key
+        retrieved_user = db.get_user_by_api_key("")
+        
+        assert retrieved_user is None
+
+    def test_get_user_by_api_key_none(self, client: FlaskClient) -> None:
+        """Test user retrieval with None API key"""
+        utils.load_test_data(client)
+        
+        # The function should handle None gracefully by returning None
+        # Since None != any valid API key string
+        retrieved_user = db.get_user_by_api_key(None)  # type: ignore
+        
+        # Should return None since no user should have None as their API key
+        # (all users get API keys during registration)
+        assert retrieved_user is None
+
+    def test_get_user_by_api_key_multiple_users(self, client: FlaskClient) -> None:
+        """Test user retrieval when multiple users exist"""
+        # Create multiple users
+        client.post("/auth/register", data={"username": "user1", "password": "password"})
+        client.post("/auth/register", data={"username": "user2", "password": "password"})
+        
+        user1 = db.get_user("user1")
+        user2 = db.get_user("user2")
+        assert user1 is not None and user2 is not None
+        
+        api_key1 = user1["api_key"]
+        api_key2 = user2["api_key"]
+        
+        # Ensure API keys are different
+        assert api_key1 != api_key2
+        
+        # Test retrieval of first user
+        retrieved_user1 = db.get_user_by_api_key(api_key1)
+        assert retrieved_user1 is not None
+        assert retrieved_user1["username"] == "user1"
+        
+        # Test retrieval of second user
+        retrieved_user2 = db.get_user_by_api_key(api_key2)
+        assert retrieved_user2 is not None
+        assert retrieved_user2["username"] == "user2"
+
+    def test_get_user_by_api_key_case_sensitive(self, client: FlaskClient) -> None:
+        """Test that API key lookup is case sensitive"""
+        utils.load_test_data(client)
+        user = utils.get_testuser()
+        api_key = user["api_key"]
+        
+        # Try with different case (assuming API key has letters)
+        if any(c.islower() for c in api_key):
+            wrong_case_key = api_key.upper()
+        else:
+            wrong_case_key = api_key.lower()
+        
+        # Should not find user with wrong case
+        retrieved_user = db.get_user_by_api_key(wrong_case_key)
+        assert retrieved_user is None
+        
+        # Should find user with correct case
+        retrieved_user = db.get_user_by_api_key(api_key)
+        assert retrieved_user is not None
+
+
+class TestApiKeyIntegration:
+    """Integration tests for API key functionality"""
+
+    def test_user_registration_creates_api_key(self, client: FlaskClient) -> None:
+        """Test that user registration automatically creates an API key"""
+        # Register a new user
+        response = client.post("/auth/register", data={"username": "newuser", "password": "password"})
+        assert response.status_code == 302  # Redirect after successful registration
+        
+        # Verify user has API key
+        user = db.get_user("newuser")
+        assert user is not None
+        assert "api_key" in user
+        assert user["api_key"] is not None
+        assert len(user["api_key"]) == 32
+
+    def test_api_key_authentication_flow(self, client: FlaskClient) -> None:
+        """Test complete API key authentication flow"""
+        # Create user and device
+        device_id = utils.load_test_data(client)
+        user = utils.get_testuser()
+        api_key = user["api_key"]
+        
+        # Use API key to authenticate API request
+        response = client.get(
+            "/v0/devices",
+            headers={"Authorization": f"Bearer {api_key}"}
+        )
+        
+        assert response.status_code == 200
+        
+        # Verify the API returned correct device data
+        import json
+        data = json.loads(response.data)
+        assert "devices" in data
+        assert len(data["devices"]) == 1
+        assert data["devices"][0]["id"] == device_id
+
+    def test_api_key_uniqueness(self, client: FlaskClient) -> None:
+        """Test that generated API keys are unique across users"""
+        # Create multiple users
+        api_keys = []
+        for i in range(5):
+            username = f"user{i}"
+            client.post("/auth/register", data={"username": username, "password": "password"})
+            user = db.get_user(username)
+            assert user is not None
+            api_keys.append(user["api_key"])
+        
+        # Verify all API keys are unique
+        assert len(api_keys) == len(set(api_keys)), "API keys should be unique"

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -173,18 +173,6 @@ class TestApiKeyRetrieval:
 
         assert retrieved_user is None
 
-    def test_get_user_by_api_key_none(self, client: FlaskClient) -> None:
-        """Test user retrieval with None API key"""
-        utils.load_test_data(client)
-
-        # The function should handle None gracefully by returning None
-        # Since None != any valid API key string
-        retrieved_user = db.get_user_by_api_key(None)  # type: ignore
-
-        # Should return None since no user should have None as their API key
-        # (all users get API keys during registration)
-        assert retrieved_user is None
-
     def test_get_user_by_api_key_multiple_users(self, client: FlaskClient) -> None:
         """Test user retrieval when multiple users exist"""
         # Create multiple users

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,12 +1,8 @@
-import secrets
 import string
-from unittest.mock import patch
 
-import pytest
 from flask.testing import FlaskClient
 
 from tronbyt_server import db
-from tronbyt_server.models.user import User
 
 from . import utils
 
@@ -14,103 +10,123 @@ from . import utils
 class TestApiKeyGeneration:
     """Test cases for API key generation functionality"""
 
-    def test_migrate_user_api_keys_generates_key_for_user_without_key(self, client: FlaskClient) -> None:
+    def test_migrate_user_api_keys_generates_key_for_user_without_key(
+        self, client: FlaskClient
+    ) -> None:
         """Test that migrate_user_api_keys generates API key for users without one"""
         # Create a user without API key by directly manipulating the user data
-        client.post("/auth/register", data={"username": "testuser", "password": "password"})
+        client.post(
+            "/auth/register", data={"username": "testuser", "password": "password"}
+        )
         user = db.get_user("testuser")
         assert user is not None
-        
+
         # Remove the API key to simulate old user without API key
         if "api_key" in user:
             del user["api_key"]
         db.save_user(user)
-        
+
         # Verify user has no API key
         user_without_key = db.get_user("testuser")
         assert user_without_key is not None
-        assert "api_key" not in user_without_key or user_without_key.get("api_key") is None
-        
+        assert (
+            "api_key" not in user_without_key or user_without_key.get("api_key") is None
+        )
+
         # Run migration
         db.migrate_user_api_keys()
-        
+
         # Verify API key was generated
         migrated_user = db.get_user("testuser")
         assert migrated_user is not None
         assert "api_key" in migrated_user
         assert migrated_user["api_key"] is not None
         assert len(migrated_user["api_key"]) == 32
-        
+
         # Verify API key contains only alphanumeric characters
         api_key = migrated_user["api_key"]
         assert all(c in string.ascii_letters + string.digits for c in api_key)
 
-    def test_migrate_user_api_keys_preserves_existing_key(self, client: FlaskClient) -> None:
+    def test_migrate_user_api_keys_preserves_existing_key(
+        self, client: FlaskClient
+    ) -> None:
         """Test that migrate_user_api_keys doesn't overwrite existing API keys"""
         # Create a user (will automatically have API key)
-        client.post("/auth/register", data={"username": "testuser", "password": "password"})
+        client.post(
+            "/auth/register", data={"username": "testuser", "password": "password"}
+        )
         user = db.get_user("testuser")
         assert user is not None
-        
+
         original_api_key = user.get("api_key")
         assert original_api_key is not None
-        
+
         # Run migration
         db.migrate_user_api_keys()
-        
+
         # Verify API key wasn't changed
         user_after_migration = db.get_user("testuser")
         assert user_after_migration is not None
         assert user_after_migration["api_key"] == original_api_key
 
-    def test_migrate_user_api_keys_handles_multiple_users(self, client: FlaskClient) -> None:
+    def test_migrate_user_api_keys_handles_multiple_users(
+        self, client: FlaskClient
+    ) -> None:
         """Test that migrate_user_api_keys handles multiple users correctly"""
         # Create multiple users
-        client.post("/auth/register", data={"username": "user1", "password": "password"})
-        client.post("/auth/register", data={"username": "user2", "password": "password"})
-        
+        client.post(
+            "/auth/register", data={"username": "user1", "password": "password"}
+        )
+        client.post(
+            "/auth/register", data={"username": "user2", "password": "password"}
+        )
+
         # Remove API key from one user
         user1 = db.get_user("user1")
         assert user1 is not None
         if "api_key" in user1:
             del user1["api_key"]
         db.save_user(user1)
-        
+
         # Keep API key for the other user
         user2 = db.get_user("user2")
         assert user2 is not None
         original_key_user2 = user2.get("api_key")
-        
+
         # Run migration
         db.migrate_user_api_keys()
-        
+
         # Verify first user got a new API key
         user1_after = db.get_user("user1")
         assert user1_after is not None
         assert "api_key" in user1_after
         assert user1_after["api_key"] is not None
         assert len(user1_after["api_key"]) == 32
-        
+
         # Verify second user's API key is unchanged
         user2_after = db.get_user("user2")
         assert user2_after is not None
         assert user2_after["api_key"] == original_key_user2
 
-    def test_migrate_user_api_keys_generates_valid_key(self, client: FlaskClient) -> None:
+    def test_migrate_user_api_keys_generates_valid_key(
+        self, client: FlaskClient
+    ) -> None:
         """Test that migrate_user_api_keys generates a valid API key"""
         # Create a user and remove their API key to simulate old user
-        client.post("/auth/register", data={"username": "testuser", "password": "password"})
+        client.post(
+            "/auth/register", data={"username": "testuser", "password": "password"}
+        )
         user = db.get_user("testuser")
         assert user is not None
-        
+
         # Remove the API key to simulate old user without API key
         if "api_key" in user:
             del user["api_key"]
         db.save_user(user)
-        
+
         # Run migration
         db.migrate_user_api_keys()
-        
+
         # Verify a valid API key was generated
         migrated_user = db.get_user("testuser")
         assert migrated_user is not None
@@ -118,7 +134,7 @@ class TestApiKeyGeneration:
         api_key = migrated_user["api_key"]
         assert api_key is not None
         assert len(api_key) == 32
-        
+
         # Verify API key contains only alphanumeric characters
         assert all(c in string.ascii_letters + string.digits for c in api_key)
 
@@ -131,10 +147,10 @@ class TestApiKeyRetrieval:
         utils.load_test_data(client)
         user = utils.get_testuser()
         api_key = user["api_key"]
-        
+
         # Retrieve user by API key
         retrieved_user = db.get_user_by_api_key(api_key)
-        
+
         assert retrieved_user is not None
         assert retrieved_user["username"] == "testuser"
         assert retrieved_user["api_key"] == api_key
@@ -142,29 +158,29 @@ class TestApiKeyRetrieval:
     def test_get_user_by_api_key_not_found(self, client: FlaskClient) -> None:
         """Test user retrieval with non-existent API key"""
         utils.load_test_data(client)
-        
+
         # Try to retrieve user with invalid API key
         retrieved_user = db.get_user_by_api_key("nonexistent_key")
-        
+
         assert retrieved_user is None
 
     def test_get_user_by_api_key_empty_string(self, client: FlaskClient) -> None:
         """Test user retrieval with empty API key"""
         utils.load_test_data(client)
-        
+
         # Try to retrieve user with empty API key
         retrieved_user = db.get_user_by_api_key("")
-        
+
         assert retrieved_user is None
 
     def test_get_user_by_api_key_none(self, client: FlaskClient) -> None:
         """Test user retrieval with None API key"""
         utils.load_test_data(client)
-        
+
         # The function should handle None gracefully by returning None
         # Since None != any valid API key string
         retrieved_user = db.get_user_by_api_key(None)  # type: ignore
-        
+
         # Should return None since no user should have None as their API key
         # (all users get API keys during registration)
         assert retrieved_user is None
@@ -172,24 +188,28 @@ class TestApiKeyRetrieval:
     def test_get_user_by_api_key_multiple_users(self, client: FlaskClient) -> None:
         """Test user retrieval when multiple users exist"""
         # Create multiple users
-        client.post("/auth/register", data={"username": "user1", "password": "password"})
-        client.post("/auth/register", data={"username": "user2", "password": "password"})
-        
+        client.post(
+            "/auth/register", data={"username": "user1", "password": "password"}
+        )
+        client.post(
+            "/auth/register", data={"username": "user2", "password": "password"}
+        )
+
         user1 = db.get_user("user1")
         user2 = db.get_user("user2")
         assert user1 is not None and user2 is not None
-        
+
         api_key1 = user1["api_key"]
         api_key2 = user2["api_key"]
-        
+
         # Ensure API keys are different
         assert api_key1 != api_key2
-        
+
         # Test retrieval of first user
         retrieved_user1 = db.get_user_by_api_key(api_key1)
         assert retrieved_user1 is not None
         assert retrieved_user1["username"] == "user1"
-        
+
         # Test retrieval of second user
         retrieved_user2 = db.get_user_by_api_key(api_key2)
         assert retrieved_user2 is not None
@@ -200,17 +220,17 @@ class TestApiKeyRetrieval:
         utils.load_test_data(client)
         user = utils.get_testuser()
         api_key = user["api_key"]
-        
+
         # Try with different case (assuming API key has letters)
         if any(c.islower() for c in api_key):
             wrong_case_key = api_key.upper()
         else:
             wrong_case_key = api_key.lower()
-        
+
         # Should not find user with wrong case
         retrieved_user = db.get_user_by_api_key(wrong_case_key)
         assert retrieved_user is None
-        
+
         # Should find user with correct case
         retrieved_user = db.get_user_by_api_key(api_key)
         assert retrieved_user is not None
@@ -222,9 +242,11 @@ class TestApiKeyIntegration:
     def test_user_registration_creates_api_key(self, client: FlaskClient) -> None:
         """Test that user registration automatically creates an API key"""
         # Register a new user
-        response = client.post("/auth/register", data={"username": "newuser", "password": "password"})
+        response = client.post(
+            "/auth/register", data={"username": "newuser", "password": "password"}
+        )
         assert response.status_code == 302  # Redirect after successful registration
-        
+
         # Verify user has API key
         user = db.get_user("newuser")
         assert user is not None
@@ -238,17 +260,17 @@ class TestApiKeyIntegration:
         device_id = utils.load_test_data(client)
         user = utils.get_testuser()
         api_key = user["api_key"]
-        
+
         # Use API key to authenticate API request
         response = client.get(
-            "/v0/devices",
-            headers={"Authorization": f"Bearer {api_key}"}
+            "/v0/devices", headers={"Authorization": f"Bearer {api_key}"}
         )
-        
+
         assert response.status_code == 200
-        
+
         # Verify the API returned correct device data
         import json
+
         data = json.loads(response.data)
         assert "devices" in data
         assert len(data["devices"]) == 1
@@ -260,10 +282,12 @@ class TestApiKeyIntegration:
         api_keys = []
         for i in range(5):
             username = f"user{i}"
-            client.post("/auth/register", data={"username": username, "password": "password"})
+            client.post(
+                "/auth/register", data={"username": username, "password": "password"}
+            )
             user = db.get_user(username)
             assert user is not None
             api_keys.append(user["api_key"])
-        
+
         # Verify all API keys are unique
         assert len(api_keys) == len(set(api_keys)), "API keys should be unique"

--- a/tests/test_devices_api.py
+++ b/tests/test_devices_api.py
@@ -30,7 +30,6 @@ class TestDevicesEndpoint:
         assert device_data["displayName"] == "TESTDEVICE"
         assert "brightness" in device_data
         assert "autoDim" in device_data
-        assert device_data["apiKey"] == "TESTKEY"
 
     def test_list_devices_with_direct_auth_header(self, client: FlaskClient) -> None:
         """Test listing devices with direct Authorization header (no Bearer prefix)"""

--- a/tests/test_devices_api.py
+++ b/tests/test_devices_api.py
@@ -1,0 +1,200 @@
+import json
+
+from flask.testing import FlaskClient
+
+from . import utils
+
+
+class TestDevicesEndpoint:
+    """Test cases for the /v0/devices endpoint"""
+
+    def test_list_devices_success(self, client: FlaskClient) -> None:
+        """Test successful listing of devices with valid API key"""
+        # Setup test data
+        device_id = utils.load_test_data(client)
+        user = utils.get_testuser()
+        api_key = user["api_key"]
+
+        # Make request with user's API key
+        response = client.get(
+            "/v0/devices", headers={"Authorization": f"Bearer {api_key}"}
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "devices" in data
+        assert len(data["devices"]) == 1
+
+        device_data = data["devices"][0]
+        assert device_data["id"] == device_id
+        assert device_data["displayName"] == "TESTDEVICE"
+        assert "brightness" in device_data
+        assert "autoDim" in device_data
+        assert device_data["apiKey"] == "TESTKEY"
+
+    def test_list_devices_with_direct_auth_header(self, client: FlaskClient) -> None:
+        """Test listing devices with direct Authorization header (no Bearer prefix)"""
+        utils.load_test_data(client)
+        user = utils.get_testuser()
+        api_key = user["api_key"]
+
+        response = client.get("/v0/devices", headers={"Authorization": api_key})
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "devices" in data
+        assert len(data["devices"]) == 1
+
+    def test_list_devices_missing_auth_header(self, client: FlaskClient) -> None:
+        """Test listing devices without Authorization header"""
+        response = client.get("/v0/devices")
+
+        assert response.status_code == 400
+        assert "Missing or invalid Authorization header" in response.data.decode()
+
+    def test_list_devices_invalid_api_key(self, client: FlaskClient) -> None:
+        """Test listing devices with invalid API key"""
+        utils.load_test_data(client)
+
+        response = client.get(
+            "/v0/devices", headers={"Authorization": "Bearer invalid_key"}
+        )
+
+        assert response.status_code == 401
+        assert "Invalid API key" in response.data.decode()
+
+    def test_list_devices_empty_devices(self, client: FlaskClient) -> None:
+        """Test listing devices when user has no devices"""
+        # Register user but don't create any devices
+        client.post(
+            "/auth/register", data={"username": "testuser", "password": "password"}
+        )
+        client.post(
+            "/auth/login", data={"username": "testuser", "password": "password"}
+        )
+
+        user = utils.get_testuser()
+        api_key = user["api_key"]
+
+        response = client.get(
+            "/v0/devices", headers={"Authorization": f"Bearer {api_key}"}
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "devices" in data
+        assert len(data["devices"]) == 0
+
+
+class TestDeviceEndpoint:
+    """Test cases for the /v0/devices/<device_id> endpoint"""
+
+    def test_get_device_with_user_api_key(self, client: FlaskClient) -> None:
+        """Test successful retrieval of device info"""
+        device_id = utils.load_test_data(client)
+        user = utils.get_testuser()
+        api_key = user["api_key"]
+
+        response = client.get(
+            f"/v0/devices/{device_id}", headers={"Authorization": f"Bearer {api_key}"}
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["id"] == device_id
+        assert data["displayName"] == "TESTDEVICE"
+        assert "brightness" in data
+        assert "autoDim" in data
+
+    def test_get_device_with_device_api_key(self, client: FlaskClient) -> None:
+        """Test device retrieval using device-specific API key"""
+        device_id = utils.load_test_data(client)
+        device = utils.get_test_device()
+        device_api_key = device["api_key"]
+
+        response = client.get(
+            f"/v0/devices/{device_id}", headers={"Authorization": device_api_key}
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["id"] == device_id
+
+    def test_get_device_invalid_device_id(self, client: FlaskClient) -> None:
+        """Test device retrieval with invalid device ID format"""
+        utils.load_test_data(client)
+        user = utils.get_testuser()
+        api_key = user["api_key"]
+
+        response = client.get(
+            "/v0/devices/invalid-id-format",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid device ID" in response.data.decode()
+
+    def test_get_device_nonexistent_device(self, client: FlaskClient) -> None:
+        """Test device retrieval with nonexistent device ID"""
+        utils.load_test_data(client)
+        user = utils.get_testuser()
+        api_key = user["api_key"]
+
+        response = client.get(
+            "/v0/devices/12345678", headers={"Authorization": f"Bearer {api_key}"}
+        )
+
+        assert response.status_code == 404
+
+    def test_get_device_unauthorized_api_key(self, client: FlaskClient) -> None:
+        """Test device retrieval with wrong API key"""
+        device_id = utils.load_test_data(client)
+
+        response = client.get(
+            f"/v0/devices/{device_id}", headers={"Authorization": "Bearer wrong_key"}
+        )
+
+        assert response.status_code == 404
+
+    def test_patch_device_with_user_api_key(self, client: FlaskClient) -> None:
+        """Test device update with user API key"""
+        device_id = utils.load_test_data(client)
+        user = utils.get_testuser()
+        api_key = user["api_key"]
+
+        response = client.patch(
+            f"/v0/devices/{device_id}",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"brightness": 128},
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["id"] == device_id
+        assert data["brightness"] == 128
+
+    def test_patch_device_with_device_api_key(self, client: FlaskClient) -> None:
+        """Test device update with device-specific API key"""
+        device_id = utils.load_test_data(client)
+        device = utils.get_test_device()
+        device_api_key = device["api_key"]
+
+        response = client.patch(
+            f"/v0/devices/{device_id}",
+            headers={"Authorization": device_api_key},
+            json={"brightness": 128},
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["id"] == device_id
+        assert data["brightness"] == 128
+
+    def test_patch_device_missing_auth(self, client: FlaskClient) -> None:
+        """Test device update without authorization"""
+        device_id = utils.load_test_data(client)
+
+        response = client.patch(f"/v0/devices/{device_id}", json={"brightness": 128})
+
+        assert response.status_code == 400
+        assert "Missing or invalid Authorization header" in response.data.decode()

--- a/tronbyt_server/api.py
+++ b/tronbyt_server/api.py
@@ -101,7 +101,7 @@ def get_device(device_id: str) -> ResponseReturnValue:
         "id": device["id"],
         "displayName": device["name"],
         "brightness": db.get_device_brightness_8bit(device),
-        "autoDim": device["night_mode_enabled"],
+        "autoDim": device.get("night_mode_enabled", False),
     }
     return Response(json.dumps(metadata), status=200, mimetype="application/json")
 

--- a/tronbyt_server/api.py
+++ b/tronbyt_server/api.py
@@ -61,6 +61,7 @@ def list_user_devices(username: str) -> ResponseReturnValue:
             "displayName": device["name"],
             "brightness": db.get_device_brightness_8bit(device),
             "autoDim": device.get("night_mode_enabled", False),
+            "apiKey": device["api_key"],
         }
         for device_id, device in devices.items()
     ]

--- a/tronbyt_server/api.py
+++ b/tronbyt_server/api.py
@@ -19,7 +19,7 @@ from werkzeug.utils import secure_filename
 import tronbyt_server.db as db
 from tronbyt_server.manager import push_new_image, render_app
 from tronbyt_server.models.app import App
-from tronbyt_server.models.device import validate_device_id
+from tronbyt_server.models.device import Device, validate_device_id
 
 bp = Blueprint("api", __name__, url_prefix="/v0")
 
@@ -32,6 +32,15 @@ def get_api_key_from_headers(headers: Headers) -> Optional[str]:
         else:
             return auth_header
     return None
+
+
+def get_device_payload(device: Device) -> dict[str, Any]:
+    return {
+        "id": device["id"],
+        "displayName": device["name"],
+        "brightness": db.get_device_brightness_8bit(device),
+        "autoDim": device.get("night_mode_enabled", False),
+    }
 
 
 @bp.route("/devices", methods=["GET"])
@@ -48,15 +57,7 @@ def list_devices() -> ResponseReturnValue:
         abort(HTTPStatus.UNAUTHORIZED, description="Invalid API key")
 
     devices = user.get("devices", {})
-    metadata = [
-        {
-            "id": device_id,
-            "displayName": device["name"],
-            "brightness": db.get_device_brightness_8bit(device),
-            "autoDim": device.get("night_mode_enabled", False),
-        }
-        for device_id, device in devices.items()
-    ]
+    metadata = [get_device_payload(device) for device in devices.values()]
     return Response(
         json.dumps({"devices": metadata}),
         status=200,
@@ -102,12 +103,7 @@ def get_device(device_id: str) -> ResponseReturnValue:
         if "autoDim" in data:
             device["night_mode_enabled"] = bool(data["autoDim"])
         db.save_user(user)
-    metadata = {
-        "id": device["id"],
-        "displayName": device["name"],
-        "brightness": db.get_device_brightness_8bit(device),
-        "autoDim": device.get("night_mode_enabled", False),
-    }
+    metadata = get_device_payload(device)
     return Response(json.dumps(metadata), status=200, mimetype="application/json")
 
 

--- a/tronbyt_server/api.py
+++ b/tronbyt_server/api.py
@@ -54,7 +54,6 @@ def list_devices() -> ResponseReturnValue:
             "displayName": device["name"],
             "brightness": db.get_device_brightness_8bit(device),
             "autoDim": device.get("night_mode_enabled", False),
-            "apiKey": device["api_key"],
         }
         for device_id, device in devices.items()
     ]
@@ -80,7 +79,13 @@ def get_device(device_id: str) -> ResponseReturnValue:
     if not user:
         abort(HTTPStatus.NOT_FOUND)
     device = user["devices"].get(device_id)
-    if not device or not (device["api_key"] == api_key or user["api_key"] == api_key):
+
+    if not device:
+        abort(HTTPStatus.NOT_FOUND)
+
+    user_api_key_matches = user.get("api_key") and user["api_key"] == api_key
+    device_api_key_matches = device.get("api_key") and device["api_key"] == api_key
+    if not user_api_key_matches and not device_api_key_matches:
         abort(HTTPStatus.NOT_FOUND)
 
     if request.method == "PATCH":

--- a/tronbyt_server/auth.py
+++ b/tronbyt_server/auth.py
@@ -1,4 +1,6 @@
 import functools
+import secrets
+import string
 import time
 from typing import Any, Callable, Optional
 
@@ -57,10 +59,15 @@ def register() -> ResponseReturnValue:
             if "email" in request.form:
                 if "@" in request.form["email"]:
                     email = request.form["email"]
+            api_key = "".join(
+                secrets.choice(string.ascii_letters + string.digits)
+                for _ in range(32)
+            )
             user = User(
                 username=username,
                 password=password,
                 email=email,
+                api_key=api_key,
             )
 
             if db.save_user(user, new_user=True):

--- a/tronbyt_server/auth.py
+++ b/tronbyt_server/auth.py
@@ -25,6 +25,13 @@ from tronbyt_server.models.user import User
 bp = Blueprint("auth", __name__, url_prefix="/auth")
 
 
+def _generate_api_key() -> str:
+    """Generate a random API key."""
+    return "".join(
+        secrets.choice(string.ascii_letters + string.digits) for _ in range(32)
+    )
+
+
 @bp.route("/register", methods=("GET", "POST"))
 def register() -> ResponseReturnValue:
     # Check if max users limit is reached
@@ -59,10 +66,7 @@ def register() -> ResponseReturnValue:
             if "email" in request.form:
                 if "@" in request.form["email"]:
                     email = request.form["email"]
-            api_key = "".join(
-                secrets.choice(string.ascii_letters + string.digits)
-                for _ in range(32)
-            )
+            api_key = _generate_api_key()
             user = User(
                 username=username,
                 password=password,

--- a/tronbyt_server/db.py
+++ b/tronbyt_server/db.py
@@ -619,6 +619,13 @@ def get_user_by_device_id(device_id: str) -> Optional[User]:
     return None
 
 
+def get_user_by_username(username: str) -> Optional[User]:
+    for user in get_all_users():
+        if user.get("username") == username:
+            return user
+    return None
+
+
 # firmare bin files named after env targets in firmware project.
 def generate_firmware(
     url: str, ap: str, pw: str, device_type: str, swap_colors: bool

--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -1151,6 +1151,9 @@ def set_api_key() -> ResponseReturnValue:
         if "api_key" not in request.form:
             abort(HTTPStatus.BAD_REQUEST)
         api_key = str(request.form.get("api_key"))
+        if not api_key:
+            flash("API Key cannot be empty.")
+            return redirect(url_for("auth.edit"))
         g.user["api_key"] = api_key
         db.save_user(g.user)
         return redirect(url_for("manager.index"))

--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -1144,6 +1144,19 @@ def set_user_repo() -> ResponseReturnValue:
     abort(HTTPStatus.NOT_FOUND)
 
 
+@bp.route("/set_api_key", methods=["GET", "POST"])
+@login_required
+def set_api_key() -> ResponseReturnValue:
+    if request.method == "POST":
+        if "api_key" not in request.form:
+            abort(HTTPStatus.BAD_REQUEST)
+        api_key = str(request.form.get("api_key"))
+        g.user["api_key"] = api_key
+        db.save_user(g.user)
+        return redirect(url_for("manager.index"))
+    abort(HTTPStatus.NOT_FOUND)
+
+
 @bp.route("/set_system_repo", methods=["GET", "POST"])
 @login_required
 def set_system_repo() -> ResponseReturnValue:

--- a/tronbyt_server/models/user.py
+++ b/tronbyt_server/models/user.py
@@ -8,3 +8,4 @@ class User(TypedDict, total=False):
     password: Required[str]
     email: str
     devices: Dict[str, Device]
+    api_key: str

--- a/tronbyt_server/templates/auth/edit.html
+++ b/tronbyt_server/templates/auth/edit.html
@@ -34,4 +34,11 @@
     <input type="submit" value="{{ _('Save') }}" class="w3-button w3-green"></input>
 </form>
 
+<h1>{{ _('Edit API Key') }}</h1>
+<form method="post" action="{{ url_for('manager.set_api_key') }}">
+    <label for="api_key">{{ _('API Key') }}</label>
+    <input type="text" name="api_key" id="api_key" required value="{{ user['api_key'] }}">
+    <input type="submit" value="{{ _('Save') }}" class="w3-button w3-green"></input>
+</form>
+
 {% endblock %}

--- a/tronbyt_server/templates/auth/edit.html
+++ b/tronbyt_server/templates/auth/edit.html
@@ -37,7 +37,7 @@
 <h1>{{ _('Edit API Key') }}</h1>
 <form method="post" action="{{ url_for('manager.set_api_key') }}">
     <label for="api_key">{{ _('API Key') }}</label>
-    <input type="text" name="api_key" id="api_key" required value="{{ user['api_key'] }}">
+    <input type="text" name="api_key" id="api_key" required value="{{ user.get('api_key', '') }}">
     <input type="submit" value="{{ _('Save') }}" class="w3-button w3-green"></input>
 </form>
 

--- a/tronbyt_server/translations/de/LC_MESSAGES/messages.po
+++ b/tronbyt_server/translations/de/LC_MESSAGES/messages.po
@@ -91,6 +91,14 @@ msgstr ""
 msgid "Edit Password"
 msgstr "Passwort bearbeiten"
 
+#: tronbyt_server/templates/auth/edit.html:37
+msgid "Edit API Key"
+msgstr "API-Schlüssel bearbeiten"
+
+#: tronbyt_server/templates/auth/edit.html:39
+msgid "API Key"
+msgstr "API-Schlüssel"
+
 #: tronbyt_server/templates/auth/edit.html:30
 msgid "Old Password"
 msgstr "Altes Passwort"


### PR DESCRIPTION
The goal is to support device discovery for home assistant integrations, by allowing a user to access the list of devices via an API key.

* Adds API key to user model, along with migration and ability to edit
* Adds GET /v0/devices endpoint that returns a list of the user's devices given their provided API key
* Update the GET/PATCH /v0/devices/id endpoint to accept user's API key in addition to the device API key.
* Add unit tests

The home assistant custom integration that uses this implementation is at https://github.com/gxlabs/tronbyt-homeassistant