### PR TITLE
feat(server): use external filepath-securejoin library for path validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.5
 
 require (
 	github.com/caarlos0/env/v6 v6.10.1
+	github.com/cyphar/filepath-securejoin v0.6.1
 	github.com/go-git/go-git/v5 v5.16.4
 	github.com/go-webauthn/webauthn v0.15.0
 	github.com/gorilla/sessions v1.4.0
@@ -40,7 +41,6 @@ require (
 	github.com/bep/golibsass v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
-	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/internal/server/render_utils.go
+++ b/internal/server/render_utils.go
@@ -14,6 +14,8 @@ import (
 	"tronbyt-server/internal/data"
 	"tronbyt-server/internal/renderer"
 	"tronbyt-server/web"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
 )
 
 func (s *Server) possiblyRender(ctx context.Context, app *data.App, device *data.Device, user *data.User) bool {
@@ -33,11 +35,9 @@ func (s *Server) possiblyRender(ctx context.Context, app *data.App, device *data
 	}
 	appBasename := fmt.Sprintf("%s-%s", app.Name, app.Iname)
 	webpDir := s.getDeviceWebPDir(device.ID)
-	webpPath := filepath.Join(webpDir, fmt.Sprintf("%s.webp", appBasename))
-
-	// Security Check: Ensure webpPath is within webpDir
-	if !strings.HasPrefix(filepath.Clean(webpPath), filepath.Clean(webpDir)+string(os.PathSeparator)) {
-		slog.Error("Path traversal attempt in webp path", "path", webpPath)
+	webpPath, err := securejoin.SecureJoin(webpDir, fmt.Sprintf("%s.webp", appBasename))
+	if err != nil {
+		slog.Error("Path traversal attempt in webp path", "app", appBasename, "error", err)
 		return false
 	}
 


### PR DESCRIPTION
Use github.com/cyphar/filepath-securejoin to guard against path traversal vulnerabilities.