### PR TITLE
RM user parameters that caused the container to bootloop

### DIFF
--- a/unraid_tronbyt-server.xml
+++ b/unraid_tronbyt-server.xml
@@ -13,7 +13,7 @@
   <WebUI>http://[IP]:[PORT:8000]</WebUI>
   <TemplateURL/>
   <Icon/>
-  <ExtraParams>--init --restart unless-stopped --user=tronbyt:tronbyt</ExtraParams>
+  <ExtraParams>--init --restart unless-stopped</ExtraParams>
   
   <Environment>
     <Variable>


### PR DESCRIPTION
This PR removed the tronbyt:tronbyt user parameter to better align with Unraid's root ownership of the container