### PR TITLE
Remove the need to specify an external address

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build
         run: pdm build
       - name: Upload Release Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: release-artifacts
           path: dist
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Fetch Release Artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v5
         with:
           path: dist
           pattern: release-artifacts

--- a/tronbyt_server/config.py
+++ b/tronbyt_server/config.py
@@ -14,10 +14,6 @@ class Settings(BaseSettings):
     )
 
     SECRET_KEY: str = "lksdj;as987q3908475ukjhfgklauy983475iuhdfkjghairutyh"
-    MAX_CONTENT_LENGTH: int = 1000 * 1000
-    SERVER_HOSTNAME: str = "localhost"
-    SERVER_PORT: str = "8000"
-    SERVER_PROTOCOL: str = "http"
     USERS_DIR: str = "users"
     DATA_DIR: str = "data"
     PRODUCTION: str = "1"

--- a/tronbyt_server/routers/auth.py
+++ b/tronbyt_server/routers/auth.py
@@ -251,7 +251,7 @@ def post_login(
         key=manager.cookie_name,
         value=access_token,
         max_age=cookie_max_age,
-        secure=settings.SERVER_PROTOCOL == "https",  # Set secure flag in production
+        secure=request.url.scheme == "https",  # Set secure flag in production
         httponly=True,  # Standard security practice
         samesite="lax",  # Can be "strict" or "lax"
     )

--- a/tronbyt_server/routers/manager.py
+++ b/tronbyt_server/routers/manager.py
@@ -54,9 +54,7 @@ from tronbyt_server.utils import (
     render_app,
     send_default_image,
     send_image,
-    server_root,
     set_repo,
-    ws_root,
 )
 
 router = APIRouter(tags=["manager"])
@@ -231,7 +229,9 @@ def index(
     if user.devices:
         for device in reversed(list(user.devices.values())):
             if not device.ws_url:
-                device.ws_url = ws_root() + f"/{device.id}/ws"
+                device.ws_url = str(
+                    request.url_for("websocket_endpoint", device_id=device.id)
+                )
                 user_updated = True
 
             ui_device = device.model_copy()
@@ -304,8 +304,10 @@ def create_post(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
-    img_url = form_data.img_url or f"{server_root()}/{device_id}/next"
-    ws_url = form_data.ws_url or ws_root() + f"/{device_id}/ws"
+    img_url = form_data.img_url or str(request.url_for("next_app", device_id=device_id))
+    ws_url = form_data.ws_url or str(
+        request.url_for("websocket_endpoint", device_id=device_id)
+    )
     api_key = form_data.api_key or "".join(
         secrets.choice(string.ascii_letters + string.digits) for _ in range(32)
     )
@@ -360,8 +362,8 @@ def update(
     if not device:
         return RedirectResponse(url="/", status_code=status.HTTP_404_NOT_FOUND)
 
-    default_img_url = f"{server_root()}/{device_id}/next"
-    default_ws_url = ws_root() + f"/{device_id}/ws"
+    default_img_url = request.url_for("next_app", device_id=device_id)
+    default_ws_url = str(request.url_for("websocket_endpoint", device_id=device_id))
 
     ui_device = device.model_copy()
     if ui_device.brightness:
@@ -495,12 +497,12 @@ def update_post(
     device.img_url = (
         db.sanitize_url(form_data.img_url)
         if form_data.img_url
-        else f"{server_root()}/{device_id}/next"
+        else str(request.url_for("next_app", device_id=device_id))
     )
     device.ws_url = (
         db.sanitize_url(form_data.ws_url)
         if form_data.ws_url
-        else ws_root() + f"/{device_id}/ws"
+        else str(request.url_for("websocket_endpoint", device_id=device_id))
     )
     device.api_key = form_data.api_key or ""
     device.notes = form_data.notes or ""
@@ -987,7 +989,6 @@ def updateapp(
             "device_id": device_id,
             "config": json.dumps(app.config, indent=4),
             "user": user,
-            "server_root": server_root(),
             "form": {},  # Empty form data for GET request
         },
     )
@@ -1742,8 +1743,10 @@ async def import_device_config_post(
             return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
         # Regenerate URLs with current server root
-        device_config["img_url"] = f"{server_root()}/{device_id}/next"
-        device_config["ws_url"] = f"{ws_root()}/{device_id}/ws"
+        device_config["img_url"] = str(request.url_for("next_app", device_id=device_id))
+        device_config["ws_url"] = str(
+            request.url_for("websocket_endpoint", device_id=device_id)
+        )
         user.devices[device_config["id"]] = Device(**device_config)
         db.save_user(db_conn, user)
         flash(request, _("Device configuration imported successfully"))
@@ -1794,8 +1797,12 @@ async def import_user_config(
         # Regenerate img_url and ws_url with new server root for all devices
         if "devices" in user_config:
             for device_id, device_data in user_config["devices"].items():
-                device_data["img_url"] = f"{server_root()}/{device_id}/next"
-                device_data["ws_url"] = f"{ws_root()}/{device_id}/ws"
+                device_data["img_url"] = str(
+                    request.url_for("next_app", device_id=device_id)
+                )
+                device_data["ws_url"] = str(
+                    request.url_for("websocket_endpoint", device_id=device_id)
+                )
 
         logging.info(f"Attempting to import user config: {user_config.keys()}")
         try:
@@ -1865,8 +1872,10 @@ async def import_device_post(
             return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
         # Regenerate URLs with current server root
-        device_config["img_url"] = f"{server_root()}/{device_id}/next"
-        device_config["ws_url"] = f"{ws_root()}/{device_id}/ws"
+        device_config["img_url"] = str(request.url_for("next_app", device_id=device_id))
+        device_config["ws_url"] = str(
+            request.url_for("websocket_endpoint", device_id=device_id)
+        )
         device = Device(**device_config)
         user.devices[device.id] = device
         db.save_user(db_conn, user)

--- a/tronbyt_server/templates/manager/updateapp.html
+++ b/tronbyt_server/templates/manager/updateapp.html
@@ -371,7 +371,7 @@
   -H "Authorization: Bearer {{ device.api_key or 'YOUR_API_KEY' }}" \
   -H "Content-Type: application/json" \
   -d '{"set_enabled": true}' \
-  {{ server_root }}/v0/devices/{{ device_id }}/installations/{{ app.iname }}</pre>
+  {{ url_for('handle_patch_device_app', device_id=device_id, installation_id=app.iname) }}</pre>
   </div>
 
   <!-- Disable App -->
@@ -381,7 +381,7 @@
   -H "Authorization: Bearer {{ device.api_key or 'YOUR_API_KEY' }}" \
   -H "Content-Type: application/json" \
   -d '{"set_enabled": false}' \
-  {{ server_root }}/v0/devices/{{ device_id }}/installations/{{ app.iname }}</pre>
+  {{ url_for('handle_patch_device_app', device_id=device_id, installation_id=app.iname) }}</pre>
   </div>
 
   <!-- Pin App -->
@@ -391,7 +391,7 @@
   -H "Authorization: Bearer {{ device.api_key or 'YOUR_API_KEY' }}" \
   -H "Content-Type: application/json" \
   -d '{"set_pinned": true}' \
-  {{ server_root }}/v0/devices/{{ device_id }}/installations/{{ app.iname }}</pre>
+  {{ url_for('handle_patch_device_app', device_id=device_id, installation_id=app.iname) }}</pre>
   </div>
 
   <!-- Unpin App -->
@@ -401,7 +401,7 @@
   -H "Authorization: Bearer {{ device.api_key or 'YOUR_API_KEY' }}" \
   -H "Content-Type: application/json" \
   -d '{"set_pinned": false}' \
-  {{ server_root }}/v0/devices/{{ device_id }}/installations/{{ app.iname }}</pre>
+  {{ url_for('handle_patch_device_app', device_id=device_id, installation_id=app.iname) }}</pre>
   </div>
 
   <small>

--- a/tronbyt_server/utils.py
+++ b/tronbyt_server/utils.py
@@ -14,7 +14,6 @@ from werkzeug.utils import secure_filename
 from fastapi_babel import _
 
 from tronbyt_server import db
-from tronbyt_server.config import get_settings
 from tronbyt_server.flash import flash
 from tronbyt_server.models import App, Device, User
 from tronbyt_server.pixlet import render_app as pixlet_render_app
@@ -28,31 +27,6 @@ def git_command(
     env = os.environ.copy()
     env.setdefault("HOME", os.getcwd())
     return subprocess.run(command, cwd=cwd, env=env, check=check)
-
-
-def server_root() -> str:
-    """Get the root URL of the server."""
-    settings = get_settings()
-    protocol = settings.SERVER_PROTOCOL
-    hostname = settings.SERVER_HOSTNAME
-    port = settings.SERVER_PORT
-    url = f"{protocol}://{hostname}"
-    if (protocol == "https" and port != "443") or (protocol == "http" and port != "80"):
-        url += f":{port}"
-    return url
-
-
-def ws_root() -> str:
-    """Get the root URL for websockets."""
-    settings = get_settings()
-    server_protocol = settings.SERVER_PROTOCOL
-    protocol = "wss" if server_protocol == "https" else "ws"
-    hostname = settings.SERVER_HOSTNAME
-    port = settings.SERVER_PORT
-    url = f"{protocol}://{hostname}"
-    if (protocol == "wss" and port != "443") or (protocol == "ws" and port != "80"):
-        url += f":{port}"
-    return url
 
 
 def add_default_config(config: dict[str, Any], device: Device) -> dict[str, Any]:


### PR DESCRIPTION
Read hostname, port, and scheme from request headers and remove the `SERVER_PROTOCOL`, `SERVER_HOSTNAME`, and `SERVER_PORT` settings.

Fixes https://github.com/tronbyt/server/issues/395