### PR TITLE
don't call g.user during a render call. might not be logged in.

### DIFF
--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -713,10 +713,12 @@ def render_app(
         magnify = 2
         # ...except for the apps which support 2x natively where we use the original size
         if app and "id" in app:
-            app_details = db.get_app_details_by_id(g.user["username"], app["id"])
-            if app_details.get("supports2x", False):
-                magnify = 1
-                width = 128
+            user = db.get_user_by_device_id(device["id"])
+            if user:
+                app_details = db.get_app_details_by_id(user["username"], app["id"])
+                if app_details.get("supports2x", False):
+                    magnify = 1
+                    width = 128
                 height = 64
 
     data, messages = pixlet_render_app(

--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -719,7 +719,7 @@ def render_app(
                 if app_details.get("supports2x", False):
                     magnify = 1
                     width = 128
-                height = 64
+                    height = 64
 
     data, messages = pixlet_render_app(
         path=app_path,


### PR DESCRIPTION
fixes #297 