### PR TITLE
FastAPI: more and faster tests, WebSocket refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Install dependencies
         run: pdm sync -d
       - name: Lint code with Ruff
-        run: pdm run ruff check --output-format=github --target-version=py312
+        run: pdm run ruff check --output-format=github
       - name: Check code formatting with Ruff
-        run: pdm run ruff format --diff --target-version=py312 --check
+        run: pdm run ruff format --diff --check
       - name: Install pixlet
         run: |
           curl -LO "https://github.com/tronbyt/pixlet/releases/download/${PIXLET_VERSION}/pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import sqlite3
 from operator import attrgetter
 from pathlib import Path
 
@@ -8,7 +9,7 @@ from tronbyt_server import db
 from tronbyt_server.models.app import App
 
 
-def test_api(auth_client: TestClient) -> None:
+def test_api(auth_client: TestClient, db_connection: sqlite3.Connection) -> None:
     # Create a device
     response = auth_client.post(
         "/create",
@@ -25,10 +26,9 @@ def test_api(auth_client: TestClient) -> None:
     assert response.headers["location"] == "/"
 
     # Get user to find device_id
-    with db.get_db() as db_conn:
-        user = db.get_user(db_conn, "testuser")
-        assert user
-        device_id = list(user.devices.keys())[0]
+    user = db.get_user(db_connection, "testuser")
+    assert user
+    device_id = list(user.devices.keys())[0]
 
     # Push base64 image via call to push
     data = """UklGRsYAAABXRUJQVlA4TLkAAAAvP8AHABcw/wKBJH/ZERYIJEHtr/b8B34K3DbbHievrd+SlSqA3btETOGfo881kEXFGJQRa+biGiCi/xPAXywwVqenXXoCj+L90gO4ryqALawrJOwGX1iVsGnVMRX8irHyqbzGagksXy0zsmlldlEbgotNM1Nfaw04UbmahSFTi0pgml3UgIvaNDNA4JMikAFTQ16YXYhDNk1jbiaGoTEgsnO5vqJ1KwpcpWXOiQrUoqbZyc3FIEb5PAA="""
@@ -73,7 +73,10 @@ def test_api(auth_client: TestClient) -> None:
 
 class TestMoveApp:
     def _setup_device_with_apps(
-        self, auth_client: TestClient, num_apps: int = 4
+        self,
+        auth_client: TestClient,
+        db_connection: sqlite3.Connection,
+        num_apps: int = 4,
     ) -> str:
         """Sets up a user, device, and apps for testing."""
         response = auth_client.post(
@@ -90,10 +93,9 @@ class TestMoveApp:
         assert response.status_code == 302
         assert response.headers["location"] == "/"
 
-        with db.get_db() as db_conn:
-            user = db.get_user(db_conn, "testuser")
-            assert user
-            device_id = list(user.devices.keys())[0]
+        user = db.get_user(db_connection, "testuser")
+        assert user
+        device_id = list(user.devices.keys())[0]
 
         for i in range(1, num_apps + 1):
             response = auth_client.post(
@@ -109,17 +111,21 @@ class TestMoveApp:
             assert response.status_code == 302
         return device_id
 
-    def _get_sorted_apps_from_db(self, device_id: str) -> list[App]:
+    def _get_sorted_apps_from_db(
+        self, db_connection: sqlite3.Connection, device_id: str
+    ) -> list[App]:
         """Retrieves and sorts apps by order for a given device from the DB."""
-        user = utils.get_testuser()
+        user = utils.get_testuser(db_connection)
         apps_dict = user.devices[device_id].apps
         apps_list = sorted(apps_dict.values(), key=attrgetter("order"))
         return apps_list
 
-    def test_move_app_scenarios(self, auth_client: TestClient) -> None:
-        device_id = self._setup_device_with_apps(auth_client, 4)
+    def test_move_app_scenarios(
+        self, auth_client: TestClient, db_connection: sqlite3.Connection
+    ) -> None:
+        device_id = self._setup_device_with_apps(auth_client, db_connection, 4)
 
-        apps = self._get_sorted_apps_from_db(device_id)
+        apps = self._get_sorted_apps_from_db(db_connection, device_id)
         app1, app2, app3, app4 = (
             apps[0].iname,
             apps[1].iname,
@@ -129,32 +135,32 @@ class TestMoveApp:
 
         # Move app2 down
         auth_client.get(f"/{device_id}/{app2}/moveapp?direction=down")
-        apps = self._get_sorted_apps_from_db(device_id)
+        apps = self._get_sorted_apps_from_db(db_connection, device_id)
         assert [app.iname for app in apps] == [app1, app3, app2, app4]
         for i, app in enumerate(apps):
             assert app.order == i
 
         # Move app2 up
         auth_client.get(f"/{device_id}/{app2}/moveapp?direction=up")
-        apps = self._get_sorted_apps_from_db(device_id)
+        apps = self._get_sorted_apps_from_db(db_connection, device_id)
         assert [app.iname for app in apps] == [app1, app2, app3, app4]
         for i, app in enumerate(apps):
             assert app.order == i
 
         # Move app1 up (should not change order)
         auth_client.get(f"/{device_id}/{app1}/moveapp?direction=up")
-        apps = self._get_sorted_apps_from_db(device_id)
+        apps = self._get_sorted_apps_from_db(db_connection, device_id)
         assert [app.iname for app in apps] == [app1, app2, app3, app4]
 
         # Move app4 down (should not change order)
         auth_client.get(f"/{device_id}/{app4}/moveapp?direction=down")
-        apps = self._get_sorted_apps_from_db(device_id)
+        apps = self._get_sorted_apps_from_db(db_connection, device_id)
         assert [app.iname for app in apps] == [app1, app2, app3, app4]
 
         # Move app1 down twice
         auth_client.get(f"/{device_id}/{app1}/moveapp?direction=down")
         auth_client.get(f"/{device_id}/{app1}/moveapp?direction=down")
-        apps = self._get_sorted_apps_from_db(device_id)
+        apps = self._get_sorted_apps_from_db(db_connection, device_id)
         assert [app.iname for app in apps] == [app2, app3, app1, app4]
         for i, app in enumerate(apps):
             assert app.order == i

--- a/tests/test_device_operations.py
+++ b/tests/test_device_operations.py
@@ -1,8 +1,11 @@
+import sqlite3
 from fastapi.testclient import TestClient
 from tests import utils
 
 
-def test_device_operations(auth_client: TestClient) -> None:
+def test_device_operations(
+    auth_client: TestClient, db_connection: sqlite3.Connection
+) -> None:
     r = auth_client.get("/create")
     assert r.status_code == 200
 
@@ -18,7 +21,7 @@ def test_device_operations(auth_client: TestClient) -> None:
         follow_redirects=False,
     )
     assert r.status_code == 302
-    user = utils.get_testuser()
+    user = utils.get_testuser(db_connection)
     device_id = list(user.devices.keys())[0]
     assert user.devices[device_id].name == "TESTDEVICE"
 

--- a/tests/test_files_upload+delete.py
+++ b/tests/test_files_upload+delete.py
@@ -1,8 +1,11 @@
 from io import BytesIO
+import os
+import sqlite3
 
 from fastapi.testclient import TestClient
 
 from tronbyt_server import db
+from tronbyt_server.config import settings
 
 
 def test_upload_and_delete(auth_client: TestClient) -> None:
@@ -37,3 +40,35 @@ def test_upload_and_delete(auth_client: TestClient) -> None:
     )
     assert response.status_code == 302
     assert response.headers["location"] == f"/{device_id}/addapp"
+
+
+def test_upload_bad_extension(
+    auth_client: TestClient, db_connection: sqlite3.Connection
+) -> None:
+    files = {"file": ("report.exe", BytesIO(b"my file contents"))}
+    auth_client.get("/create")
+    response = auth_client.post(
+        "/create",
+        data={
+            "name": "TESTDEVICE",
+            "img_url": "TESTID",
+            "api_key": "TESTKEY",
+            "notes": "TESTNOTES",
+            "brightness": "3",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    user = db.get_user(db_connection, "testuser")
+    assert user
+    device_id = list(user.devices.keys())[0]
+
+    response = auth_client.post(
+        f"/{device_id}/uploadapp", files=files, follow_redirects=False
+    )
+    assert response.status_code == 400
+    assert "File type not allowed" in response.text
+
+    user_apps_path = os.path.join(settings.USERS_DIR, user.username, "apps")
+    assert not os.path.exists(os.path.join(user_apps_path, "report.exe"))

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,0 +1,65 @@
+import sqlite3
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from tronbyt_server.models.user import User
+from tests import utils
+
+
+@pytest.fixture
+def device_user_ws(auth_client: TestClient, db_connection: sqlite3.Connection) -> User:
+    """Fixture to create a user with a device for websocket tests."""
+    response = auth_client.post(
+        "/create",
+        data={
+            "name": "TESTDEVICE_WS",
+            "img_url": "TESTID",
+            "api_key": "TESTKEY",
+            "notes": "TESTNOTES",
+            "brightness": "3",
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    return utils.get_testuser(db_connection)
+
+
+def test_websocket_invalid_device_id_format(auth_client: TestClient) -> None:
+    """Test websocket connection with an invalid device ID format."""
+    with pytest.raises(WebSocketDisconnect) as excinfo:
+        with auth_client.websocket_connect("/invalid-id/ws"):
+            pass
+    assert excinfo.value.code == 1008
+
+
+def test_websocket_nonexistent_device_id(auth_client: TestClient) -> None:
+    """Test websocket connection with a non-existent but valid device ID."""
+    with pytest.raises(WebSocketDisconnect) as excinfo:
+        with auth_client.websocket_connect("/12345678/ws"):
+            pass
+    assert excinfo.value.code == 1008
+
+
+def test_websocket_success_connection_and_data(
+    auth_client: TestClient, device_user_ws: User
+) -> None:
+    """Test successful websocket connection and receiving data."""
+    device_id = list(device_user_ws.devices.keys())[0]
+
+    with auth_client.websocket_connect(f"/{device_id}/ws") as websocket:
+        # It should send brightness first
+        data = websocket.receive_json()
+        assert "brightness" in data
+        assert isinstance(data["brightness"], int)
+
+        # Then it should send the default image or an error message
+        message = websocket.receive()
+        if "bytes" in message:
+            image_data = message["bytes"]
+            assert image_data is not None
+            assert len(image_data) > 0
+        elif "text" in message:
+            json_data = message["text"]
+            assert "status" in json_data
+            assert "message" in json_data

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,33 +1,14 @@
-from pathlib import Path
 import sqlite3
-
-import tronbyt_server.db as db
-from tronbyt_server.config import settings
+from tronbyt_server import db
 from tronbyt_server.models.user import User
 
-uploads_path = Path("tests/users/testuser/apps")
 
-
-def _get_db_conn() -> sqlite3.Connection:
-    db_file = Path(settings.DB_FILE)
-    db_file.parent.mkdir(exist_ok=True)
-    conn = sqlite3.connect(db_file, check_same_thread=False)
-    # conn.row_factory = sqlite3.Row
-    return conn
-
-
-def get_testuser() -> User:
-    conn = _get_db_conn()
+def get_testuser(conn: sqlite3.Connection) -> User:
     user = db.get_user(conn, "testuser")
-    conn.close()
     if not user:
         raise Exception("testuser not found")
     return user
 
 
-def get_user_uploads_list() -> list[str]:
-    star_files = []
-    for file in uploads_path.rglob("*.star"):
-        relative_path = file.relative_to(uploads_path)
-        star_files.append(str(relative_path))
-    return star_files
+def get_user_by_username(conn: sqlite3.Connection, username: str) -> User | None:
+    return db.get_user(conn, username)

--- a/tronbyt_server/main.py
+++ b/tronbyt_server/main.py
@@ -39,7 +39,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     system_apps.update_system_repo(db.get_data_dir(), logger)
     yield
     # Shutdown
-    pass
+    from tronbyt_server.sync import get_sync_manager
+
+    get_sync_manager(logger).shutdown()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/tronbyt_server/routers/manager.py
+++ b/tronbyt_server/routers/manager.py
@@ -582,9 +582,12 @@ async def uploadapp_post(
     app_subdir.mkdir(parents=True, exist_ok=True)
 
     if not await db.save_user_app(file, app_subdir):
-        flash(request, "Save Failed")
-        return RedirectResponse(
-            url=f"/{device_id}/uploadapp", status_code=status.HTTP_302_FOUND
+        flash(request, "File type not allowed")
+        return templates.TemplateResponse(
+            request,
+            "manager/uploadapp.html",
+            {"device_id": device_id, "user": user},
+            status_code=status.HTTP_400_BAD_REQUEST,
         )
 
     flash(request, "Upload Successful")

--- a/tronbyt_server/routers/websockets.py
+++ b/tronbyt_server/routers/websockets.py
@@ -4,12 +4,16 @@ import asyncio
 import json
 import logging
 import sqlite3
+from pathlib import Path
 from typing import cast
 
-from fastapi import APIRouter, WebSocket, status
+from fastapi import APIRouter, Depends, WebSocket, status, Response
+from fastapi.responses import FileResponse
+from starlette.websockets import WebSocketDisconnect
 
 import re
 from tronbyt_server import db
+from tronbyt_server.dependencies import get_db
 from tronbyt_server.routers.manager import _next_app_logic
 from tronbyt_server.sync import get_sync_manager
 
@@ -17,14 +21,87 @@ router = APIRouter(tags=["websockets"])
 logger = logging.getLogger(__name__)
 
 
+async def _send_response(
+    websocket: WebSocket, response: Response, last_brightness: int
+) -> tuple[int, int]:
+    """Send a response to the websocket."""
+    dwell_time = 5
+    if response.status_code == 200:
+        brightness_str = response.headers.get("Tronbyt-Brightness")
+        if brightness_str:
+            brightness = int(brightness_str)
+            if brightness != last_brightness:
+                await websocket.send_text(json.dumps({"brightness": brightness}))
+                last_brightness = brightness
+
+        if isinstance(response, FileResponse):
+            content = await asyncio.get_running_loop().run_in_executor(
+                None, Path(response.path).read_bytes
+            )
+            await websocket.send_bytes(content)
+        else:
+            await websocket.send_bytes(cast(bytes, response.body))
+        dwell_time = int(response.headers.get("Tronbyt-Dwell-Secs", 5))
+    else:
+        await websocket.send_text(
+            json.dumps(
+                {
+                    "status": "error",
+                    "message": f"Error fetching image: {response.status_code}",
+                }
+            )
+        )
+    return dwell_time, last_brightness
+
+
+async def sender(
+    websocket: WebSocket, device_id: str, db_conn: sqlite3.Connection
+) -> None:
+    """The sender task for the websocket."""
+    waiter = get_sync_manager(logger).get_waiter(device_id)
+    loop = asyncio.get_running_loop()
+    last_brightness = -1
+    dwell_time = 5
+
+    try:
+        # Main loop
+        while True:
+            response = await loop.run_in_executor(
+                None, _next_app_logic, db_conn, device_id
+            )
+            dwell_time, last_brightness = await _send_response(
+                websocket, response, last_brightness
+            )
+            await loop.run_in_executor(None, waiter.wait, dwell_time)
+
+    except asyncio.CancelledError:
+        pass  # Expected on disconnect
+    except Exception as e:
+        logger.error(f"WebSocket sender error for device {device_id}: {e}")
+    finally:
+        waiter.close()
+
+
+async def receiver(websocket: WebSocket, device_id: str) -> None:
+    """The receiver task for the websocket."""
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        logger.info(f"WebSocket disconnected for device {device_id}")
+
+
 @router.websocket("/{device_id}/ws")
-async def websocket_endpoint(websocket: WebSocket, device_id: str) -> None:
+async def websocket_endpoint(
+    websocket: WebSocket,
+    device_id: str,
+    db_conn: sqlite3.Connection = Depends(get_db),
+) -> None:
     """WebSocket endpoint for devices."""
     if not re.match(r"^[a-fA-F0-9]{8}$", device_id):
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
 
-    db_conn: sqlite3.Connection = db.get_db()
     user = db.get_user_by_device_id(db_conn, device_id)
     if not user:
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
@@ -36,50 +113,25 @@ async def websocket_endpoint(websocket: WebSocket, device_id: str) -> None:
         return
 
     await websocket.accept()
-    waiter = get_sync_manager(logger).get_waiter(device_id)
 
-    async def reader() -> None:
-        while True:
-            try:
-                waiter.wait(timeout=60)
-                await send_next_image()
-            except Exception as e:
-                logger.error(f"Error in reader: {e}")
-                break
+    sender_task = asyncio.create_task(sender(websocket, device_id, db_conn))
+    receiver_task = asyncio.create_task(receiver(websocket, device_id))
 
-    async def send_next_image() -> int:
+    done, pending = await asyncio.wait(
+        [sender_task, receiver_task], return_when=asyncio.FIRST_COMPLETED
+    )
+
+    for task in done:
         try:
-            response = _next_app_logic(db_conn, device_id)
-            if response.status_code == 200:
-                brightness = response.headers.get("Tronbyt-Brightness")
-                if brightness is not None:
-                    await websocket.send_text(
-                        json.dumps({"brightness": int(brightness)})
-                    )
-                await websocket.send_bytes(cast(bytes, response.body))
-                return int(response.headers.get("Tronbyt-Dwell-Secs", 5))
-            else:
-                await websocket.send_text(
-                    json.dumps(
-                        {
-                            "status": "error",
-                            "message": f"Error fetching image: {response.status_code}",
-                        }
-                    )
-                )
+            task.result()
+        except WebSocketDisconnect:
+            logger.info(f"WebSocket disconnected for device {device_id}")
+            break
         except Exception as e:
-            logger.error(f"Error in send_next_image: {e}")
-        return 5
+            logger.error(f"WebSocket task failed for device {device_id}: {e}")
+            break
 
-    reader_task = asyncio.create_task(reader())
-    try:
-        while True:
-            dwell_time = await send_next_image()
-            await asyncio.sleep(dwell_time)
-    except Exception as e:
-        logger.error(f"WebSocket error: {e}")
-    finally:
-        reader_task.cancel()
-        waiter.close()
-        await websocket.close()
-        db_conn.close()
+    for task in pending:
+        task.cancel()
+
+    await asyncio.gather(*pending, return_exceptions=True)

--- a/tronbyt_server/sync.py
+++ b/tronbyt_server/sync.py
@@ -42,6 +42,11 @@ class SyncManager(ABC):
         """Notify waiters for a given device ID."""
         raise NotImplementedError
 
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Shut down the sync manager."""
+        raise NotImplementedError
+
 
 class MultiprocessingWaiter(Waiter):
     """A waiter that uses multiprocessing primitives."""
@@ -59,7 +64,8 @@ class MultiprocessingWaiter(Waiter):
     def wait(self, timeout: int) -> None:
         """Wait for a notification."""
         with self._condition:
-            self._condition.wait(timeout=timeout)
+            if not self._manager._shutdown_event.is_set():
+                self._condition.wait(timeout=timeout)
 
     def close(self) -> None:
         """Clean up the waiter."""
@@ -77,6 +83,7 @@ class MultiprocessingSyncManager(SyncManager):
         self._waiter_counts: dict[str, int] = cast(dict[str, int], manager.dict())
         self._lock = manager.Lock()
         self._manager = manager
+        self._shutdown_event = manager.Event()
 
     def _release_condition(self, device_id: str) -> None:
         """Decrement waiter count and clean up condition if no waiters are left."""
@@ -107,6 +114,14 @@ class MultiprocessingSyncManager(SyncManager):
         if condition:
             with condition:
                 condition.notify_all()
+
+    def shutdown(self) -> None:
+        """Shut down the sync manager."""
+        self._shutdown_event.set()
+        with self._lock:
+            for condition in self._conditions.values():
+                with condition:
+                    condition.notify_all()
 
 
 class RedisWaiter(Waiter):
@@ -151,6 +166,10 @@ class RedisSyncManager(SyncManager):
     def notify(self, device_id: str) -> None:
         """Notify waiters for a given device ID."""
         self._redis.publish(device_id, NOTIFY_MESSAGE)
+
+    def shutdown(self) -> None:
+        """Shut down the sync manager."""
+        self._redis.close()
 
 
 _sync_manager: SyncManager | None = None


### PR DESCRIPTION
The `app` fixture in `tests/conftest.py` was function-scoped, causing a new database to be created for each test. This was slow.

This change makes the `app` fixture session-scoped, so the application and database are created only once per test session.

To ensure test isolation, the following changes were also made:
- A single database connection is shared across the test session and injected into the app.
- A fixture (`db_cleanup`) cleans all database tables after each test.
- A fixture (`settings_cleanup`) restores application settings after each test to prevent state leakage.

fix(api): Return 404 for non-existent devices

The `/v0/devices/{device_id}` endpoint was returning a 400 Bad Request when a device was not found. This was because the `validate_device_id` check was being performed before the user was authenticated.

This change modifies the `get_device` endpoint to authenticate the user before validating the device ID. This ensures that the endpoint returns a 404 Not Found when a device is not found, which is more semantically correct.

The tests have been updated to reflect this change.

refactor(websockets): Use dependency injection for DB connection

The WebSocket endpoint was directly calling `db.get_db()` to get a database connection. This was inconsistent with the rest of the FastAPI application, which uses dependency injection.

This change refactors the WebSocket endpoint to use `Depends(get_db)` to get the database connection. This makes the code cleaner, more maintainable, and more consistent with the rest of the application.

A test was also updated to reflect a related API change.

feat(upload): Reject files with invalid extensions

The file upload endpoint was not correctly handling files with invalid extensions. This change adds a test to ensure that files with invalid extensions are rejected and updates the API to return a 400 Bad Request when a user tries to upload a file with an invalid extension.

fix(websockets): Handle FileResponse correctly

The WebSocket handler was trying to access the `.body` attribute of a `FileResponse` object, which was causing an `AttributeError`. This change modifies the WebSocket handler to correctly handle `FileResponse` objects by reading the file content from the response's path.

refactor(websockets): Improve websocket logic

The WebSocket endpoint was not correctly handling the application logic. This change refactors the WebSocket endpoint to correctly handle the application logic by sending the brightness whenever it changes (and always before the first image), and getting the next app either after the dwell time expires or when a new image is pushed.

fix(websockets): Gracefully handle websocket close on shutdown

A `RuntimeError` was being raised during server shutdown if a WebSocket client was connected. This was because the application was trying to close a connection that had already been closed by the server.

This change wraps the `websocket.close()` call in a `try...except RuntimeError` block to gracefully handle this situation.