### PR TITLE
chore(docker): update pixlet version to v0.46.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pdm install --check --prod --no-editable && pdm build --no-sdist --no-wheel
 
 # Ignore hadolint findings about version pinning
 # hadolint global ignore=DL3007,DL3008,DL3013
-FROM ghcr.io/tronbyt/pixlet:0.45.0 AS pixlet
+FROM ghcr.io/tronbyt/pixlet:0.46.0 AS pixlet
 
 # build runtime image
 FROM debian:trixie-slim AS runtime


### PR DESCRIPTION
See https://github.com/tronbyt/pixlet/releases/tag/v0.46.0