### PR TITLE
Fix: Auto-search and select location on config page load

### DIFF
--- a/tronbyt_server/static/js/location.js
+++ b/tronbyt_server/static/js/location.js
@@ -1,56 +1,79 @@
 function enableLocationSearch(inputElement, resultsElement, hiddenInputElement, onChangeCallback) {
     let timeout = null;
+    const apiKey = '49863bd631b84a169b347fafbf128ce6';
 
-    inputElement.addEventListener('input', function () {
-        clearTimeout(timeout);
-        const query = this.value.trim();
+    function performSearch(query, isInitialSearch = false) {
         if (query.length === 0) {
             resultsElement.innerHTML = '';
             return;
         }
 
-        timeout = setTimeout(() => {
-            const apiKey = '49863bd631b84a169b347fafbf128ce6';
-            const encodedQuery = encodeURIComponent(query);
-            const url = `https://api.geoapify.com/v1/geocode/search?text=${encodedQuery}&apiKey=${apiKey}`;
+        const encodedQuery = encodeURIComponent(query);
+        const url = `https://api.geoapify.com/v1/geocode/search?text=${encodedQuery}&apiKey=${apiKey}`;
 
-            fetch(url)
-                .then(response => response.json())
-                .then(data => {
-                    resultsElement.innerHTML = '';
+        fetch(url)
+            .then(response => response.json())
+            .then(data => {
+                resultsElement.innerHTML = '';
 
-                    if (data.features && data.features.length > 0) {
-                        data.features.forEach(feature => {
-                            const li = document.createElement('li');
-                            li.textContent = `📍 ${feature.properties.formatted}`;
-                            li.dataset.lat = feature.properties.lat;
-                            li.dataset.lon = feature.properties.lon;
-                            li.dataset.timezone = feature.properties.timezone?.name;
-                            li.dataset.name = feature.properties.formatted;
+                if (data.features && data.features.length > 0) {
+                    let exactMatchFound = false;
+                    data.features.forEach((feature, index) => {
+                        const li = document.createElement('li');
+                        li.textContent = `📍 ${feature.properties.formatted}`;
+                        li.dataset.lat = feature.properties.lat;
+                        li.dataset.lon = feature.properties.lon;
+                        li.dataset.timezone = feature.properties.timezone?.name;
+                        li.dataset.name = feature.properties.formatted;
 
-                            li.addEventListener('click', function () {
-                                inputElement.value = this.dataset.name;
-                                resultsElement.innerHTML = '';
-                                const hiddenValue = JSON.stringify({
-                                    name: this.dataset.name,
-                                    timezone: this.dataset.timezone,
-                                    lat: this.dataset.lat,
-                                    lng: this.dataset.lon
-                                });
-                                hiddenInputElement.value = hiddenValue;
-
-                                if (onChangeCallback) {
-                                    onChangeCallback(hiddenValue);
-                                }
+                        li.addEventListener('click', function () {
+                            inputElement.value = this.dataset.name;
+                            resultsElement.innerHTML = '';
+                            const hiddenValue = JSON.stringify({
+                                name: this.dataset.name,
+                                timezone: this.dataset.timezone,
+                                lat: this.dataset.lat,
+                                lng: this.dataset.lon
                             });
+                            hiddenInputElement.value = hiddenValue;
 
-                            resultsElement.appendChild(li);
+                            if (onChangeCallback) {
+                                onChangeCallback(hiddenValue); // Simplified callback
+                            }
                         });
-                    } else {
-                        resultsElement.innerHTML = `<li>{{ _('No results found') }}</li>`;
+
+                        resultsElement.appendChild(li);
+
+                        if (isInitialSearch && feature.properties.formatted === query) {
+                            exactMatchFound = true;
+                            // Simulate click on the exact match
+                            li.click(); // This will trigger the above event listener
+                        }
+                    });
+
+                    if (isInitialSearch && !exactMatchFound && resultsElement.firstChild) {
+                        // If no exact match was found during initial search, and there are results, click the first one.
+                        resultsElement.firstChild.click(); // This will trigger the event listener on the first child
                     }
-                })
-                .catch(error => console.error('Error fetching location data:', error));
+
+                } else {
+                    resultsElement.innerHTML = `<li>{{ _('No results found') }}</li>`;
+                }
+            })
+            .catch(error => console.error('Error fetching location data:', error));
+    }
+
+    inputElement.addEventListener('input', function () {
+        clearTimeout(timeout);
+        const query = this.value.trim();
+        timeout = setTimeout(() => {
+            performSearch(query, false);
         }, 300);
     });
+
+    // Perform initial search if there's a value in the input field on load
+    const initialQuery = inputElement.value.trim();
+    if (initialQuery.length > 0) {
+        performSearch(initialQuery, true);
+    }
 }

--- a/tronbyt_server/templates/manager/configapp.html
+++ b/tronbyt_server/templates/manager/configapp.html
@@ -179,16 +179,7 @@
     searchInput.id = `${field.id}_search`;
     searchInput.placeholder = "{{ _('Enter a location') }}";
     searchInput.setAttribute("data-ignore-config", "true");
-
-    let locationValue;
-    try {
-      locationValue = JSON.parse(config[field.id] || deviceLocation || field.default || "{}");
-      if (locationValue && locationValue.name) {
-        searchInput.value = locationValue.name;
-      }
-    } catch (e) {
-      console.error("Error parsing location value:", e);
-    }
+    // The searchInput.value will be set by the caller function (createLocationField or createLocationBasedField)
 
     container.appendChild(searchInput);
 
@@ -203,9 +194,26 @@
 
   // Helper function to create location field
   function createLocationField(field, config) {
-    const { container, searchInput, resultsList } = createLocationSearchElements(field, config);
+    const { container, searchInput, resultsList } = createLocationSearchElements(field); // config no longer passed here
 
-    const locationValue = config[field.id] || deviceLocation || field.default || {}
+    let initialLocationJsonString = config[field.id] || (deviceLocation !== null ? deviceLocation : undefined) || field.default || "{}";
+    // Ensure initialLocationJsonString is a string, as expected by JSON.parse and hiddenInput.value
+    if (typeof initialLocationJsonString !== 'string') {
+        initialLocationJsonString = "{}"; // Default to empty object string if not a string
+    }
+
+    try {
+        const parsedLoc = JSON.parse(initialLocationJsonString);
+        if (parsedLoc && parsedLoc.name) {
+            searchInput.value = parsedLoc.name;
+        } else {
+            // If parsing works but no name, or if it's an empty object, ensure searchInput is empty
+            searchInput.value = "";
+        }
+    } catch (e) {
+        console.warn("Could not parse initial location for search input in createLocationField:", initialLocationJsonString, e);
+        searchInput.value = ""; // Default to empty if parsing fails
+    }
 
     const hiddenInput = document.createElement("input");
     hiddenInput.type = "hidden";
@@ -225,7 +233,24 @@
 
   // Helper function to create location-based field
   function createLocationBasedField(field, config) {
-    const { container, searchInput, resultsList } = createLocationSearchElements(field, config);
+    const { container, searchInput, resultsList } = createLocationSearchElements(field); // config no longer passed here
+
+    // For locationbased fields, the search input text is always based on deviceLocation
+    if (deviceLocation && typeof deviceLocation === 'string') {
+        try {
+            const parsedDevLoc = JSON.parse(deviceLocation);
+            if (parsedDevLoc && parsedDevLoc.name) {
+                searchInput.value = parsedDevLoc.name;
+            } else {
+                searchInput.value = ""; // Parsed but no name
+            }
+        } catch (e) {
+            console.warn("Could not parse deviceLocation for search input in createLocationBasedField:", deviceLocation, e);
+            searchInput.value = ""; // Default to empty if parsing fails
+        }
+    } else {
+        searchInput.value = ""; // No deviceLocation string
+    }
 
     const hiddenInput = document.createElement("input");
     hiddenInput.type = "hidden";
@@ -242,8 +267,10 @@
     dropdown.className = "form-control";
     container.appendChild(dropdown);
 
-    enableLocationSearch(searchInput, resultsList, hiddenInput, async location => {
-      await fetchOptionsForLocation(field, location, dropdown);
+    enableLocationSearch(searchInput, resultsList, hiddenInput, async locationQueryJson => {
+      // locationQueryJson is the stringified JSON from the location search (e.g., Geoapify result)
+      const currentOptionJsonString = config[field.id]; // This is the currently saved option for the dropdown field
+      await fetchOptionsForLocation(field, locationQueryJson, dropdown, currentOptionJsonString);
     });
 
     return container;
@@ -432,31 +459,72 @@
   }
 
   // Function to fetch options for location-based fields
-  async function fetchOptionsForLocation(field, location, dropdown) {
+  async function fetchOptionsForLocation(field, locationQueryJson, dropdown, currentOptionJsonString) {
     try {
       const response = await fetch(`{{ url_for('manager.schema_handler', device_id=device['id'], iname=app['iname'], handler='') }}${field.handler}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: field.id, param: location })
+        // locationQueryJson is the result of the Geoapify search (e.g., {name: "New York", lat: ..., lon:...})
+        body: JSON.stringify({ id: field.id, param: locationQueryJson })
       });
 
       if (!response.ok) {
-        throw new Error("Failed to fetch options");
+        throw new Error(`Failed to fetch options for ${field.id}: ${response.statusText}`);
       }
 
       const options = await response.json();
       dropdown.innerHTML = ""; // Clear existing options
 
-      options.forEach(option => {
-        const opt = document.createElement("option");
-        opt.value = JSON.stringify(option);
-        opt.textContent = option.display;
-        dropdown.appendChild(opt);
-      });
+      let selectedIndex = 0; // Default to first option
+      let currentOptionFromConfig = null;
 
-      dropdown.dispatchEvent(new Event("change"));
+      if (typeof currentOptionJsonString === 'string' && currentOptionJsonString !== 'undefined' && currentOptionJsonString !== 'null') {
+        try {
+            currentOptionFromConfig = JSON.parse(currentOptionJsonString);
+        } catch (e) {
+            console.warn(`Could not parse currentOptionJsonString for field ${field.id}:`, currentOptionJsonString, e);
+        }
+      }
+
+      if (options && options.length > 0) {
+        options.forEach((option, index) => {
+          const opt = document.createElement("option");
+          const optionValueString = JSON.stringify(option); // The entire option object is the value
+          opt.value = optionValueString;
+          opt.textContent = option.display; // Assuming options have a 'display' property
+          dropdown.appendChild(opt);
+
+          if (currentOptionFromConfig && typeof currentOptionFromConfig === 'object' && typeof option === 'object') {
+            // Compare stringified JSON of the option objects for simplicity.
+            // A more robust comparison might involve checking a specific ID field if available.
+            if (JSON.stringify(option) === JSON.stringify(currentOptionFromConfig)) {
+              selectedIndex = index;
+            }
+          }
+        });
+        dropdown.selectedIndex = selectedIndex;
+      } else {
+        // No options returned from API
+        const noOpt = document.createElement("option");
+        noOpt.textContent = "{{ _('No options available for this location') }}";
+        noOpt.value = "";
+        noOpt.disabled = true;
+        dropdown.appendChild(noOpt);
+        dropdown.selectedIndex = 0;
+      }
+
+      dropdown.dispatchEvent(new Event("change")); // This updates config[field.id] via the main form listener
     } catch (error) {
-      console.error("Error fetching options:", error);
+      console.error(`Error fetching options for field ${field.id}:`, error);
+      dropdown.innerHTML = ""; // Clear in case of error
+      const errOpt = document.createElement("option");
+      errOpt.textContent = "{{ _('Error loading options') }}";
+      errOpt.value = "";
+      errOpt.disabled = true;
+      dropdown.appendChild(errOpt);
+      if (dropdown.options.length > 0) dropdown.selectedIndex = 0;
+      // Dispatch change so config might be updated to an empty/error state if needed
+      dropdown.dispatchEvent(new Event("change"));
     }
   }
 


### PR DESCRIPTION
- Implements initial location search when config page loads with a pre-filled location for fields of type 'location' and 'locationbased'.
- If an exact match for the pre-filled location is found, it's selected.
- Otherwise, the first result from the location search is selected.
- For 'locationbased' fields, after the initial location is determined, options are fetched, and an attempt is made to re-select the previously configured option or the first new option.
- Ensures that the preview updates correctly upon initial load and selection.
- Fixes initialization of the location search input's text value to correctly use deviceLocation for 'locationbased' fields or field's config for 'location' fields.