### PR TITLE
Force the render of the current app

### DIFF
--- a/tronbyt_server/pixlet.py
+++ b/tronbyt_server/pixlet.py
@@ -148,6 +148,7 @@ def render_app(
     timeout: int,
     image_format: int,
     logger: Logger,
+    use_cache: int = 1,
 ) -> Tuple[Optional[bytes], List[str]]:
     initialize_pixlet_library(logger)
     if not pixlet_render_app:
@@ -162,7 +163,7 @@ def render_app(
         maxDuration,
         timeout,
         image_format,
-        1,
+        use_cache,
         None,
     )
     error = c_char_p_to_string(ret.error)

--- a/tronbyt_server/templates/manager/updateapp.html
+++ b/tronbyt_server/templates/manager/updateapp.html
@@ -200,6 +200,8 @@
 
   <div style="display: flex; gap: 10px; margin-top: 20px;">
     <input type="submit" class="w3-button w3-green w3-round" value="{{ _('Save') }}">
+    <input type="submit" class="w3-button w3-blue w3-round" name="force_render" value="{{ _('Force Render') }}"
+      onclick="this.value='{{ _('Rendering...') }}'">
     <input type="submit" class="w3-button w3-red w3-round"
       formaction="{{ url_for('manager.deleteapp', device_id=device_id,iname=app['iname']) }}" formmethod="post"
       onclick="return confirm('{{ _('Delete App?') }}');" value="{{ _('Delete') }}">


### PR DESCRIPTION
@IngmarStein I needed a way to bust the cache outside of dev land, to see if it's working.  This adds a button to bypass the cache and force the app to render with fresh data.  I tried to confirm that the pixlet changes are indeed the cache mechanism, but I'm not sure where to find the reference to that function.  It seems like this feature it working for me.