### PR TITLE
Refactor(manager, websockets): Optimize app rotation logic

### DIFF
--- a/tronbyt_server/db.py
+++ b/tronbyt_server/db.py
@@ -304,26 +304,6 @@ def delete_device_dirs(device_id: str) -> None:
         logger.error(f"Error deleting directory {dir_to_delete}: {str(e)}")
 
 
-def get_last_app_index(db: sqlite3.Connection, device_id: str) -> int | None:
-    """Get the last app index for a device."""
-    device = get_device_by_id(db, device_id)
-    if device is None:
-        return None
-    return device.last_app_index
-
-
-def save_last_app_index(db: sqlite3.Connection, device_id: str, index: int) -> None:
-    """Save the last app index for a device."""
-    user = get_user_by_device_id(db, device_id)
-    if user is None:
-        return
-    device = user.devices.get(device_id)
-    if device is None:
-        return
-    device.last_app_index = index
-    save_user(db, user)
-
-
 def get_device_timezone(device: Device) -> ZoneInfo:
     """Get timezone for a device."""
     if device.location and device.location.timezone:


### PR DESCRIPTION
The `next_app_logic` function fetched the User and Device from the database on every call. Because the function calls itself recursively to find the next valid app to display, this resulted in numerous redundant database queries.

This commit refactors `next_app_logic` and its helper `_get_app_to_display` to accept the User and Device objects as parameters. The primary callers (`/next` endpoint and the websocket `sender` task) now fetch these objects once and pass them down through the call chain.

This change significantly reduces database load during app rotation, improving performance.