### PR TITLE
Firmware download soft fail

### DIFF
--- a/tronbyt_server/db.py
+++ b/tronbyt_server/db.py
@@ -1080,6 +1080,33 @@ def get_firmware_version() -> str | None:
     return None
 
 
+def check_firmware_bins_available() -> bool:
+    """Check if any firmware bin files are available in the data directory.
+
+    Returns:
+        True if at least one firmware bin file exists, False otherwise.
+    """
+    firmware_dir = get_data_dir() / "firmware"
+    if not firmware_dir.exists():
+        return False
+
+    # Check for any of the expected firmware files
+    # NOTE: This list must be kept in sync with `firmware_name_mapping`
+    # in `tronbyt_server/firmware_utils.py`.
+    firmware_files = [
+        "tidbyt-gen1.bin",
+        "tidbyt-gen1_swap.bin",
+        "tidbyt-gen2.bin",
+        "pixoticker.bin",
+        "tronbyt-S3.bin",
+        "tronbyt-s3-wide.bin",
+        "matrixportal-s3.bin",
+        "matrixportal-s3-waveshare.bin",
+    ]
+
+    return any((firmware_dir / filename).exists() for filename in firmware_files)
+
+
 def get_user_by_api_key(db: sqlite3.Connection, api_key: str) -> User | None:
     """Get a user by API key."""
     for user in get_all_users(db):


### PR DESCRIPTION
don't fail if firmware can't be downloaded for some reason.  Allow the user to login and play around and re-try the download at a later time.