### PR TITLE
feat(config): add loading indicator when preview is updating

### DIFF
--- a/tronbyt_server/static/css/addapp-simple.css
+++ b/tronbyt_server/static/css/addapp-simple.css
@@ -30,27 +30,6 @@
   display: none;
 }
 
-/* Skeleton loader */
-.skeleton-loader {
-  width: 100%;
-  aspect-ratio: 2 / 1;
-  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
-  background-size: 200% 100%;
-  animation: loading 1.5s infinite;
-  border-radius: 4px;
-  margin-bottom: 10px;
-}
-
-@keyframes loading {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-
-/* Hide skeleton when image loads */
-.app-img img.loaded + .skeleton-loader {
-  display: none;
-}
-
 /* Optimized grid layout */
 .app-grid {
   display: grid;

--- a/tronbyt_server/static/css/style.css
+++ b/tronbyt_server/static/css/style.css
@@ -114,6 +114,8 @@ input[type=submit] {
 
 /* app-img styles with variables */
 .app-img {
+  aspect-ratio: 2 / 1;
+  position: relative;
   background: var(--app-img-bg);
   overflow: hidden;
   border: 1px solid var(--app-img-border);
@@ -132,6 +134,28 @@ input[type=submit] {
   mask-size: cover;
   width: 100%;
   height: 100%;
+}
+
+/* Skeleton loader */
+.skeleton-loader {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, #0009 25%, #fff3 50%, #0009 75%);
+  background-size: 200% 100%;
+  animation: loading 1.5s infinite;
+  border-radius: 4px;
+}
+
+@keyframes loading {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Hide skeleton when image loads */
+.app-img img.loaded + .skeleton-loader {
+  display: none;
 }
 
 /* Theme Toggle Styles - now using variables */

--- a/tronbyt_server/templates/manager/configapp.html
+++ b/tronbyt_server/templates/manager/configapp.html
@@ -93,7 +93,16 @@
     // Reload the preview image to reflect updated config
     const url = new URL(previewImage.src);
     url.searchParams.set("config", JSON.stringify(config));
+    let loading = true;
+    previewImage.addEventListener('load', () => {
+        loading = false;
+        previewImage.classList.add('loaded');
+        previewImage.classList.remove('hidden');
+    }, { once: true });
     previewImage.src = url.toString();
+    setTimeout(() => {
+        if (loading) previewImage.classList.remove('loaded');
+    }, 500);
   }, 100);
 
   // Centralized config update handler
@@ -759,9 +768,11 @@
 
 <!-- App Preview -->
 <div class="app-img">
-  <img id="previewImage" 
+  <img id="previewImage"
     src="{{ url_for('manager.preview', device_id=device['id'], iname=app['iname']) }}?config={{ config | tojson | urlencode }}"
-    alt="{{ _('Preview') }}">
+    alt="{{ _('Preview') }}"
+    class="hidden">
+  <div class="skeleton-loader"></div>
 </div>
 <form method="post" id="dynamicForm"></form>
 {% endblock %}


### PR DESCRIPTION
This uses the skeleton loader from the "Add App" page on the config page. The loader waits 500ms to show in case the app preview updates quickly. The loader colors have also been changed to match the dark background of most apps, and is a bit translucent so the previous preview shows through.

Closes #362

https://github.com/user-attachments/assets/270d8cfb-36a1-4396-a367-fdba87eaa80d

