### PR TITLE
Logging improvements

### DIFF
--- a/tronbyt_server/config.py
+++ b/tronbyt_server/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     LANGUAGES: list[str] = ["en", "de"]
     MAX_USERS: int = 100
     ENABLE_USER_REGISTRATION: str = "0"
-    LOG_LEVEL: str = "WARNING"
+    LOG_LEVEL: str = "INFO"
     SYSTEM_APPS_REPO: str = "https://github.com/tronbyt/apps.git"
     LIBPIXLET_PATH: str | None = None
     REDIS_URL: str | None = None

--- a/tronbyt_server/main.py
+++ b/tronbyt_server/main.py
@@ -29,7 +29,6 @@ MODULE_ROOT = Path(__file__).parent.resolve()
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Run startup and shutdown events."""
     # Startup
-    logging.basicConfig(level=get_settings().LOG_LEVEL)
     logger = logging.getLogger(__name__)
 
     settings = get_settings()

--- a/tronbyt_server/startup.py
+++ b/tronbyt_server/startup.py
@@ -48,7 +48,6 @@ def backup_database(db_file: str, logger: logging.Logger) -> None:
 def run_once() -> None:
     """Run tasks that should only be executed once at application startup."""
     settings = get_settings()
-    logging.basicConfig(level=settings.LOG_LEVEL)
     logger = logging.getLogger(__name__)
     logger.info("Running one-time startup tasks...")
     try:


### PR DESCRIPTION
- remove redundant logging configurations (basicConfig was called multiple times)
- use a consistent LOG_LEVEL setting (from Settings which respects .env files, not just the environment)
- remove logger names (like `uvicorn.access`) and add timestamps