### PR TITLE
add filter param to pixlet call

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -3,7 +3,7 @@
 pipx install pdm
 pdm sync -d
 
-PIXLET_VERSION=v0.42.1
+PIXLET_VERSION=v0.43.0
 curl -LO "https://github.com/tronbyt/pixlet/releases/download/${PIXLET_VERSION}/pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
 sudo tar -C /usr/local/bin -xvf "pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
 sudo mv /usr/local/bin/libpixlet.so /usr/lib/libpixlet.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           sudo mv /usr/local/bin/libpixlet.so /usr/lib/libpixlet.so
           rm "pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
         env:
-          PIXLET_VERSION: v0.42.0
+          PIXLET_VERSION: v0.43.0
       - name: Test with pytest
         run: pdm run -v pytest tests --doctest-modules --junitxml=junit/test-results.xml
       - name: Type check with mypy

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN pdm install --check --prod --no-editable && pdm build --no-sdist --no-wheel
 
 # Ignore hadolint findings about version pinning
 # hadolint global ignore=DL3007,DL3008,DL3013
-FROM ghcr.io/tronbyt/pixlet:0.42.1 AS pixlet
+FROM ghcr.io/tronbyt/pixlet:0.43.0 AS pixlet
 
 # build runtime image
 FROM debian:trixie-slim AS runtime

--- a/tronbyt_server/__init__.py
+++ b/tronbyt_server/__init__.py
@@ -19,7 +19,7 @@ from tronbyt_server import db, system_apps
 babel = Babel()
 sock = Sock()
 pixlet_render_app: Optional[
-    Callable[[bytes, bytes, int, int, int, int, int, int, int], Any]
+    Callable[[bytes, bytes, int, int, int, int, int, int, int, Optional[bytes]], Any]
 ] = None
 pixlet_get_schema: Optional[Callable[[bytes], Any]] = None
 pixlet_call_handler: Optional[
@@ -57,6 +57,7 @@ def load_pixlet_library() -> None:
         ctypes.c_int,
         ctypes.c_int,
         ctypes.c_int,
+        ctypes.c_char_p,
     ]
 
     # Use c_void_p for the return type to avoid ctype's automatic copying into bytes() objects.
@@ -150,6 +151,7 @@ def render_app(
         timeout,
         image_format,
         1,
+        None,
     )
     error = c_char_p_to_string(ret.error)
     messagesJSON = c_char_p_to_string(ret.messages)


### PR DESCRIPTION
I'm getting a nil pointer dereference error from pixlet on the latest `main` for both the server and pixlet:

```
Jul 02 04:28:56 tronbyt tronbyt-server[70752]: panic: runtime error: invalid memory address or nil pointer dereference
Jul 02 04:28:56 tronbyt tronbyt-server[70752]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x400 pc=0x7ed354dae5e0]
Jul 02 04:28:56 tronbyt tronbyt-server[70752]: goroutine 17 [running, locked to thread]:
Jul 02 04:28:56 tronbyt tronbyt-server[70752]: main._Cfunc_GoString(...)
Jul 02 04:28:56 tronbyt tronbyt-server[70752]:         _cgo_gotypes.go:101
Jul 02 04:28:56 tronbyt tronbyt-server[70752]: main.render_app(0xc000074e60?, 0x7ed3569072f0, 0x40, 0x20, 0x1, 0x3a98, 0x7530, 0x0, 0x1, 0x400)
Jul 02 04:28:56 tronbyt tronbyt-server[70752]:         /home/vincent/pixlet/library/library.go:59 +0x170
```

Haven't spent too much time on it, but it looks like we're missing an argument, I think related to this commit https://github.com/tronbyt/pixlet/commit/ccd8c7da64863b141925a63f30b14eede73086e2

The adjustment in this PR makes things work again, so thought I'd share for anyone else running into the same. Note that I have no context on the intended purpose of the parameter or its planned implementation here.