### PR TITLE
add @branch syntax to system_apps_url

### DIFF
--- a/tronbyt_server/system_apps.py
+++ b/tronbyt_server/system_apps.py
@@ -36,7 +36,7 @@ def update_system_repo(base_path: Path) -> None:
     )
 
     # Check if the URL contains a branch specification
-    if "@" in system_apps_url:
+    if "@" in system_apps_url and ".git@" in system_apps_url:
         system_apps_repo, branch_name = system_apps_url.rsplit("@", 1)
     else:
         system_apps_repo = system_apps_url


### PR DESCRIPTION
In the event we want to have a more curated branch specified based on a single repo you can do 
https://github.com/tronbyt/apps.git@BRANCH_NAME and it will clone that branch instead of main.