### PR TITLE
ci(release): automate Homebrew releases

### DIFF
--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -1,0 +1,20 @@
+name: Bump Homebrew formula on release
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  bump-homebrew-formula:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+      - name: Bump formula
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_BUMP_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          brew tap tronbyt/homebrew-tronbyt
+          brew bump-formula-pr tronbyt-server --strict --version=${VERSION#v} --no-browse --no-fork


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the process of updating the Homebrew formula for `tronbyt-server` upon a new release.

The new workflow, triggered by the `release` event, automatically runs `brew bump-formula-pr`. This command creates a pull request in the `tronbyt/homebrew-tronbyt` repository to update the formula to the newly released version. The workflow also includes a flag to prevent opening a browser during the process.

This automation removes the need for manual intervention, streamlining the release process.

Fixes #406