### PR TITLE
Support optional GitHub Token env var for firmware downloads

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -22,3 +22,4 @@ services:
       - UVICORN_ACCESS_LOG=${UVICORN_ACCESS_LOG:-false}
       - WEB_CONCURRENCY
       - TRONBYT_HOST=0.0.0.0
+      - GITHUB_TOKEN

--- a/docker-compose.https.yaml
+++ b/docker-compose.https.yaml
@@ -15,6 +15,7 @@ services:
       - ENABLE_USER_REGISTRATION
       - WEB_CONCURRENCY
       - TRONBYT_HOST=0.0.0.0
+      - GITHUB_TOKEN
 
     healthcheck:
       test: ["CMD", "python3", "-m", "tronbyt_server.healthcheck", "http://localhost:8000/health"]

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -19,6 +19,7 @@ services:
       - WEB_CONCURRENCY
       - TRONBYT_HOST=0.0.0.0
       - SINGLE_USER_AUTO_LOGIN
+      - GITHUB_TOKEN
 
     healthcheck:
       test: ["CMD", "python3", "-m", "tronbyt_server.healthcheck", "http://localhost:8000/health"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - WEB_CONCURRENCY
       - TRONBYT_HOST=0.0.0.0
       - SINGLE_USER_AUTO_LOGIN
+      - GITHUB_TOKEN
 
     healthcheck:
       test: ["CMD", "python3", "-m", "tronbyt_server.healthcheck", "http://localhost:8000/health"]

--- a/tronbyt_server/config.py
+++ b/tronbyt_server/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     SYSTEM_APPS_REPO: str = "https://github.com/tronbyt/apps.git"
     LIBPIXLET_PATH: str | None = None
     REDIS_URL: str | None = None
+    GITHUB_TOKEN: str | None = None  # Optional GitHub API token for higher rate limits
     SINGLE_USER_AUTO_LOGIN: str = (
         "0"  # Auto-login when exactly 1 user exists (private networks only)
     )

--- a/tronbyt_server/firmware_utils.py
+++ b/tronbyt_server/firmware_utils.py
@@ -11,6 +11,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from tronbyt_server import db
+from tronbyt_server.config import get_settings
 from tronbyt_server.firmware import correct_firmware_esptool
 
 
@@ -138,7 +139,8 @@ def update_firmware_binaries(base_path: Path) -> dict[str, Any]:
     api_url = f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
 
     # Optional GitHub API token
-    github_token = os.environ.get("GITHUB_TOKEN")
+    settings = get_settings()
+    github_token = settings.GITHUB_TOKEN
 
     try:
         logger.info(f"Fetching latest release info from {api_url}")


### PR DESCRIPTION
I have been trying to deploy the Tronbyt server to Render using Blueprints, but during the deploy, the requests to the GitHub API to fetch release info from the firmware repo have been failing with a 403 error and a message that the rate limit has been hit. This PR adds an optional environment variable for a GitHub token, and uses that token if provided when making these GitHub API calls.