### PR TITLE
chore(deps): update pixlet to v0.48.0

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -3,7 +3,7 @@
 pipx install pdm
 pdm sync -d
 
-PIXLET_VERSION=v0.47.3
+PIXLET_VERSION=v0.48.0
 curl -LO "https://github.com/tronbyt/pixlet/releases/download/${PIXLET_VERSION}/pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
 sudo tar -C /usr/local/bin -xvf "pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
 sudo mv /usr/local/bin/libpixlet.so /usr/lib/libpixlet.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           sudo mv /usr/local/bin/libpixlet.so /usr/lib/libpixlet.so
           rm "pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
         env:
-          PIXLET_VERSION: v0.47.3
+          PIXLET_VERSION: v0.48.0
       - name: Test with pytest
         run: pdm run -v pytest tests --doctest-modules --junitxml=junit/test-results.xml
       - name: Type check with mypy

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pdm install --check --prod --no-editable && pdm build --no-sdist --no-wheel
 
 # Ignore hadolint findings about version pinning
 # hadolint global ignore=DL3007,DL3008,DL3013
-FROM ghcr.io/tronbyt/pixlet:0.47.3 AS pixlet
+FROM ghcr.io/tronbyt/pixlet:0.48.0 AS pixlet
 
 # build runtime image
 FROM debian:trixie-slim AS runtime


### PR DESCRIPTION
Updates Pixlet to [v0.48.0](https://github.com/tronbyt/pixlet/releases/tag/v0.48.0).

Drastically improves rendering times by decreasing the WebP compression level from 9 to 6, adds bidirectional text support, default 2x font is now `terminus-16`, and adds a yaml module.

<details>
  <summary>Full changelog</summary>

## What's Changed
* chore(deps-dev): bump js-yaml from 4.1.0 to 4.1.1 in /frontend by @dependabot[bot] in https://github.com/tronbyt/pixlet/pull/256
* fix: fix `pixlet profile` (and transitively `pixlet check`) by @IngmarStein in https://github.com/tronbyt/pixlet/pull/257
* fix(runtime): enforce app filesystem sandbox by @gabe565 in https://github.com/tronbyt/pixlet/pull/261
* chore(fonts): remove gz files before gzipping fonts by @gabe565 in https://github.com/tronbyt/pixlet/pull/260
* feat(runtime): add env to override HTTP response limit by @gabe565 in https://github.com/tronbyt/pixlet/pull/263
* feat(runtime): add module `encoding/yaml.star` by @gabe565 in https://github.com/tronbyt/pixlet/pull/265
* feat(render): add support for bidirectional text by @gabe565 in https://github.com/tronbyt/pixlet/pull/266
* feat(webp): add env to override webp compression level by @gabe565 in https://github.com/tronbyt/pixlet/pull/268
* feat: decrease webp compression level, add flag to override by @gabe565 in https://github.com/tronbyt/pixlet/pull/269
* feat(render): change default 2x font to `terminus-16` by @gabe565 in https://github.com/tronbyt/pixlet/pull/267


**Full Changelog**: https://github.com/tronbyt/pixlet/compare/v0.47.3...v0.48.0
</details>