### PR TITLE
feat(server): add gzip middleware for HTTP responses

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -266,6 +266,6 @@ func (s *Server) routes() {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Chain middlewares: Recover -> Logging -> Proxy -> Mux
-	RecoverMiddleware(LoggingMiddleware(ProxyMiddleware(s.Router))).ServeHTTP(w, r)
+	// Chain middlewares: Recover -> Gzip -> Logging -> Proxy -> Mux
+	RecoverMiddleware(GzipMiddleware(LoggingMiddleware(ProxyMiddleware(s.Router)))).ServeHTTP(w, r)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"compress/gzip"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,7 +16,7 @@ import (
 )
 
 func newTestServer(t *testing.T) *Server {
-	dbName := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	dbName := fmt.Sprintf("file:%s?mode=memory&cache=shared&_busy_timeout=5000", t.Name())
 	db, err := gorm.Open(sqlite.Open(dbName), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("Failed to open DB: %v", err)
@@ -60,4 +62,106 @@ func TestLoginRedirectToRegisterIfNoUsers(t *testing.T) {
 		t.Errorf("handler returned wrong redirect location: got %v want %v",
 			location.Path, "/auth/register")
 	}
+}
+
+func TestGzipMiddleware(t *testing.T) {
+	s := newTestServer(t)
+	s.Router.HandleFunc("GET /gzip-test", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		if _, err := w.Write([]byte("Hello, Gzip!")); err != nil {
+			t.Logf("Write failed: %v", err)
+		}
+	})
+	s.Router.HandleFunc("GET /gzip-204", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	t.Run("with Accept-Encoding gzip", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "/gzip-test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		rr := httptest.NewRecorder()
+
+		s.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("Expected 200 OK, got %v", rr.Code)
+		}
+
+		if rr.Header().Get("Content-Encoding") != "gzip" {
+			t.Errorf("Expected Content-Encoding: gzip, got %v", rr.Header().Get("Content-Encoding"))
+		}
+
+		// Verify content
+		gr, err := gzip.NewReader(rr.Body)
+		if err != nil {
+			t.Fatalf("Failed to create gzip reader: %v", err)
+		}
+		defer func() { _ = gr.Close() }()
+
+		body, err := io.ReadAll(gr)
+		if err != nil {
+			t.Fatalf("Failed to read gzip body: %v", err)
+		}
+
+		if string(body) != "Hello, Gzip!" {
+			t.Errorf("Expected body 'Hello, Gzip!', got %q", string(body))
+		}
+	})
+
+	t.Run("without Accept-Encoding", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "/gzip-test", nil)
+		rr := httptest.NewRecorder()
+
+		s.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("Expected 200 OK, got %v", rr.Code)
+		}
+
+		if rr.Header().Get("Content-Encoding") != "" {
+			t.Errorf("Expected no Content-Encoding, got %v", rr.Header().Get("Content-Encoding"))
+		}
+
+		if rr.Body.String() != "Hello, Gzip!" {
+			t.Errorf("Expected body 'Hello, Gzip!', got %q", rr.Body.String())
+		}
+	})
+
+	t.Run("with 204 No Content", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "/gzip-204", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		rr := httptest.NewRecorder()
+
+		s.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusNoContent {
+			t.Errorf("Expected 204 No Content, got %v", rr.Code)
+		}
+
+		if rr.Header().Get("Content-Encoding") == "gzip" {
+			t.Error("Expected no Content-Encoding for 204 response")
+		}
+
+		if rr.Body.Len() > 0 {
+			t.Errorf("Expected empty body for 204, got length %d", rr.Body.Len())
+		}
+	})
+
+	t.Run("WebSocket Upgrade Skipped", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "/gzip-test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		req.Header.Set("Connection", "Upgrade")
+		req.Header.Set("Upgrade", "websocket")
+		rr := httptest.NewRecorder()
+
+		s.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("Expected 200 OK (mock handler), got %v", rr.Code)
+		}
+
+		if rr.Header().Get("Content-Encoding") != "" {
+			t.Errorf("Expected no Content-Encoding for WS upgrade, got %v", rr.Header().Get("Content-Encoding"))
+		}
+	})
 }


### PR DESCRIPTION
Implemented a custom GzipMiddleware to compress HTTP responses when the client supports it. This improves performance by reducing the size of transferred data, especially for JSON API responses and static assets. Included tests to verify behavior with and without Accept-Encoding header.