### PR TITLE
feat: Enhance Docker images for Unraid compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
+    gosu \
     libsharpyuv0 \
     libwebp7 \
     libwebpdemux2 \
@@ -49,11 +50,11 @@ ENV PATH="/app/.venv/bin:$PATH"
 # owned by the non-root user (newly created named volumes are owned by root,
 # if their target doesn't exist).
 RUN mkdir -p /app/data /app/users && \
-    chown -R tronbyt:tronbyt /app/data /app/users && \
     chmod -R 755 /app/data /app/users
 
-# Set the user to non-root
-USER tronbyt
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 # start the app
-ENTRYPOINT ["python3", "run.py"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["python3", "run.py"]

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -4,7 +4,6 @@ services:
       context: .
       dockerfile: Dockerfile
     init: true
-    user: "${UID:-1000}:${GID:-${UID:-1000}}" # Use host user and group IDs for file permissions
     ports:
       - "${SERVER_PORT}:8000" # Map server port on the host to port 8000 in the container
     volumes:
@@ -13,6 +12,8 @@ services:
       - ./data:/app/data # for development
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
     environment:
+      - PUID=${UID:-1000}
+      - PGID=${GID:-${UID:-1000}}
       - PYTHONUNBUFFERED=1
       - SYSTEM_APPS_REPO
       - PRODUCTION

--- a/docker-compose.https.yaml
+++ b/docker-compose.https.yaml
@@ -2,13 +2,14 @@ services:
   web:
     image: ghcr.io/tronbyt/server:latest
     restart: unless-stopped
-    user: "tronbyt:tronbyt"
     init: true
     volumes:
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users
       - data:/app/data
     environment:
+      - PUID=${UID:-1000}
+      - PGID=${GID:-${UID:-1000}}
       - SYSTEM_APPS_REPO
       - PRODUCTION
       - ENABLE_USER_REGISTRATION

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -4,13 +4,14 @@ services:
     restart: unless-stopped
     ports:
       - "${SERVER_PORT}:8000" # Map server port on the host to port 8000 in the container
-    user: "tronbyt:tronbyt"
     init: true
     volumes:
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users
       - data:/app/data
     environment:
+      - PUID=${UID:-1000}
+      - PGID=${GID:-${UID:-1000}}
       - SYSTEM_APPS_REPO
       - PRODUCTION
       - REDIS_URL=redis://redis:6379

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,13 +4,14 @@ services:
     restart: unless-stopped
     ports:
       - "${SERVER_PORT}:8000" # Map server port on the host to port 8000 in the container
-    user: "tronbyt:tronbyt"
     init: true
     volumes:
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users
       - data:/app/data
     environment:
+      - PUID=${UID:-1000}
+      - PGID=${GID:-${UID:-1000}}
       - SYSTEM_APPS_REPO
       - PRODUCTION
       - ENABLE_USER_REGISTRATION

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+if [ "$(id -u)" = '0' ]; then
+    # Set user and group id, default to 1000
+    PUID=${PUID:-1000}
+    PGID=${PGID:-1000}
+
+    CURRENT_UID=$(id -u tronbyt)
+    CURRENT_GID=$(id -g tronbyt)
+
+    if [ "$CURRENT_GID" -ne "$PGID" ]; then
+        groupmod -o -g "$PGID" tronbyt
+    fi
+
+    if [ "$CURRENT_UID" -ne "$PUID" ]; then
+        usermod -o -u "$PUID" tronbyt
+    fi
+
+    # Take ownership of directories if needed
+    if [ "$(stat -c %u /app/data)" != "$PUID" ] || [ "$(stat -c %g /app/data)" != "$PGID" ]; then
+        chown -R tronbyt:tronbyt /app/data /app/users
+    fi
+
+    # Execute the command as tronbyt user
+    exec gosu tronbyt "$@"
+else
+    # If not running as root, just execute the command
+    exec "$@"
+fi


### PR DESCRIPTION
This commit introduces several changes to improve the compatibility of Tronbyt Server Docker images with Unraid and other environments that utilize PUID/PGID for user/group mapping.

Key changes include:
- **Unraid Compatibility:** Implemented a `docker-entrypoint.sh` script to dynamically set user (PUID) and group (PGID) IDs at runtime, ensuring proper file permissions within the container.
- **Dockerfile Updates:**
    - Integrated `gosu` for secure privilege management within the entrypoint.
- **Docker Compose Configuration:** Updated `docker-compose.dev.yaml`, `docker-compose.https.yaml`, `docker-compose.redis.yaml`, and `docker-compose.yaml` to pass `PUID` and `PGID` environment variables instead of hardcoding the `user` directive.
- **Robust Entrypoint Script:** The `docker-entrypoint.sh` script now conditionally applies user/group modifications and ownership changes only when running as root, and gracefully executes the command as the current user if a specific user is defined in the compose file.

These changes provide greater flexibility and robustness for deploying Tronbyt Server in various Docker environments, particularly those requiring dynamic user/group management.

Fixes #445