### PR TITLE
perf: vacuum database on startup

### DIFF
--- a/tronbyt_server/main.py
+++ b/tronbyt_server/main.py
@@ -37,6 +37,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     db_connection = next(get_db(settings=settings))
     with db_connection:
         db.init_db(db_connection)
+
     yield
     # Shutdown
     from tronbyt_server.sync import get_sync_manager

--- a/tronbyt_server/startup.py
+++ b/tronbyt_server/startup.py
@@ -64,4 +64,10 @@ def run_once() -> None:
     else:
         logger.info("Skipping system apps update and database backup (dev mode)")
 
+    try:
+        with sqlite3.connect(settings.DB_FILE) as conn:
+            db.vacuum(conn)
+    except Exception as e:
+        logger.warning(f"Could not vacuum database: {e}")
+
     logger.info("One-time startup tasks complete.")


### PR DESCRIPTION
My database file was over 200 MiB, so I vacuumed it to bring its size down to 20 KiB. This PR adds a `VACUUM` call during startup (immediately after backup and migrations). I also looked into enabling incremental backup, but I think it would only help if we were doing a large number of deletes. This will at least trim the extra database pages during each restart.