### PR TITLE
dockerfile: run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN mkdir -p /app/data /app/users && \
     chown -R tronbyt:tronbyt /app/data /app/users && \
     chmod -R 755 /app/data /app/users
 
-# Set the user to non-root (disabled for a while to support legacy setups which ran as root)
-#USER tronbyt
+# Set the user to non-root
+USER tronbyt
 
 # start the app
 ENTRYPOINT ["python3", "run.py"]

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -4,6 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     init: true
+    user: "${UID:-1000}:${GID:-${UID:-1000}}" # Use host user and group IDs for file permissions
     ports:
       - "${SERVER_PORT}:8000" # Map server port on the host to port 8000 in the container
     volumes:


### PR DESCRIPTION
Docker Compose installations have been running as non-root since #204. The non-root user was not changed in the Dockerfile for backward compatibility.  There were many releases since then, so it's time to update the Dockerfile as well.