### PR TITLE
feat: pass cycle time to pixlet

### DIFF
--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -986,9 +986,7 @@ def render_app(
                     height = 64
 
     device_interval = device.get("default_interval", 15)
-    app_interval = app.get("display_time", device_interval) if app else device_interval
-    if app_interval == 0:
-        app_interval = device_interval
+    app_interval = (app and app.get("display_time")) or device_interval
 
     data, messages = pixlet_render_app(
         path=app_path,


### PR DESCRIPTION
Pixlet supports limiting the max rendered duration (unless an app sets `show_full_animation = True`). This would speed up renders if an app is not going to be shown for the full animation time. For this to work, the device cycle time/app display time needs to be passed into the Pixlet render.