### PR TITLE
fix: debounce config preview updates

### DIFF
--- a/tronbyt_server/templates/manager/configapp.html
+++ b/tronbyt_server/templates/manager/configapp.html
@@ -46,8 +46,18 @@
   const deviceLocation = null;
   {% endif %}
 
+  function debounce(func, wait) {
+    let timeout;
+    return function(...args) {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        func.apply(this, args);
+      }, wait);
+    };
+  }
+
   // Function to update the config text and preview image
-  function updateConfigAndPreview() {
+  const updateConfigAndPreview = debounce(() => {
     const configContent = document.getElementById("configContent").querySelector("pre");
     const previewImage = document.getElementById("previewImage");
     configContent.textContent = JSON.stringify(config, null, 2);
@@ -55,9 +65,7 @@
     const url = new URL(previewImage.src);
     url.searchParams.set("config", JSON.stringify(config));
     previewImage.src = url.toString();
-  }
-
-
+  }, 100);
 
   // Centralized config update handler
   function handleConfigUpdate(event) {


### PR DESCRIPTION
I've noticed when updating config for an app, every change triggers a preview update. For plugins that are slower to render, these pile up and cause the server to go unresponsive. It's especially bad if I drag on the color picker.

This PR debounces `updateConfigAndPreview` so that the preview doesn't update until values have stopped changing for 100ms (see example video below).

Ideally, this should be done on the server-side too but I'm not familiar enough with WSGI and all of the AI solutions seemed hacky, so this is only client-side for now.

Edit: The debounce function was inspired by [You-Dont-Need-Lodash-Underscore](https://you-dont-need.github.io/You-Dont-Need-Lodash-Underscore/#/?id=_debounce).

<details>
  <summary>Before</summary>

<video src="https://github.com/user-attachments/assets/a0587dc9-d58b-427a-a448-5d9ec5c4ba4b"></video>
</details>

<details>
  <summary>After</summary>

<video src="https://github.com/user-attachments/assets/2cf5e749-ba6a-4ece-a458-ffb39a54d4f7"></video>
</details>