### PR TITLE
feat(server): Improve multi-worker startup and resource management

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,4 +6,9 @@ services:
   image:
     url: ghcr.io/tronbyt/server:1.5.1
   plan: free
+  envVars:
+  - key: PRODUCTION
+    value: "1"
+  - key: WEB_CONCURRENCY
+    value: "1"
 version: "1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 import shutil
 
+from tronbyt_server import db
 from tronbyt_server.main import app as fastapi_app
 from tronbyt_server.dependencies import get_db
 from tronbyt_server.config import get_settings
@@ -28,6 +29,8 @@ def db_connection(
     settings.ENABLE_USER_REGISTRATION = "1"
 
     with sqlite3.connect(settings.DB_FILE, check_same_thread=False) as conn:
+        # Initialize the database schema immediately after connection.
+        db.init_db(conn)
         yield conn
 
 
@@ -59,12 +62,9 @@ def db_cleanup(db_connection: sqlite3.Connection) -> Iterator[None]:
 def settings_cleanup() -> Iterator[None]:
     original_enable_user_registration = settings.ENABLE_USER_REGISTRATION
     original_max_users = settings.MAX_USERS
-    original_disable_sync_manager_shutdown = settings.DISABLE_SYNC_MANAGER_SHUTDOWN
-    settings.DISABLE_SYNC_MANAGER_SHUTDOWN = True
     yield
     settings.ENABLE_USER_REGISTRATION = original_enable_user_registration
     settings.MAX_USERS = original_max_users
-    settings.DISABLE_SYNC_MANAGER_SHUTDOWN = original_disable_sync_manager_shutdown
 
 
 @pytest.fixture()

--- a/tronbyt_server/config.py
+++ b/tronbyt_server/config.py
@@ -25,11 +25,6 @@ class Settings(BaseSettings):
     SYSTEM_APPS_REPO: str = "https://github.com/tronbyt/apps.git"
     LIBPIXLET_PATH: str | None = None
     REDIS_URL: str | None = None
-    # This setting is only used for testing purposes.
-    # It prevents the multiprocessing.Manager from being shut down prematurely
-    # during the FastAPI TestClient's lifespan shutdown, which can lead to
-    # FileNotFoundError and AttributeError in subsequent tests due to shared state.
-    DISABLE_SYNC_MANAGER_SHUTDOWN: bool = False
 
 
 @lru_cache

--- a/tronbyt_server/main.py
+++ b/tronbyt_server/main.py
@@ -1,9 +1,7 @@
 """Main application file."""
 
-from contextlib import asynccontextmanager
 from pathlib import Path
 
-from typing import AsyncGenerator
 
 from fastapi import FastAPI, Request
 from fastapi.responses import Response
@@ -11,37 +9,18 @@ from fastapi.staticfiles import StaticFiles
 from fastapi_babel import Babel, BabelConfigs, BabelMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
-from tronbyt_server import db
 from tronbyt_server.config import get_settings
 from tronbyt_server.dependencies import (
     NotAuthenticatedException,
     auth_exception_handler,
-    get_db,
 )
 from tronbyt_server.routers import api, auth, manager, websockets
-from tronbyt_server.sync import get_sync_manager
 from tronbyt_server.templates import templates
 
 MODULE_ROOT = Path(__file__).parent.resolve()
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    """Run startup and shutdown events."""
-    # Startup
-    settings = get_settings()
-
-    db_connection = next(get_db(settings=settings))
-    with db_connection:
-        db.init_db(db_connection)
-
-    yield
-    # Shutdown
-    if not settings.DISABLE_SYNC_MANAGER_SHUTDOWN:
-        get_sync_manager().shutdown()
-
-
-app = FastAPI(lifespan=lifespan)
+app = FastAPI()
 
 
 app.add_middleware(SessionMiddleware, secret_key=get_settings().SECRET_KEY)

--- a/tronbyt_server/startup.py
+++ b/tronbyt_server/startup.py
@@ -53,6 +53,7 @@ def run_once() -> None:
     settings = get_settings()
     logger = logging.getLogger(__name__)
     logger.info("Running one-time startup tasks...")
+
     try:
         firmware_utils.update_firmware_binaries(db.get_data_dir())
     except Exception as e:
@@ -66,10 +67,12 @@ def run_once() -> None:
     else:
         logger.info("Skipping system apps update and database backup (dev mode)")
 
+    # Initialize, migrate, and vacuum database
     try:
         with sqlite3.connect(settings.DB_FILE) as conn:
+            db.init_db(conn)
             db.vacuum(conn)
     except Exception as e:
-        logger.warning(f"Could not vacuum database: {e}")
+        logger.error(f"Could not initialize or vacuum database: {e}", exc_info=True)
 
     logger.info("One-time startup tasks complete.")

--- a/tronbyt_server/sync.py
+++ b/tronbyt_server/sync.py
@@ -50,6 +50,16 @@ class SyncManager(ABC):
         """Shut down the sync manager."""
         raise NotImplementedError
 
+    @abstractmethod
+    def __enter__(self) -> "SyncManager":
+        """Enter the context manager."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Exit the context manager."""
+        raise NotImplementedError
+
 
 class MultiprocessingWaiter(Waiter):
     """A waiter that uses multiprocessing primitives."""
@@ -131,6 +141,12 @@ class MultiprocessingSyncManager(SyncManager):
                     condition.notify_all()
         self._manager.shutdown()
 
+    def __enter__(self) -> "MultiprocessingSyncManager":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.shutdown()
+
 
 class RedisWaiter(Waiter):
     """A waiter that uses Redis Pub/Sub."""
@@ -184,6 +200,12 @@ class RedisSyncManager(SyncManager):
     def shutdown(self) -> None:
         """Shut down the sync manager."""
         self._redis.close()
+
+    def __enter__(self) -> "RedisSyncManager":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.shutdown()
 
 
 _sync_manager: SyncManager | None = None


### PR DESCRIPTION
Refactors the application startup and shutdown process to prevent race conditions and ensure stability when running with multiple Uvicorn workers.

Key changes:
- Centralizes database initialization (including migration and vacuuming) to a `run_once()` function, ensuring it only executes in the main parent process before workers are forked.
- Manages the `SyncManager` lifecycle with a context manager (`with` block) in `run.py`. This guarantees the manager process is created by the parent and is the only one to call `shutdown()`, preventing workers from terminating the shared manager.
- Removes the now-redundant `lifespan` manager from the FastAPI app.
- Updates test fixtures to explicitly initialize the database, as it is no longer handled automatically by the app's lifespan.
- Sets `PRODUCTION=1` and `WEB_CONCURRENCY=1` in `render.yaml` to provide sensible defaults for the free tier.
- Removes the unused `DISABLE_SYNC_MANAGER_SHUTDOWN` setting.