### PR TITLE
refactor: replace hardcoded URL paths with named route references

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,9 +4,10 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from . import utils
 from tronbyt_server import db
 from tronbyt_server.models.app import App
+
+from . import utils
 
 
 def test_api(auth_client: TestClient, db_connection: sqlite3.Connection) -> None:
@@ -23,7 +24,7 @@ def test_api(auth_client: TestClient, db_connection: sqlite3.Connection) -> None
         follow_redirects=False,
     )
     assert response.status_code == 302
-    assert response.headers["location"] == "/"
+    assert response.headers["location"] == "http://testserver/"
 
     # Get user to find device_id
     user = db.get_user(db_connection, "testuser")
@@ -91,7 +92,7 @@ class TestMoveApp:
             follow_redirects=False,
         )
         assert response.status_code == 302
-        assert response.headers["location"] == "/"
+        assert response.headers["location"] == "http://testserver/"
 
         user = db.get_user(db_connection, "testuser")
         assert user

--- a/tests/test_register+login.py
+++ b/tests/test_register+login.py
@@ -22,7 +22,7 @@ def test_register_login_logout(auth_client: TestClient) -> None:
         follow_redirects=False,
     )
     assert response.status_code == 302
-    assert response.headers["location"] == "/"
+    assert response.headers["location"] == "http://testserver/"
 
     response = auth_client.get("/auth/logout", follow_redirects=False)
     assert response.status_code == 302

--- a/tests/test_webp_upload.py
+++ b/tests/test_webp_upload.py
@@ -1,5 +1,5 @@
-from io import BytesIO
 import shutil
+from io import BytesIO
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -52,7 +52,7 @@ def test_webp_upload_and_app_creation(auth_client: TestClient) -> None:
         follow_redirects=False,
     )
     assert response.status_code == 302
-    assert response.headers["location"] == "/"
+    assert response.headers["location"] == "http://testserver/"
 
     # 4. Check that the app is added and file is copied
     with db.get_db() as db_conn:


### PR DESCRIPTION
Replace hardcoded URL strings (e.g., "/", "/auth/edit") with request.url_for() calls using named routes throughout auth.py and manager.py routers. This improves maintainability by centralizing route definitions and eliminates potential bugs from manually updating URLs across multiple files.