### PR TITLE
fix: Display default image for missing app webp

### DIFF
--- a/tronbyt_server/routers/manager.py
+++ b/tronbyt_server/routers/manager.py
@@ -2480,7 +2480,9 @@ def appwebp(iname: str, deps: UserAndDevice = Depends(get_user_and_device)) -> R
     if webp_path.exists() and webp_path.stat().st_size > 0:
         return send_image(webp_path, device, app)
     else:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+        resp = send_default_image(device)
+        resp.status_code = status.HTTP_404_NOT_FOUND
+        return resp
 
 
 @router.post("/{device_id}/{iname}/schema_handler/{handler}", name="schema_handler")


### PR DESCRIPTION
Instead of raising a 404 HTTPException when an app's webp image is not found, return the default image. This prevents browsers from showing a broken image icon and provides a better user experience by consistently displaying a placeholder. The response still includes a 404 status code, but the content is now a valid image.