### PR TITLE
fix locality bug #364

### DIFF
--- a/tronbyt_server/static/js/location.js
+++ b/tronbyt_server/static/js/location.js
@@ -77,8 +77,10 @@ function enableLocationSearch(inputElement, resultsElement, hiddenInputElement, 
     });
 
     // Perform initial search if there's a value in the input field on load
+    // BUT only if there's no existing location data in the hidden field
     const initialQuery = inputElement.value.trim();
-    if (initialQuery.length > 0) {
+    const existingLocationData = hiddenInputElement.value.trim();
+    if (initialQuery.length > 0 && (!existingLocationData || existingLocationData === '{}')) {
         performSearch(initialQuery, true);
     }
 }

--- a/tronbyt_server/templates/manager/configapp.html
+++ b/tronbyt_server/templates/manager/configapp.html
@@ -255,10 +255,10 @@
 
     try {
       const parsedLoc = JSON.parse(initialLocationJsonString);
-      if (parsedLoc && parsedLoc.locality) {
-        searchInput.value = parsedLoc.locality;
+      if (parsedLoc && parsedLoc.description) {
+        searchInput.value = parsedLoc.description;
       } else {
-        // If parsing works but no locality, or if it's an empty object, ensure searchInput is empty
+        // If parsing works but no description, or if it's an empty object, ensure searchInput is empty
         searchInput.value = "";
       }
     } catch (e) {
@@ -290,10 +290,10 @@
     if (deviceLocation && typeof deviceLocation === 'string') {
       try {
         const parsedDevLoc = JSON.parse(deviceLocation);
-        if (parsedDevLoc && parsedDevLoc.locality) {
-          searchInput.value = parsedDevLoc.locality;
+        if (parsedDevLoc && parsedDevLoc.description) {
+          searchInput.value = parsedDevLoc.description;
         } else {
-          searchInput.value = ""; // Parsed but no locality
+          searchInput.value = ""; // Parsed but no description
         }
       } catch (e) {
         console.warn("Could not parse deviceLocation for search input in createLocationBasedField:", deviceLocation, e);

--- a/tronbyt_server/templates/manager/update.html
+++ b/tronbyt_server/templates/manager/update.html
@@ -363,7 +363,7 @@
     <div class="form-group">
       <label for="location_search">{{ _('Location') }}</label>
       <input type="text" id="location_search" placeholder="{{ _('Enter a location') }}"
-        value="{{ request.form['location_search'] or device.get('location', {}).get('locality', '') }}">
+        value="{{ request.form['location_search'] or device.get('location', {}).get('description', '') }}">
       <ul id="location_results"></ul>
       <input type="hidden" name="location" id="location"
         value='{{ (request.form["location"] or device["location"] or {}) | tojson }}'>


### PR DESCRIPTION
fixes #364
The full location was getting stripped down to a shorter "locality" value and this value was being used to search for the location on page load and was being replaced by the first result. Now use full description as returned by the initial search and not abridged locality version.