### PR TITLE
feat(manager): inject `$2x` into config

### DIFF
--- a/tronbyt_server/manager.py
+++ b/tronbyt_server/manager.py
@@ -888,6 +888,7 @@ def updateapp(device_id: str, iname: str) -> ResponseReturnValue:
 
 def add_default_config(config: Dict[str, Any], device: Device) -> Dict[str, Any]:
     config["$tz"] = db.get_device_timezone_str(device)
+    config["$2x"] = str(device_supports_2x(device))
     return config
 
 


### PR DESCRIPTION
Adds `$2x` to device config. Can be used like:
```python
if config.bool("$2x"):
  ...
```

To test, I made a simple app:
```python
def main(config):
    print(config.bool("$2x"))
    return []
```
and got the expected results.

From a Gen1:
<img width="400" alt="Gen1" src="https://github.com/user-attachments/assets/a4e51296-eead-45f0-bfca-f0e981a1f9b2" />

From an S3 Wide:
<img width="400" alt="S3 Wide" src="https://github.com/user-attachments/assets/531258ed-6fa1-4810-942a-9e1fb6bb3fa5" />
