### PR TITLE
feat: Enable WAL mode and increase SQLite timeout for improved concurrency

### DIFF
--- a/tronbyt_server/db.py
+++ b/tronbyt_server/db.py
@@ -28,11 +28,18 @@ logger = logging.getLogger(__name__)
 
 def get_db() -> sqlite3.Connection:
     """Get a database connection."""
-    return sqlite3.connect(get_settings().DB_FILE, check_same_thread=False)
+    return sqlite3.connect(
+        get_settings().DB_FILE, check_same_thread=False, timeout=10
+    )  # Set a 10-second timeout
 
 
 def init_db(db: sqlite3.Connection) -> None:
     """Initialize the database."""
+    # Enable WAL mode for better concurrency
+    row = db.execute("PRAGMA journal_mode=WAL").fetchone()
+    if not row or row[0].lower() != "wal":
+        logger.warning("Failed to enable WAL mode. Concurrency might be limited.")
+
     cursor = db.cursor()
     cursor.execute(
         """


### PR DESCRIPTION
This commit addresses potential "database is locked" errors by enhancing SQLite database handling.

- Increased the SQLite connection timeout to 10 seconds in  to reduce contention during concurrent access.
- Enabled Write-Ahead Logging (WAL) mode for the SQLite database. WAL mode improves concurrency by allowing readers and writers to operate simultaneously, and offers better crash recovery.