### PR TITLE
Refactor: Improve logging and reduce code duplication

### DIFF
--- a/tronbyt_server/db.py
+++ b/tronbyt_server/db.py
@@ -602,7 +602,7 @@ def get_apps_list(user: str) -> list[dict[str, Any]]:
         list_file = get_data_dir() / "system-apps.json"
         if not list_file.exists():
             logger.info("Generating apps.json file...")
-            system_apps.update_system_repo(get_data_dir(), logger)
+            system_apps.update_system_repo(get_data_dir())
             logger.debug("apps.json file generated.")
         with list_file.open("r") as f:
             app_list = json.load(f)

--- a/tronbyt_server/firmware_utils.py
+++ b/tronbyt_server/firmware_utils.py
@@ -5,7 +5,7 @@ import os
 import requests
 import subprocess
 import sys
-from logging import Logger
+import logging
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -14,9 +14,16 @@ from tronbyt_server import db
 from tronbyt_server.firmware import correct_firmware_esptool
 
 
+logger = logging.getLogger(__name__)
+
+
 # firmware bin files named after env targets in firmware project.
 def generate_firmware(
-    url: str, ap: str, pw: str, device_type: str, swap_colors: bool, logger: Logger
+    url: str,
+    ap: str,
+    pw: str,
+    device_type: str,
+    swap_colors: bool,
 ) -> bytes:
     # Determine the firmware filename based on device type
     if device_type == "tidbyt_gen2":
@@ -76,7 +83,7 @@ def generate_firmware(
         return content
 
 
-def update_firmware_binaries(base_path: Path, logger: Logger) -> dict[str, Any]:
+def update_firmware_binaries(base_path: Path) -> dict[str, Any]:
     """Download the latest firmware bin files from GitHub releases.
 
     Returns:
@@ -265,7 +272,7 @@ def update_firmware_binaries(base_path: Path, logger: Logger) -> dict[str, Any]:
 
 
 def update_firmware_binaries_subprocess(
-    base_path: Path, logger: Logger
+    base_path: Path,
 ) -> dict[str, Any]:
     # Run the update_firmware_binaries function in a subprocess.
     # This is a workaround for a conflict between Python's and Go's TLS implementations.
@@ -282,8 +289,7 @@ def update_firmware_binaries_subprocess(
                 "from tronbyt_server import firmware_utils; "
                 "import logging, sys, json; "
                 "from pathlib import Path;"
-                "logger = logging.getLogger('firmware_update'); "
-                "result = firmware_utils.update_firmware_binaries(Path(sys.argv[1]), logger); "
+                "result = firmware_utils.update_firmware_binaries(Path(sys.argv[1])); "
                 "print(json.dumps(result))"
             ),
             str(base_path),

--- a/tronbyt_server/main.py
+++ b/tronbyt_server/main.py
@@ -1,6 +1,5 @@
 """Main application file."""
 
-import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -29,8 +28,6 @@ MODULE_ROOT = Path(__file__).parent.resolve()
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Run startup and shutdown events."""
     # Startup
-    logger = logging.getLogger(__name__)
-
     settings = get_settings()
 
     db_connection = next(get_db(settings=settings))
@@ -41,7 +38,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Shutdown
     from tronbyt_server.sync import get_sync_manager
 
-    get_sync_manager(logger).shutdown()
+    get_sync_manager().shutdown()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/tronbyt_server/routers/api.py
+++ b/tronbyt_server/routers/api.py
@@ -291,7 +291,7 @@ def _push_image(
     if installation_id and db_conn:
         db.add_pushed_app(db_conn, device_id, installation_id)
 
-    push_new_image(device_id, logger)
+    push_new_image(device_id)
 
 
 @router.post("/devices/{device_id}/push")
@@ -474,7 +474,7 @@ def handle_app_push(
     installation_id = data.installationID or data.installationId or ""
     app_dict = db.get_pushed_app(user, device_id, installation_id)
     app = App(**app_dict)
-    image_bytes = render_app(db_conn, app_path, data.config, None, device, app, logger)
+    image_bytes = render_app(db_conn, app_path, data.config, None, device, app)
     if image_bytes is None:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/tronbyt_server/routers/websockets.py
+++ b/tronbyt_server/routers/websockets.py
@@ -308,7 +308,7 @@ async def sender(
     ack: DeviceAcknowledgment,
 ) -> None:
     """The sender task for the websocket."""
-    waiter = get_sync_manager(logger).get_waiter(device_id)
+    waiter = get_sync_manager().get_waiter(device_id)
     loop = asyncio.get_running_loop()
     last_brightness = -1
     dwell_time = 5

--- a/tronbyt_server/startup.py
+++ b/tronbyt_server/startup.py
@@ -10,7 +10,10 @@ from tronbyt_server import db, firmware_utils, system_apps
 from tronbyt_server.config import get_settings
 
 
-def backup_database(db_file: str, logger: logging.Logger) -> None:
+logger = logging.getLogger(__name__)
+
+
+def backup_database(db_file: str) -> None:
     """Create a timestamped backup of the SQLite database."""
     db_path = Path(db_file)
     if not db_path.exists():
@@ -51,15 +54,15 @@ def run_once() -> None:
     logger = logging.getLogger(__name__)
     logger.info("Running one-time startup tasks...")
     try:
-        firmware_utils.update_firmware_binaries(db.get_data_dir(), logger)
+        firmware_utils.update_firmware_binaries(db.get_data_dir())
     except Exception as e:
         logger.error(f"Failed to update firmware during startup: {e}")
 
     # Backup the database before initializing (only in production)
     # Skip system apps update in dev mode
     if settings.PRODUCTION == "1":
-        system_apps.update_system_repo(db.get_data_dir(), logger)
-        backup_database(settings.DB_FILE, logger)
+        system_apps.update_system_repo(db.get_data_dir())
+        backup_database(settings.DB_FILE)
     else:
         logger.info("Skipping system apps update and database backup (dev mode)")
 

--- a/tronbyt_server/sync.py
+++ b/tronbyt_server/sync.py
@@ -15,6 +15,8 @@ ConditionType = Any
 
 NOTIFY_MESSAGE = "notify"
 
+logger = logging.getLogger(__name__)
+
 
 class Waiter(ABC):
     """Abstract base class for a waiter."""
@@ -182,7 +184,7 @@ _sync_manager: SyncManager | None = None
 _sync_manager_lock = Lock()
 
 
-def get_sync_manager(logger: logging.Logger) -> SyncManager:
+def get_sync_manager() -> SyncManager:
     """Get the synchronization manager for the application."""
     global _sync_manager
     if _sync_manager is None:


### PR DESCRIPTION
This commit introduces several refactorings to enhance code quality and maintainability:

- **Idiomatic Logging:** Replaced explicit `logger` argument passing with module-level `logging.getLogger(__name__)` instances across `firmware_utils.py`, `main.py`, `pixlet.py`, `routers/api.py`, `routers/manager.py`, `routers/websockets.py`, `startup.py`, `sync.py`, `system_apps.py`, and `utils.py`. This aligns with Python's standard logging practices, improving decoupling and configuration flexibility.

- **Dynamic Git Repo Info:** Modified `system_apps.get_system_repo_info()` to dynamically retrieve the Git remote URL and current branch directly from the local repository using `git` commands. This change addresses an inconsistency where the system app repository URL was stored in both the admin user's settings and the global system settings. The UI, particularly on pages like `addapp`, would always display the system setting, which could be different from the admin user's configured URL, leading to confusion. By fetching directly from Git, the displayed information is always accurate and consistent with the actual repository in use, regardless of which user is viewing the page.

- **Auth Router Duplication Reduction:** Introduced `_render_edit_template()` in `routers/auth.py` to consolidate template rendering logic for the user edit page, eliminating duplication between `get_edit()` and `post_edit()`.

- **Simplified `set_repo`:** Streamlined the `set_repo()` function in `utils.py` by removing unnecessary `db_conn`, `user`, and `repo_name` parameters, and adjusting its call sites accordingly. This makes the function more focused on its core responsibility of managing Git repositories.

These changes collectively improve the codebase's structure, readability, and adherence to best practices.