### PR TITLE
feat: Switch to 2x previews in addapp page

### DIFF
--- a/tests/test_app_create_edit_delete.py
+++ b/tests/test_app_create_edit_delete.py
@@ -87,7 +87,7 @@ def test_app_create_edit_config_delete(
     assert test_app.display_time == 69
     assert test_app.notes == "69"
 
-    auth_client.get(f"/{device_id}/{app_id}/delete")
+    auth_client.post(f"/{device_id}/{app_id}/delete")
 
     user = utils.get_testuser(db_connection)
     assert app_id not in user.devices[device_id].apps

--- a/tronbyt_server/routers/auth.py
+++ b/tronbyt_server/routers/auth.py
@@ -210,7 +210,7 @@ def post_register(
     )
 
 
-@router.get("/login", name="login")
+@router.get("/login")
 def login(
     request: Request,
     db_conn: sqlite3.Connection = Depends(get_db),
@@ -312,7 +312,7 @@ def post_edit(
         return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.get("/logout", name="logout")
+@router.get("/logout")
 def logout(request: Request) -> Response:
     """Log the user out."""
     flash(request, _("Logged Out"))
@@ -359,7 +359,7 @@ def set_theme_preference(
         )
 
 
-@router.post("/generate_api_key", name="generate_api_key")
+@router.post("/generate_api_key")
 def generate_api_key(
     request: Request,
     user: Annotated[User, Depends(manager)],

--- a/tronbyt_server/routers/manager.py
+++ b/tronbyt_server/routers/manager.py
@@ -392,7 +392,7 @@ def _next_app_logic(
     return _next_app_logic(db_conn, device_id, next_index, recursion_depth + 1)
 
 
-@router.get("/", name="index")
+@router.get("/")
 def index(
     request: Request,
     user: User = Depends(manager),
@@ -426,7 +426,7 @@ def index(
     )
 
 
-@router.get("/create", name="create")
+@router.get("/create")
 def create(request: Request, user: User = Depends(manager)) -> Response:
     """Render the device creation page."""
     return templates.TemplateResponse(request, "manager/create.html", {"user": user})
@@ -445,7 +445,7 @@ class DeviceCreateFormData(BaseModel):
     location: str | None = None
 
 
-@router.post("/create", name="create_post")
+@router.post("/create")
 def create_post(
     request: Request,
     form_data: Annotated[DeviceCreateFormData, Form()],
@@ -529,7 +529,7 @@ def create_post(
     return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.get("/{device_id}/update", name="update")
+@router.get("/{device_id}/update")
 def update(
     request: Request, device_id: DeviceID, user: User = Depends(manager)
 ) -> Response:
@@ -565,7 +565,7 @@ def update(
     )
 
 
-@router.post("/{device_id}/update_brightness", name="update_brightness")
+@router.post("/{device_id}/update_brightness")
 async def update_brightness(
     device_id: DeviceID,
     user: User = Depends(manager),
@@ -610,7 +610,7 @@ async def update_brightness(
     return Response(status_code=status.HTTP_200_OK)
 
 
-@router.post("/{device_id}/update_interval", name="update_interval")
+@router.post("/{device_id}/update_interval")
 def update_interval(
     device_id: DeviceID,
     user: User = Depends(manager),
@@ -650,7 +650,7 @@ class DeviceUpdateFormData(BaseModel):
     interstitial_app: str | None = None
 
 
-@router.post("/{device_id}/update", name="update_post")
+@router.post("/{device_id}/update")
 def update_post(
     request: Request,
     device_id: DeviceID,
@@ -751,7 +751,7 @@ def update_post(
     return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.post("/{device_id}/delete", name="delete")
+@router.post("/{device_id}/delete")
 def delete(
     device_id: DeviceID,
     user: User = Depends(manager),
@@ -767,7 +767,7 @@ def delete(
     return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.get("/{device_id}/addapp", name="addapp")
+@router.get("/{device_id}/addapp")
 def addapp(
     request: Request,
     device_id: DeviceID,
@@ -813,7 +813,7 @@ def addapp(
     )
 
 
-@router.post("/{device_id}/addapp", name="addapp_post")
+@router.post("/{device_id}/addapp")
 def addapp_post(
     request: Request,
     device_id: DeviceID,
@@ -873,7 +873,7 @@ def addapp_post(
     )
 
 
-@router.get("/{device_id}/uploadapp", name="uploadapp")
+@router.get("/{device_id}/uploadapp")
 def uploadapp(
     request: Request, device_id: DeviceID, user: User = Depends(manager)
 ) -> Response:
@@ -887,7 +887,7 @@ def uploadapp(
     )
 
 
-@router.post("/{device_id}/uploadapp", name="app_preview")
+@router.post("/{device_id}/uploadapp")
 async def uploadapp_post(
     request: Request,
     device_id: DeviceID,
@@ -950,7 +950,7 @@ async def uploadapp_post(
     )
 
 
-@router.get("/app_preview/{filename}", name="app_preview")
+@router.get("/app_preview/{filename}")
 def app_preview(filename: str) -> FileResponse:
     """Serve app preview images."""
     file_path = db.get_data_dir() / "apps" / filename
@@ -959,7 +959,7 @@ def app_preview(filename: str) -> FileResponse:
     return FileResponse(file_path)
 
 
-@router.get("/{device_id}/deleteupload/{filename}", name="deleteupload")
+@router.get("/{device_id}/deleteupload/{filename}")
 def deleteupload(
     request: Request,
     device_id: DeviceID,
@@ -990,8 +990,7 @@ def deleteupload(
     )
 
 
-@router.get("/{device_id}/{iname}/delete", name="deleteapp")
-@router.post("/{device_id}/{iname}/delete", name="deleteapp")
+@router.post("/{device_id}/{iname}/delete")
 def deleteapp(
     device_id: DeviceID,
     iname: str,
@@ -1019,7 +1018,7 @@ def deleteapp(
     return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.post("/{device_id}/{iname}/toggle_pin", name="toggle_pin")
+@router.post("/{device_id}/{iname}/toggle_pin")
 def toggle_pin(
     request: Request,
     device_id: DeviceID,
@@ -1048,7 +1047,7 @@ def toggle_pin(
     return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.post("/{device_id}/{iname}/duplicate", name="duplicate_app")
+@router.post("/{device_id}/{iname}/duplicate")
 def duplicate_app(
     request: Request,
     device_id: DeviceID,
@@ -1149,7 +1148,7 @@ def duplicate_app(
         return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.get("/{device_id}/{iname}/updateapp", name="updateapp")
+@router.get("/{device_id}/{iname}/updateapp")
 def updateapp(
     request: Request, device_id: DeviceID, iname: str, user: User = Depends(manager)
 ) -> Response:
@@ -1212,7 +1211,7 @@ class AppUpdateFormData(BaseModel):
     day_of_week_pattern: str | None = None
 
 
-@router.post("/{device_id}/{iname}/updateapp", name="updateapp_post")
+@router.post("/{device_id}/{iname}/updateapp")
 def updateapp_post(
     request: Request,
     device_id: DeviceID,
@@ -1284,11 +1283,7 @@ def updateapp_post(
     return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.api_route(
-    "/{device_id}/{iname}/toggle_enabled",
-    methods=["GET", "POST"],
-    name="toggle_enabled",
-)
+@router.post("/{device_id}/{iname}/toggle_enabled")
 def toggle_enabled(
     request: Request,
     device_id: DeviceID,
@@ -1309,7 +1304,7 @@ def toggle_enabled(
     return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.post("/{device_id}/{iname}/moveapp", name="moveapp")
+@router.post("/{device_id}/{iname}/moveapp")
 def moveapp(
     request: Request,
     device_id: DeviceID,
@@ -1373,7 +1368,7 @@ def moveapp(
     return Response("OK", status_code=status.HTTP_200_OK)
 
 
-@router.get("/{device_id}/{iname}/configapp", name="configapp")
+@router.get("/{device_id}/{iname}/configapp")
 def configapp(
     request: Request,
     device_id: DeviceID,
@@ -1407,7 +1402,7 @@ def configapp(
     )
 
 
-@router.post("/{device_id}/{iname}/configapp", name="configapp_post")
+@router.post("/{device_id}/{iname}/configapp")
 async def configapp_post(
     request: Request,
     device_id: DeviceID,
@@ -1447,7 +1442,7 @@ async def configapp_post(
     return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.get("/{device_id}/{iname}/preview", name="preview")
+@router.get("/{device_id}/{iname}/preview")
 def preview(
     request: Request,
     device_id: DeviceID,
@@ -1497,7 +1492,7 @@ def preview(
         )
 
 
-@router.get("/adminindex", name="adminindex")
+@router.get("/adminindex")
 def adminindex(
     request: Request,
     user: User = Depends(manager),
@@ -1512,7 +1507,7 @@ def adminindex(
     )
 
 
-@router.post("/admin/{username}/deleteuser", name="deleteuser")
+@router.post("/admin/{username}/deleteuser")
 def deleteuser(
     username: str,
     user: User = Depends(manager),
@@ -1526,7 +1521,7 @@ def deleteuser(
     return RedirectResponse(url="/adminindex", status_code=status.HTTP_302_FOUND)
 
 
-@router.get("/{device_id}/firmware", name="generate_firmware")
+@router.get("/{device_id}/firmware")
 def generate_firmware(
     request: Request, device_id: DeviceID, user: User = Depends(manager)
 ) -> Response:
@@ -1542,7 +1537,7 @@ def generate_firmware(
     )
 
 
-@router.post("/{device_id}/firmware", name="generate_firmware_post")
+@router.post("/{device_id}/firmware")
 def generate_firmware_post(
     device_id: DeviceID,
     user: User = Depends(manager),
@@ -1579,7 +1574,7 @@ def generate_firmware_post(
     )
 
 
-@router.post("/set_user_repo", name="set_user_repo")
+@router.post("/set_user_repo")
 def set_user_repo(
     request: Request,
     user: User = Depends(manager),
@@ -1605,7 +1600,7 @@ def set_user_repo(
     return RedirectResponse(url="/auth/edit", status_code=status.HTTP_302_FOUND)
 
 
-@router.post("/set_api_key", name="set_api_key")
+@router.post("/set_api_key")
 def set_api_key(
     request: Request,
     user: User = Depends(manager),
@@ -1621,7 +1616,7 @@ def set_api_key(
     return RedirectResponse(url="/", status_code=status.HTTP_302_FOUND)
 
 
-@router.post("/set_system_repo", name="set_system_repo")
+@router.post("/set_system_repo")
 def set_system_repo(
     request: Request,
     user: User = Depends(manager),
@@ -1648,7 +1643,7 @@ def set_system_repo(
     return RedirectResponse(url="/auth/edit", status_code=status.HTTP_302_FOUND)
 
 
-@router.post("/refresh_system_repo", name="refresh_system_repo")
+@router.post("/refresh_system_repo")
 def refresh_system_repo(
     request: Request,
     user: User = Depends(manager),
@@ -1662,7 +1657,7 @@ def refresh_system_repo(
     return RedirectResponse(url="/auth/edit", status_code=status.HTTP_302_FOUND)
 
 
-@router.post("/mark_app_broken/{app_name}", name="mark_app_broken")
+@router.post("/mark_app_broken/{app_name}")
 def mark_app_broken(
     app_name: str,
     user: User = Depends(manager),
@@ -1731,7 +1726,7 @@ def mark_app_broken(
         )
 
 
-@router.post("/unmark_app_broken/{app_name}", name="unmark_app_broken")
+@router.post("/unmark_app_broken/{app_name}")
 def unmark_app_broken(
     app_name: str,
     user: User = Depends(manager),
@@ -1805,7 +1800,7 @@ def unmark_app_broken(
         )
 
 
-@router.post("/update_firmware", name="update_firmware")
+@router.post("/update_firmware")
 def update_firmware(request: Request, user: User = Depends(manager)) -> Response:
     """Update firmware binaries (admin only)."""
     if user.username != "admin":
@@ -1828,7 +1823,7 @@ def update_firmware(request: Request, user: User = Depends(manager)) -> Response
     )
 
 
-@router.post("/refresh_user_repo", name="refresh_user_repo")
+@router.post("/refresh_user_repo")
 def refresh_user_repo(
     request: Request,
     user: User = Depends(manager),
@@ -1840,7 +1835,7 @@ def refresh_user_repo(
     return RedirectResponse(url="/auth/edit", status_code=status.HTTP_302_FOUND)
 
 
-@router.get("/export_user_config", name="export_user_config")
+@router.get("/export_user_config")
 def export_user_config(user: User = Depends(manager)) -> Response:
     """Export user configuration as a JSON file."""
     user_dict = user.model_dump(mode="json")
@@ -1855,7 +1850,7 @@ def export_user_config(user: User = Depends(manager)) -> Response:
     )
 
 
-@router.get("/{device_id}/export_config", name="export_device_config")
+@router.get("/{device_id}/export_config")
 def export_device_config(
     device_id: DeviceID, user: User = Depends(manager)
 ) -> Response:
@@ -1880,7 +1875,7 @@ def export_device_config(
     )
 
 
-@router.get("/{device_id}/import_config", name="import_device_config")
+@router.get("/{device_id}/import_config")
 def import_device_config(
     request: Request, device_id: DeviceID, user: User = Depends(manager)
 ) -> Response:
@@ -1954,7 +1949,7 @@ async def import_device_config_post(
         )
 
 
-@router.post("/import_user_config", name="import_user_config")
+@router.post("/import_user_config")
 async def import_user_config(
     request: Request,
     user: User = Depends(manager),

--- a/tronbyt_server/templates/manager/addapp.html
+++ b/tronbyt_server/templates/manager/addapp.html
@@ -512,8 +512,8 @@
         <!-- Skeleton loader for images -->
         <div class="app-img">
           <div class="skeleton-loader"></div>
-          {% if 'preview' in app %}
-          <img data-src="{{ url_for('app_preview', filename=app['preview']) }}"
+          {% if app.get('preview') or app.get('preview2x') %}
+          <img data-src="{{ url_for('app_preview', filename=app.get('preview2x') or app.get('preview')) }}"
                alt="{{ app['name'] }}"
                class="lazy-image"
                {% if app.get('broken') %}style="opacity: 0.4;"{% endif %}>

--- a/tronbyt_server/templates/manager/configapp.html
+++ b/tronbyt_server/templates/manager/configapp.html
@@ -723,7 +723,7 @@
       {% if delete_on_cancel == 1 %}
       // Delete the app via fetch, then close the tab
       fetch("{{ url_for('deleteapp', device_id=device.id, iname=app.iname) }}", {
-        method: 'GET'
+        method: 'POST'
       }).then(() => {
         window.close();
       }).catch(() => {
@@ -852,7 +852,7 @@
       cancelButtonTop.addEventListener("click", function() {
         {% if delete_on_cancel == 1 %}
         fetch("{{ url_for('deleteapp', device_id=device.id, iname=app.iname) }}", {
-          method: 'GET'
+          method: 'POST'
         }).then(() => {
           window.close();
         }).catch(() => {


### PR DESCRIPTION
Introduces support for 2x preview images on the addapp page, prioritizing the higher-resolution `preview2x` image when available.

Also: remove the `name` parameter from @router decorators when it is identical to the function name (in which case it's redundant).

Fixes #412