### PR TITLE
Custom app delete and system apps version

### DIFF
--- a/ADDAPP_VERSION_DISPLAY.md
+++ b/ADDAPP_VERSION_DISPLAY.md
@@ -1,0 +1,161 @@
+# Add App Page - System Apps Version Display
+
+## Overview
+Added display of system-apps version (commit hash) next to the "System Apps" title on the add app page, with a clickable link to the GitHub repository at that specific commit.
+
+## Changes Made
+
+### 1. Manager Route (`tronbyt_server/manager.py`)
+
+Updated the `addapp` route to pass `system_repo_info` to the template:
+
+```python
+# Sort apps_list so that installed apps appear first
+apps_list.sort(key=lambda app_metadata: not app_metadata["is_installed"])
+
+system_repo_info = system_apps.get_system_repo_info(db.get_data_dir())
+
+return render_template(
+    "manager/addapp.html",
+    device=g.user["devices"][device_id],
+    apps_list=apps_list,
+    custom_apps_list=custom_apps_list,
+    system_repo_info=system_repo_info,
+)
+```
+
+### 2. Add App Template (`tronbyt_server/templates/manager/addapp.html`)
+
+#### Updated the `render_app_list` Macro
+
+Added `show_version` parameter to the macro and inline version display:
+
+```html
+{% macro render_app_list(title, search_id, grid_id, app_list, show_controls=true, show_version=false) %}
+<div class="app-group">
+  <h3 style="display: inline-block; margin-right: 10px;">{{ title }}</h3>
+  {% if show_version and system_repo_info and system_repo_info.commit_hash %}
+  <span style="font-size: 14px; color: #888;">
+    (version: <a href="{{ system_repo_info.commit_url }}" target="_blank" style="color: #4CAF50; text-decoration: none;">{{ system_repo_info.commit_hash }}</a>)
+  </span>
+  {% endif %}
+  ...
+```
+
+#### Updated System Apps Call
+
+Enabled version display for System Apps:
+
+```html
+{{ render_app_list(_('System Apps'), 'system_search', 'system_app_grid', apps_list, show_version=true) }}
+```
+
+## Features
+
+### Display Information
+- **Inline with Title**: Version appears on the same line as "System Apps" heading
+- **Commit Hash**: Shows the short commit hash (7 characters)
+- **Clickable Link**: Links to the exact commit on GitHub
+- **Subtle Styling**: Gray text with green link to not distract from main content
+
+### Visual Design
+- Inline display: `System Apps (version: abc1234)`
+- H3 heading uses `display: inline-block` to allow inline version text
+- Version text is smaller (14px) and gray (#888)
+- Commit hash link is green (#4CAF50) matching site theme
+- Opens in new tab (`target="_blank"`)
+
+### Conditional Display
+- Only shows if `show_version=true` is passed to macro
+- Only shows if `system_repo_info` exists
+- Only shows if `commit_hash` is available
+- Custom Apps section does NOT show version (only System Apps)
+
+## User Experience
+
+### On Add App Page
+
+Users will see:
+
+```
+Custom Apps
+[app grid...]
+
+─────────────────────────────────
+
+System Apps (version: abc1234)
+                      ↑ clickable link to GitHub
+[search and filter controls]
+[app grid...]
+```
+
+### Example Display
+
+```
+System Apps (version: a1b2c3d)
+```
+
+Where "a1b2c3d" is a clickable link to:
+`https://github.com/tronbyt/apps/tree/a1b2c3d1234567890abcdef`
+
+## Benefits
+
+1. **Visibility**: Users can see which version of system apps is available
+2. **Debugging**: Easy to verify which commit is deployed when reporting issues
+3. **Traceability**: Direct link to view the exact code on GitHub
+4. **Non-intrusive**: Subtle styling doesn't distract from app selection
+5. **Consistent**: Matches the pattern used on firmware and admin pages
+6. **Selective**: Only shows for System Apps, not Custom Apps (which are user-specific)
+
+## Technical Notes
+
+- The version is only displayed if the commit hash is available
+- If the system-apps directory is not a git repository, the version won't appear
+- The commit URL format is: `{repo_url}/tree/{commit_hash}`
+- Uses inline-block display to keep title and version on same line
+- Fully internationalized with `{{ _() }}` translation markers for "System Apps"
+- The macro is reusable - can be enabled for other app lists if needed
+
+## Files Modified
+
+1. `tronbyt_server/manager.py` - Added system_repo_info to addapp route
+2. `tronbyt_server/templates/manager/addapp.html` - Added version display to macro and enabled for System Apps
+
+## Testing
+
+To test the feature:
+
+1. Navigate to any device's "Add App" page
+2. Scroll to the "System Apps" section
+3. Verify the version appears next to the title: `System Apps (version: abc1234)`
+4. Click the commit hash link - should open GitHub at that specific commit
+5. Verify Custom Apps section does NOT show a version
+6. Verify the display is inline and doesn't break the layout
+
+## Comparison with Other Pages
+
+### Admin Settings Page
+- Shows detailed box with commit, repo URL, and branch
+- Includes management buttons
+- More prominent display
+
+### Firmware Generation Page
+- Shows version in a styled info box
+- Includes management button for admins
+- Separate box similar to firmware version
+
+### Add App Page (This Implementation)
+- Shows version inline with title
+- Subtle, non-intrusive display
+- No management buttons (not needed in this context)
+- Focuses on quick reference
+
+## Future Enhancements
+
+Possible future improvements:
+- Add tooltip showing full commit hash on hover
+- Show commit date
+- Add "last updated" timestamp
+- Include branch name if not on main
+- Add visual indicator if version is outdated
+

--- a/UPLOAD_APP_DELETE_BUTTON.md
+++ b/UPLOAD_APP_DELETE_BUTTON.md
@@ -1,0 +1,188 @@
+# Uploaded App Delete Button Enhancement
+
+## Overview
+Enhanced the delete button for uploaded apps on the add app page to make it more prominent and user-friendly with better styling and confirmation dialog.
+
+## Changes Made
+
+### 1. Template Updates (`tronbyt_server/templates/manager/addapp.html`)
+
+#### Enhanced Delete Link
+Added styling, icon, and confirmation dialog:
+
+```html
+{% if is_custom_apps %}
+<a href="{{ url_for('manager.deleteupload', filename=app['path'].split('/')[-1], device_id=device['id']) }}"
+   class="delete-upload-btn"
+   onclick="event.stopPropagation(); return confirm('{{ _('Delete this uploaded app?') }}');">
+  🗑️ {{ _('Delete') }}
+</a>
+{% endif %}
+```
+
+#### Updated Macro Signature
+Added `is_custom_apps` parameter to the `render_app_list` macro:
+
+```html
+{% macro render_app_list(title, search_id, grid_id, app_list, show_controls=true, show_version=false, is_custom_apps=false) %}
+```
+
+#### Updated Macro Calls
+Pass `is_custom_apps=true` for custom apps and `is_custom_apps=false` for system apps:
+
+```html
+{{ render_app_list(_('Custom Apps'), 'custom_search', 'custom_app_grid', custom_apps_list, show_controls=false, is_custom_apps=true) }}
+
+{{ render_app_list(_('System Apps'), 'system_search', 'system_app_grid', apps_list, show_version=true, is_custom_apps=false) }}
+```
+
+#### Added CSS Styling
+New styles for the delete button:
+
+```css
+.delete-upload-btn {
+  display: inline-block;
+  background-color: #f44336;
+  color: white;
+  padding: 5px 10px;
+  border-radius: 3px;
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: bold;
+  margin-top: 8px;
+  transition: background-color 0.2s;
+}
+
+.delete-upload-btn:hover {
+  background-color: #d32f2f;
+  text-decoration: none;
+}
+```
+
+## Features
+
+### Visual Improvements
+- **Red Button**: Prominent red background (#f44336) to indicate destructive action
+- **Trash Icon**: 🗑️ emoji for visual clarity
+- **Bold Text**: Makes the button stand out
+- **Rounded Corners**: Modern, polished appearance
+- **Hover Effect**: Darker red (#d32f2f) on hover for feedback
+
+### Functional Improvements
+- **Confirmation Dialog**: Asks "Delete this uploaded app?" before deletion
+- **Event Propagation Stop**: `event.stopPropagation()` prevents app selection when clicking delete
+- **Internationalized**: Uses `{{ _() }}` for translation support
+
+### User Experience
+- **Clear Intent**: Red color and trash icon clearly indicate deletion
+- **Safety**: Confirmation dialog prevents accidental deletion
+- **No Interference**: Clicking delete doesn't select the app
+- **Responsive**: Hover effect provides visual feedback
+
+## Before vs After
+
+### Before
+```
+[App Preview]
+App Name - Description
+From Author
+Delete  ← plain text link
+```
+
+### After
+```
+[App Preview]
+App Name - Description
+From Author
+┌─────────────┐
+│ 🗑️ Delete  │  ← red button with icon
+└─────────────┘
+```
+
+## Technical Details
+
+### Conditional Display
+The delete button only appears for uploaded apps:
+```python
+{% if is_custom_apps %}
+```
+
+This uses a flag passed to the macro that explicitly indicates whether the app list contains custom/uploaded apps (not system apps). This is more reliable than checking the path string.
+
+### Event Handling
+```javascript
+onclick="event.stopPropagation(); return confirm('...');"
+```
+
+1. `event.stopPropagation()` - Prevents the click from bubbling up to the app-item div (which would select the app)
+2. `return confirm('...')` - Shows confirmation dialog; only proceeds if user clicks OK
+
+### Existing Route
+The delete functionality uses the existing `deleteupload` route:
+```python
+url_for('manager.deleteupload', filename=app['path'].split('/')[-1], device_id=device['id'])
+```
+
+## User Flow
+
+1. User navigates to Add App page
+2. User sees uploaded apps in the Custom Apps section
+3. Each uploaded app shows a red "🗑️ Delete" button
+4. User clicks the delete button
+5. Confirmation dialog appears: "Delete this uploaded app?"
+6. If user clicks OK:
+   - App is deleted from the server
+   - Page redirects back to Add App page
+   - App no longer appears in the list
+7. If user clicks Cancel:
+   - Nothing happens
+   - App remains in the list
+
+## Benefits
+
+1. **Visibility**: Red button is much more noticeable than plain text link
+2. **Safety**: Confirmation dialog prevents accidental deletion
+3. **Clarity**: Trash icon makes the action obvious
+4. **Professional**: Styled button looks polished and modern
+5. **Consistent**: Matches the styling of other action buttons in the app
+6. **Accessible**: Clear visual and textual indication of purpose
+
+## Files Modified
+
+1. `tronbyt_server/templates/manager/addapp.html`
+   - Enhanced delete link with class, icon, and confirmation
+   - Added CSS styling for delete button
+
+## Testing
+
+To test the feature:
+
+1. Upload a .star file using the "Upload .star file" button
+2. Navigate to the Add App page
+3. Find the uploaded app in the Custom Apps section
+4. Verify the red "🗑️ Delete" button appears
+5. Click the delete button
+6. Verify confirmation dialog appears
+7. Click Cancel - verify nothing happens
+8. Click the delete button again
+9. Click OK - verify app is deleted and page refreshes
+10. Verify the app no longer appears in the list
+
+## Edge Cases Handled
+
+- **Click Propagation**: Delete button click doesn't select the app
+- **Confirmation**: User must confirm before deletion
+- **System Apps**: Delete button only shows for uploaded apps, not system apps
+- **Hover State**: Visual feedback when hovering over button
+- **Text Decoration**: No underline on hover (common link issue)
+
+## Future Enhancements
+
+Possible future improvements:
+- Add undo functionality
+- Show toast notification after deletion
+- Add bulk delete option
+- Show file size next to delete button
+- Add "last uploaded" date display
+- Implement soft delete with recovery option
+

--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -613,11 +613,14 @@ def addapp(device_id: str) -> ResponseReturnValue:
         # Sort apps_list so that installed apps appear first
         apps_list.sort(key=lambda app_metadata: not app_metadata["is_installed"])
 
+        system_repo_info = system_apps.get_system_repo_info(db.get_data_dir())
+
         return render_template(
             "manager/addapp.html",
             device=g.user["devices"][device_id],
             apps_list=apps_list,
             custom_apps_list=custom_apps_list,
+            system_repo_info=system_repo_info,
         )
 
     elif request.method == "POST":

--- a/tronbyt_server/templates/auth/edit.html
+++ b/tronbyt_server/templates/auth/edit.html
@@ -8,7 +8,7 @@
 {% if system_repo_info and system_repo_info.commit_hash %}
 <div style="background-color: #2a2a2a; padding: 15px; margin-bottom: 15px; border-radius: 4px; border-left: 4px solid #4CAF50;">
     <div style="margin-bottom: 10px;">
-        <strong>{{ _('Current Commit') }}:</strong>
+        <strong>{{ _('Installed Commit') }}:</strong>
         <a href="{{ system_repo_info.commit_url }}" target="_blank" style="color: #4CAF50; text-decoration: none;">
             {{ system_repo_info.commit_hash }}
         </a>
@@ -50,6 +50,9 @@
             {{ _('Update Firmware') }}
         </button>
     </form>
+    <p style="margin-top: 10px; color: #888; font-size: 0.85em; font-style: italic;">
+        ℹ️ {{ _('Note: This updates the firmware files available for flashing, not the firmware on existing devices. Devices must be manually reflashed to use the new firmware.') }}
+    </p>
 </div>
 {% else %}
 <div style="background-color: #2a2a2a; padding: 15px; margin-bottom: 15px; border-radius: 4px; border-left: 4px solid #ff9800;">
@@ -64,6 +67,9 @@
             {{ _('Download Firmware') }}
         </button>
     </form>
+    <p style="margin-top: 10px; color: #888; font-size: 0.85em; font-style: italic;">
+        ℹ️ {{ _('Note: This updates the firmware files available for flashing, not the firmware on existing devices. Devices must be manually reflashed to use the new firmware.') }}
+    </p>
 </div>
 {% endif %}
 {% endif %}

--- a/tronbyt_server/templates/manager/addapp.html
+++ b/tronbyt_server/templates/manager/addapp.html
@@ -116,9 +116,14 @@
 <form method="post" id="main_form">
   <label for="name">{{ _('App Selection') }}</label>
 
-  {% macro render_app_list(title, search_id, grid_id, app_list, show_controls=true) %}
+  {% macro render_app_list(title, search_id, grid_id, app_list, show_controls=true, show_version=false, is_custom_apps=false) %}
   <div class="app-group">
-    <h3>{{ title }}</h3>
+    <h3 style="display: inline-block; margin-right: 10px;">{{ title }}</h3>
+    {% if show_version and system_repo_info and system_repo_info.commit_hash %}
+    <span style="font-size: 14px; color: #888;">
+      (version: <a href="{{ system_repo_info.commit_url }}" target="_blank" style="color: #4CAF50; text-decoration: none;">{{ system_repo_info.commit_hash }}</a>)
+    </span>
+    {% endif %}
 
     {% if show_controls %}
     <!-- Filter and Sort Controls -->
@@ -179,8 +184,12 @@
           <span style="font-size: 10px; font-weight: normal;">{{ app.get('brokenReason', 'Unknown') }}</span>
         </div>
         {% endif %}
-        {% if app.get('path', '').startswith("users/") %}
-        <a href="{{ url_for('manager.deleteupload', filename=app['path'].split('/')[-1], device_id=device['id']) }}">{{ _('Delete') }}</a>
+        {% if is_custom_apps %}
+        <a href="{{ url_for('manager.deleteupload', filename=app['path'].split('/')[-1], device_id=device['id']) }}"
+           class="delete-upload-btn"
+           onclick="event.stopPropagation(); return confirm('{{ _('Delete this uploaded app?') }}');">
+          🗑️ {{ _('Delete') }}
+        </a>
         {% endif %}
         {% if config['PRODUCTION'] == '0' and not app.get('path', '').startswith("users/") %}
           {% if app.get('broken') %}
@@ -196,12 +205,12 @@
   {% endmacro %}
 
   {% if custom_apps_list %}
-  {{ render_app_list(_('Custom Apps'), 'custom_search', 'custom_app_grid', custom_apps_list, show_controls=false) }}
+  {{ render_app_list(_('Custom Apps'), 'custom_search', 'custom_app_grid', custom_apps_list, show_controls=false, is_custom_apps=true) }}
 
   <hr>
   {% endif %}
 
-  {{ render_app_list(_('System Apps'), 'system_search', 'system_app_grid', apps_list) }}
+  {{ render_app_list(_('System Apps'), 'system_search', 'system_app_grid', apps_list, show_version=true, is_custom_apps=false) }}
 
   <input type="hidden" name="name" id="selected_app">
   <br>
@@ -325,6 +334,31 @@
 
   .filter-sort-controls .control-checkbox {
     margin: 0;
+  }
+
+  .delete-upload-btn {
+    display: inline-block !important;
+    background-color: #f44336 !important;
+    color: white !important;
+    padding: 5px 10px !important;
+    border-radius: 3px !important;
+    text-decoration: none !important;
+    font-size: 12px !important;
+    font-weight: bold !important;
+    margin-top: 8px !important;
+    transition: background-color 0.2s !important;
+    position: relative !important;
+    z-index: 5 !important;
+  }
+
+  .delete-upload-btn:hover {
+    background-color: #d32f2f !important;
+    text-decoration: none !important;
+    color: white !important;
+  }
+
+  .delete-upload-btn:visited {
+    color: white !important;
   }
 </style>
 


### PR DESCRIPTION
Add a delete button for each uploaded app in the apps list page.
Display the system-apps commit hash on add apps page and admin page.