### PR TITLE
fix: use absolute path for default image to prevent RuntimeError

### DIFF
--- a/tronbyt_server/utils.py
+++ b/tronbyt_server/utils.py
@@ -26,6 +26,7 @@ from tronbyt_server.sync import get_sync_manager
 
 
 logger = logging.getLogger(__name__)
+MODULE_ROOT = Path(__file__).parent.resolve()
 
 
 class RepoStatus(Enum):
@@ -243,7 +244,7 @@ def possibly_render(
 
 def send_default_image(device: Device) -> Response:
     """Send the default image."""
-    return send_image(Path("tronbyt_server/static/images/default.webp"), device, None)
+    return send_image(MODULE_ROOT / "static" / "images" / "default.webp", device, None)
 
 
 def send_image(


### PR DESCRIPTION
Defined MODULE_ROOT in utils.py and used it to construct the absolute path for default.webp. This fixes an issue where the file was not found when running the server.