### PR TITLE
chore(deps): update pixlet to v0.48.1

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -3,7 +3,7 @@
 pipx install pdm
 pdm sync -d
 
-PIXLET_VERSION=v0.48.0
+PIXLET_VERSION=v0.48.1
 curl -LO "https://github.com/tronbyt/pixlet/releases/download/${PIXLET_VERSION}/pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
 sudo tar -C /usr/local/bin -xvf "pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
 sudo mv /usr/local/bin/libpixlet.so /usr/lib/libpixlet.so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           sudo mv /usr/local/bin/libpixlet.so /usr/lib/libpixlet.so
           rm "pixlet_${PIXLET_VERSION}_linux_amd64.tar.gz"
         env:
-          PIXLET_VERSION: v0.48.0
+          PIXLET_VERSION: v0.48.1
       - name: Test with pytest
         run: pdm run -v pytest tests --doctest-modules --junitxml=junit/test-results.xml
       - name: Type check with mypy

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pdm install --check --prod --no-editable && pdm build --no-sdist --no-wheel
 
 # Ignore hadolint findings about version pinning
 # hadolint global ignore=DL3007,DL3008,DL3013
-FROM ghcr.io/tronbyt/pixlet:0.48.0 AS pixlet
+FROM ghcr.io/tronbyt/pixlet:0.48.1 AS pixlet
 
 # build runtime image
 FROM debian:trixie-slim AS runtime


### PR DESCRIPTION
Pixlet v0.48.0 had a bug with 2x displays and changing the default font. Fixed in [v0.48.1](https://github.com/tronbyt/pixlet/releases/tag/v0.48.1).