### PR TITLE
Optionally use Redis Pub/Sub for WebSocket synchronization

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -17,6 +17,7 @@ The application is structured into several modules:
 *   `tronbyt_server/firmware_utils.py`: Provides utilities for generating, modifying, and downloading firmware binaries.
 *   `tronbyt_server/manager.py`: The web application.
 *   `tronbyt_server/pixlet.py`: Provides an interface to the `libpixlet.so` shared library.
+*   `tronbyt_server/sync.py`: Synchronization primitives.
 *   `tronbyt_server/system_apps.py`: Utilities for managing the system apps repository.
 
 ## Building and Running

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = []
 lock_version = "4.5.0"
-content_hash = "sha256:d707237fbe4f814c9e66116aeedb7db95def06d86a2902d49177f4d7d5c5c0ba"
+content_hash = "sha256:c3e57f498c4f448c57b60a10b3a254f29a200dce4d0a667af8c830ea184549cf"
 
 [[metadata.targets]]
 requires_python = ">=3.12"
@@ -598,6 +598,19 @@ files = [
     {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
     {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
     {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+]
+
+[[package]]
+name = "redis"
+version = "6.4.0"
+requires_python = ">=3.9"
+summary = "Python client for Redis database and key-value store"
+dependencies = [
+    "async-timeout>=4.0.3; python_full_version < \"3.11.3\"",
+]
+files = [
+    {file = "redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f"},
+    {file = "redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-dotenv",
     "requests",
     "tzlocal",
+    "redis>=6.4.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"

--- a/tronbyt_server/sync.py
+++ b/tronbyt_server/sync.py
@@ -1,0 +1,174 @@
+"""Synchronization primitives for Tronbyt Server."""
+
+import os
+from abc import ABC, abstractmethod
+from multiprocessing import Manager
+from typing import Any, cast, Dict, Optional
+
+import redis
+from flask import current_app
+from threading import Lock
+
+# Type alias for multiprocessing.Condition, which is not a class
+ConditionType = Any
+
+NOTIFY_MESSAGE = "notify"
+
+
+class Waiter(ABC):
+    """Abstract base class for a waiter."""
+
+    @abstractmethod
+    def wait(self, timeout: int) -> None:
+        """Wait for a notification."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def close(self) -> None:
+        """Clean up the waiter."""
+        raise NotImplementedError
+
+
+class SyncManager(ABC):
+    """Abstract base class for synchronization managers."""
+
+    @abstractmethod
+    def get_waiter(self, device_id: str) -> Waiter:
+        """Get a waiter for a given device ID."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def notify(self, device_id: str) -> None:
+        """Notify waiters for a given device ID."""
+        raise NotImplementedError
+
+
+class MultiprocessingWaiter(Waiter):
+    """A waiter that uses multiprocessing primitives."""
+
+    def __init__(
+        self,
+        condition: "ConditionType",
+        manager: "MultiprocessingSyncManager",
+        device_id: str,
+    ):
+        self._condition = condition
+        self._manager = manager
+        self._device_id = device_id
+
+    def wait(self, timeout: int) -> None:
+        """Wait for a notification."""
+        with self._condition:
+            self._condition.wait(timeout=timeout)
+
+    def close(self) -> None:
+        """Clean up the waiter."""
+        self._manager._release_condition(self._device_id)
+
+
+class MultiprocessingSyncManager(SyncManager):
+    """A synchronization manager that uses multiprocessing primitives."""
+
+    def __init__(self) -> None:
+        manager = Manager()
+        self._conditions: Dict[str, "ConditionType"] = cast(
+            Dict[str, "ConditionType"], manager.dict()
+        )
+        self._waiter_counts: Dict[str, int] = cast(Dict[str, int], manager.dict())
+        self._lock = manager.Lock()
+        self._manager = manager
+
+    def _release_condition(self, device_id: str) -> None:
+        """Decrement waiter count and clean up condition if no waiters are left."""
+        with self._lock:
+            if device_id in self._waiter_counts:
+                self._waiter_counts[device_id] -= 1
+                if self._waiter_counts[device_id] == 0:
+                    del self._conditions[device_id]
+                    del self._waiter_counts[device_id]
+
+    def get_waiter(self, device_id: str) -> Waiter:
+        """Get a waiter for a given device ID."""
+        with self._lock:
+            if device_id not in self._conditions:
+                self._conditions[device_id] = self._manager.Condition()
+                self._waiter_counts[device_id] = 0
+            self._waiter_counts[device_id] += 1
+            condition = self._conditions[device_id]
+        return MultiprocessingWaiter(condition, self, device_id)
+
+    def notify(self, device_id: str) -> None:
+        """Notify waiters for a given device ID."""
+        condition: Optional["ConditionType"] = None
+        with self._lock:
+            if device_id in self._conditions:
+                condition = self._conditions[device_id]
+
+        if condition:
+            with condition:
+                condition.notify_all()
+
+
+class RedisWaiter(Waiter):
+    """A waiter that uses Redis Pub/Sub."""
+
+    def __init__(self, redis_client: redis.Redis, device_id: str):
+        # ignore_subscribe_messages=True prevents subscription confirmation messages
+        # from being delivered to the consumer. This is useful for simple notification
+        # use-cases, but may hide connection/debugging issues. Consider making this
+        # configurable if you need to debug subscription events.
+        self._pubsub = redis_client.pubsub(  # type: ignore[no-untyped-call]
+            ignore_subscribe_messages=True
+        )
+        self._device_id = device_id
+        self._pubsub.subscribe(self._device_id)
+
+    def wait(self, timeout: int) -> None:
+        """Wait for a notification."""
+        self._pubsub.get_message(timeout=timeout)
+
+    def close(self) -> None:
+        """Clean up the waiter."""
+        try:
+            self._pubsub.unsubscribe(self._device_id)
+        except ConnectionError:
+            # Ignore connection errors during cleanup
+            pass
+        finally:
+            self._pubsub.close()
+
+
+class RedisSyncManager(SyncManager):
+    """A synchronization manager that uses Redis Pub/Sub."""
+
+    def __init__(self, redis_url: str) -> None:
+        self._redis = redis.from_url(redis_url)  # type: ignore[no-untyped-call]
+
+    def get_waiter(self, device_id: str) -> Waiter:
+        """Get a waiter for a given device ID."""
+        return RedisWaiter(self._redis, device_id)
+
+    def notify(self, device_id: str) -> None:
+        """Notify waiters for a given device ID."""
+        self._redis.publish(device_id, NOTIFY_MESSAGE)
+
+
+_sync_manager: Optional[SyncManager] = None
+_sync_manager_lock = Lock()
+
+
+def get_sync_manager() -> SyncManager:
+    """Get the synchronization manager for the application."""
+    global _sync_manager
+    if _sync_manager is None:
+        with _sync_manager_lock:
+            if _sync_manager is None:  # Double-checked locking
+                redis_url = os.getenv("REDIS_URL")
+                if redis_url:
+                    current_app.logger.info("Using Redis for synchronization")
+                    _sync_manager = RedisSyncManager(redis_url)
+                else:
+                    current_app.logger.info("Using multiprocessing for synchronization")
+                    _sync_manager = MultiprocessingSyncManager()
+    assert _sync_manager is not None
+    return _sync_manager


### PR DESCRIPTION
The default syncronization method remains Multiprocessing, but installations which use Redis already for cache might want to leverage that for a more robust, production-ready solution. This remains completely optional to that Tronbyt Server can be run without any external dependencies.