### PR TITLE
refactor(apps): Manage broken app status via manifest.yaml

### DIFF
--- a/tronbyt_server/system_apps.py
+++ b/tronbyt_server/system_apps.py
@@ -99,16 +99,6 @@ def generate_apps_json(base_path: Path) -> None:
     # find all the .star files in the apps_path directory
     apps_array: list[AppMetadata] = []
     apps = list(system_apps_path.rglob("*.star"))
-    broken_apps = []
-
-    broken_apps_path = system_apps_path / "broken_apps.txt"
-    if broken_apps_path.exists():
-        logger.info(f"processing broken_apps file {broken_apps_path}")
-        try:
-            broken_apps = broken_apps_path.read_text().splitlines()
-            logger.info(str(broken_apps))
-        except Exception as e:
-            logger.info(f"problem reading broken_apps_txt {e}")
 
     apps.sort()
     count = 0
@@ -173,14 +163,6 @@ def generate_apps_json(base_path: Path) -> None:
                 path=str(app),
                 date=mod_time.strftime("%Y-%m-%d %H:%M"),
             )
-
-            # Check if app is broken
-            is_broken = broken_apps and app.name in broken_apps
-            if is_broken:
-                logger.info(f"marking broken app {app.name}")
-                app_dict.broken = True
-                app_dict.brokenReason = "Marked Broken"
-                skip_count += 1
 
             # Check if app uses secret.star module
             app_str = app.read_text()

--- a/tronbyt_server/templates/manager/addapp.html
+++ b/tronbyt_server/templates/manager/addapp.html
@@ -554,9 +554,9 @@
         {% endif %}
         {% if config['PRODUCTION'] == '0' and not app.path.startswith("users/") %}
           {% if app.broken %}
-          <button class="unmark-broken-btn" onclick="unmarkAppAsBroken('{{ app.file_name or app.name }}', event);" style="background-color: #4CAF50; color: white; border: none; padding: 5px 10px; cursor: pointer; margin-top: 5px; font-size: 12px;">{{ _('Unmark Broken') }}</button>
+          <button class="unmark-broken-btn" onclick="unmarkAppAsBroken('{{ app.file_name or app.name }}', '{{ app.package_name }}', event);" style="background-color: #4CAF50; color: white; border: none; padding: 5px 10px; cursor: pointer; margin-top: 5px; font-size: 12px;">{{ _('Unmark Broken') }}</button>
           {% else %}
-          <button class="mark-broken-btn" onclick="markAppAsBroken('{{ app.file_name or app.name }}', event);" style="background-color: #f44336; color: white; border: none; padding: 5px 10px; cursor: pointer; margin-top: 5px; font-size: 12px;">{{ _('Mark Broken') }}</button>
+          <button class="mark-broken-btn" onclick="markAppAsBroken('{{ app.file_name or app.name }}', '{{ app.package_name }}', event);" style="background-color: #f44336; color: white; border: none; padding: 5px 10px; cursor: pointer; margin-top: 5px; font-size: 12px;">{{ _('Mark Broken') }}</button>
           {% endif %}
         {% endif %}
       </div>
@@ -663,16 +663,21 @@
   });
 
   // Function to mark app as broken (development mode only)
-  function markAppAsBroken(appName, event) {
+  function markAppAsBroken(appName, packageName, event) {
     // Stop the event from bubbling up to the parent div
     event.stopPropagation();
     event.preventDefault();
 
-    if (!confirm("Mark '" + appName + "' as broken? This will add it to broken_apps.txt and prevent it from being installed.")) {
+    if (!confirm("Mark '" + appName + "' as broken? This will add 'broken: true' to its manifest.yaml and prevent it from being installed.")) {
       return;
     }
 
-    fetch("{{ url_for('mark_app_broken', app_name='PLACEHOLDER') }}".replace('PLACEHOLDER', encodeURIComponent(appName)), {
+    let url = "{{ url_for('mark_app_broken', app_name='PLACEHOLDER') }}".replace('PLACEHOLDER', encodeURIComponent(appName));
+    if (packageName && packageName !== 'None' && packageName !== '') {
+      url += "?package_name=" + encodeURIComponent(packageName);
+    }
+
+    fetch(url, {
       method: 'POST'
     })
     .then(response => response.json())
@@ -691,16 +696,21 @@
   }
 
   // Function to unmark app as broken (development mode only)
-  function unmarkAppAsBroken(appName, event) {
+  function unmarkAppAsBroken(appName, packageName, event) {
     // Stop the event from bubbling up to the parent div
     event.stopPropagation();
     event.preventDefault();
 
-    if (!confirm("Unmark '" + appName + "' as broken? This will remove it from broken_apps.txt and allow it to be installed.")) {
+    if (!confirm("Unmark '" + appName + "' as broken? This will set 'broken: false' in its manifest.yaml and allow it to be installed.")) {
       return;
     }
 
-    fetch("{{ url_for('unmark_app_broken', app_name='PLACEHOLDER') }}".replace('PLACEHOLDER', encodeURIComponent(appName)), {
+    let url = "{{ url_for('unmark_app_broken', app_name='PLACEHOLDER') }}".replace('PLACEHOLDER', encodeURIComponent(appName));
+    if (packageName && packageName !== 'None' && packageName !== '') {
+      url += "?package_name=" + encodeURIComponent(packageName);
+    }
+
+    fetch(url, {
       method: 'POST'
     })
     .then(response => response.json())


### PR DESCRIPTION
Removed the outdated `broken_apps.txt` file for tracking broken apps. The system now exclusively uses the `broken` field within an app's `manifest.yaml` to mark and unmark apps as broken.

Optimized manifest lookup in `mark_app_broken` and `unmark_app_broken` endpoints by allowing an optional `package_name` query parameter for direct path resolution, falling back to recursive search if not provided. This improves efficiency and accuracy in development mode.

The UI (`addapp.html`) has been updated to reflect these changes, including passing `package_name` for API calls.

Fixes: #14