### PR TITLE
refactor(db): Use atomic updates for app rendering messages to prevent race conditions

### DIFF
--- a/tronbyt_server/routers/api.py
+++ b/tronbyt_server/routers/api.py
@@ -499,7 +499,7 @@ def handle_app_push(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid app data"
         )
-    image_bytes = render_app(db_conn, app_path, data.config, None, device, app)
+    image_bytes = render_app(db_conn, app_path, data.config, None, device, app, user)
     if image_bytes is None:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/tronbyt_server/routers/manager.py
+++ b/tronbyt_server/routers/manager.py
@@ -977,6 +977,7 @@ async def uploadapp_post(
             default_interval=15,
         ),
         None,
+        user,
     )
 
     return RedirectResponse(
@@ -1447,6 +1448,7 @@ async def configapp_post(
         webp_path,
         device,
         app,
+        user,
     )
     if image is not None:
         app.enabled = True
@@ -1461,6 +1463,7 @@ async def configapp_post(
 @router.get("/{device_id}/{iname}/preview")
 def preview(
     device_and_app: DeviceAndApp = Depends(get_device_and_app),
+    user: User = Depends(manager),
     db_conn: sqlite3.Connection = Depends(get_db),
     config: str = "{}",
 ) -> Response:
@@ -1493,6 +1496,7 @@ def preview(
             webp_path=None,
             device=device,
             app=app,
+            user=user,
         )
         if data is None:
             raise HTTPException(

--- a/tronbyt_server/utils.py
+++ b/tronbyt_server/utils.py
@@ -46,6 +46,7 @@ def render_app(
     webp_path: Path | None,
     device: Device,
     app: App | None,
+    user: User,
 ) -> bytes | None:
     """Renders a pixlet app to a webp image."""
     config_data = config.copy()
@@ -78,7 +79,7 @@ def render_app(
         logger.error("Error running pixlet render")
         return None
     if messages and app is not None:
-        db.save_render_messages(db_conn, device, app, messages)
+        db.save_render_messages(db_conn, user, device, app, messages)
 
     if len(data) > 0 and webp_path:
         webp_path.write_bytes(data)
@@ -162,7 +163,7 @@ def possibly_render(
         device = user.devices[device_id]
         config = app.config.copy()
         add_default_config(config, device)
-        image = render_app(db_conn, app_path, config, webp_path, device, app)
+        image = render_app(db_conn, app_path, config, webp_path, device, app, user)
         if image is None:
             logger.error(f"Error rendering {app_basename}")
         app.empty_last_render = len(image) == 0 if image is not None else False


### PR DESCRIPTION
The `save_render_messages` function previously relied on `db.save_user` to persist changes after an app was rendered. This approach was not atomic and could lead to race conditions, where concurrent modifications to the user object or other devices were overwritten.

This commit refactors the rendering logic to use granular, atomic database updates.
    
- `save_render_messages` is similarly updated to atomically save only the `render_messages` for an app.
- The `user` object is now passed through the `render_app` call chain to provide the necessary context for these atomic updates, resulting in signature changes in routers.