### PR TITLE
feat: Add app preview button and refactor image push logic (#480)

### DIFF
--- a/tronbyt_server/static/js/manager.js
+++ b/tronbyt_server/static/js/manager.js
@@ -316,6 +316,29 @@ function deleteApp(deviceId, iname) {
     });
 }
 
+// AJAX function to preview an app
+function previewApp(deviceId, iname) {
+  fetch(`/${deviceId}/${iname}/preview`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    }
+  })
+    .then(response => {
+      if (!response.ok) {
+        console.error('Failed to preview app');
+        alert('Failed to preview app. Please try again.');
+      } else {
+        console.log('App previewed successfully');
+        // Optionally, provide some feedback to the user
+      }
+    })
+    .catch((error) => {
+      console.error('Unexpected error:', error);
+      alert('An error occurred while previewing the app. Please try again.');
+    });
+}
+
 // Cookie utility functions
 function setCookie(name, value, days = 365) {
   const expires = new Date();

--- a/tronbyt_server/templates/partials/app_card.html
+++ b/tronbyt_server/templates/partials/app_card.html
@@ -55,6 +55,8 @@
              href="{{ url_for('updateapp', device_id=device.id, iname=app.iname) }}"><i class="fa-solid fa-pen-to-square" aria-hidden="true"></i> {{ _('Edit') }}</a>
           <a class="action w3-button w3-blue w3-round"
              href="{{ url_for('configapp', device_id=device.id, iname=app.iname) }}?delete_on_cancel=False"><i class="fa-solid fa-sliders" aria-hidden="true"></i> {{ _('Configure') }}</a>
+          <button class="action w3-button w3-blue w3-round"
+                  onclick="previewApp('{{ device.id }}', '{{ app.iname }}')"><i class="fa-solid fa-play" aria-hidden="true"></i> {{ _('Preview') }}</button>
           <button class="action w3-button w3-green w3-round"
                   onclick="duplicateApp('{{ device.id }}', '{{ app.iname }}')"><i class="fa-solid fa-copy" aria-hidden="true"></i> {{ _('Duplicate') }}</button>
           <button class="action w3-button w3-red w3-round"


### PR DESCRIPTION
Introduces a "Preview" button on app cards, allowing users to push a temporary render of an app to their device for immediate display.

The `_push_image` utility function has been moved from `tronbyt_server/routers/api.py` to `tronbyt_server/utils.py` and renamed to `push_image` to centralize image pushing logic. The new `push_preview` endpoint in `tronbyt_server/routers/manager.py` now utilizes this shared `push_image` function to handle temporary app previews.