### PR TITLE
fix(server): update ClientInfo JSON tags to snake_case

### DIFF
--- a/internal/server/websockets.go
+++ b/internal/server/websockets.go
@@ -20,10 +20,10 @@ type WSMessage struct {
 }
 
 type ClientInfo struct {
-	FirmwareVersion string `json:"firmwareVersion"`
-	FirmwareType    string `json:"firmwareType"`
-	ProtocolVersion *int   `json:"protocolVersion"`
-	MACAddress      string `json:"macAddress"`
+	FirmwareVersion string `json:"firmware_version"`
+	FirmwareType    string `json:"firmware_type"`
+	ProtocolVersion *int   `json:"protocol_version"`
+	MACAddress      string `json:"mac"`
 }
 
 type WSEvent struct {


### PR DESCRIPTION
Aligns the ClientInfo struct JSON tags with the Python DeviceInfoBase model and the expected JSON format from the device (snake_case). Also corrects `macAddress` to `mac`.