### PR TITLE
Changing to use TZ variable

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -10,7 +10,6 @@ services:
       - ./tronbyt_server:/app/tronbyt_server # for development
       - ./users:/app/users # for development
       - ./data:/app/data # for development
-      - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
     environment:
       - PUID=${UID:-1000}
       - PGID=${GID:-${UID:-1000}}
@@ -23,3 +22,4 @@ services:
       - WEB_CONCURRENCY
       - TRONBYT_HOST=0.0.0.0
       - GITHUB_TOKEN
+      - TZ=America/Tijuana # Set local timezone of Docker Container

--- a/docker-compose.https.yaml
+++ b/docker-compose.https.yaml
@@ -4,7 +4,6 @@ services:
     restart: unless-stopped
     init: true
     volumes:
-      - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users
       - data:/app/data
     environment:
@@ -16,7 +15,7 @@ services:
       - WEB_CONCURRENCY
       - TRONBYT_HOST=0.0.0.0
       - GITHUB_TOKEN
-
+      - TZ=America/Tijuana # Set local timezone of Docker Container
     healthcheck:
       test: ["CMD", "python3", "-m", "tronbyt_server.healthcheck", "http://localhost:8000/health"]
       interval: 1m30s

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -6,7 +6,6 @@ services:
       - "${SERVER_PORT:-8000}:8000" # Map server port on the host to port 8000 in the container
     init: true
     volumes:
-      - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users
       - data:/app/data
     environment:
@@ -20,6 +19,7 @@ services:
       - TRONBYT_HOST=0.0.0.0
       - SINGLE_USER_AUTO_LOGIN
       - GITHUB_TOKEN
+      - TZ=America/Tijuana # Set local timezone of Docker Container
 
     healthcheck:
       test: ["CMD", "python3", "-m", "tronbyt_server.healthcheck", "http://localhost:8000/health"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,6 @@ services:
       - "${SERVER_PORT:-8000}:8000" # Map server port on the host to port 8000 in the container
     init: true
     volumes:
-      - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
       - users:/app/users
       - data:/app/data
     environment:
@@ -19,6 +18,7 @@ services:
       - TRONBYT_HOST=0.0.0.0
       - SINGLE_USER_AUTO_LOGIN
       - GITHUB_TOKEN
+      - TZ=America/Tijuana # Set local timezone of Docker Container
 
     healthcheck:
       test: ["CMD", "python3", "-m", "tronbyt_server.healthcheck", "http://localhost:8000/health"]


### PR DESCRIPTION
Hi There!

First off, thank you for all you do.
Secondly, there's been some discussion about setting the timezone on the docker container separately from the host. 
Upon testing it looks like these containers support the TZ variable, and the defined timezone by the timezone database

A quick way for users to find the timezone is either https://timezone.mariushosting.com/ or from the IANA list https://nodatime.org/TimeZones

I've switched the docker-composes to utilize this instead of the hardcoded timezone from the host.

