### PR TITLE
feat: add color palette buttons

### DIFF
--- a/tronbyt_server/static/css/configapp-simple.css
+++ b/tronbyt_server/static/css/configapp-simple.css
@@ -3,3 +3,25 @@
 .button-separator {
   color: #666; /* Override common color */
 }
+
+.palette {
+  text-align: center;
+  padding-bottom: 10px;
+}
+.palette button {
+  background-color: var(--color);
+  border-radius: 100%;
+  margin: 2px;
+  padding: 10px;
+}
+.palette button:hover {
+  background-color: var(--color) !important;
+  filter: brightness(1.25);
+}
+
+@media screen and (max-width: 600px) {
+  .palette button {
+    width: auto;
+    padding: 20px;
+  }
+}

--- a/tronbyt_server/templates/manager/configapp.html
+++ b/tronbyt_server/templates/manager/configapp.html
@@ -223,6 +223,10 @@
           if (!config[field.id]) {
             config[field.id] = field.default || "#000000";
           }
+          if (field.palette) {
+              const div = createColorPaletteButtons(field, inputElement);
+              inputCell.appendChild(div);
+          }
           break;
 
         case "png":
@@ -569,6 +573,33 @@
     sourceField.addEventListener("input", updateGeneratedFields);
 
     updateGeneratedFields(); // Initial call to populate fields
+  }
+
+  function createColorPaletteButtons(field, inputElement) {
+    const hexColorRegex = /^#([0-9a-f]{3}){1,2}$/i;
+    const div = document.createElement('div');
+    div.className = 'palette';
+    field.palette?.forEach(color => {
+      if (!hexColorRegex.test(color)) {
+        console.warn(`Skipping invalid color from palette: ${color}`);
+        return;
+      }
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'w3-button';
+      btn.style.setProperty('--color', color);
+      btn.setAttribute('aria-label', `Set color to ${color}`);
+      btn.addEventListener('click', () => {
+          if (color.length === 4) {
+            // Expand #rgb to #rrggbb
+            color = '#' + [...color.slice(1)].map(c => c + c).join('');
+          }
+          inputElement.value = color;
+          inputElement.dispatchEvent(new Event('input'));
+      })
+      div.appendChild(btn);
+    })
+    return div;
   }
 
   // Function to fetch options for location-based fields


### PR DESCRIPTION
Adds buttons to choose a color when an app provides a color palette.

Tested in Chrome, Firefox, and Safari.

Desktop view:
<img width="943" height="348" alt="image" src="https://github.com/user-attachments/assets/46c73392-d30e-4c6d-8e1d-f1aff748556c" />

Mobile view:
<img width="516" height="652" alt="image" src="https://github.com/user-attachments/assets/fe1b88bd-c1bf-4ed2-a701-0b19d6842356" />
