### PR TITLE
add `users:` volume to redis docker-compose

### DIFF
--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -35,5 +35,6 @@ services:
       timeout: 3s
       retries: 3
 volumes:
+  users:
   data:
   redis:


### PR DESCRIPTION
This was missing from the file previously, leading to an error: 

```
service "web" refers to undefined volume users: invalid compose project
```
