### PR TITLE
Remove run as tronbyt:tronbyt

### DIFF
--- a/unraid_tronbyt-server.xml
+++ b/unraid_tronbyt-server.xml
@@ -13,7 +13,7 @@
   <WebUI>http://[IP]:[PORT:8000]</WebUI>
   <TemplateURL/>
   <Icon/>
-  <ExtraParams>--init --restart unless-stopped --user=tronbyt:tronbyt</ExtraParams>
+  <ExtraParams>--init --restart unless-stopped</ExtraParams>
   
   <Environment>
     <Variable>


### PR DESCRIPTION
Allows the container to successfully start in Unraid