### PR TITLE
fix(server): enable HTTP/2 in manual TLS config

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -346,6 +346,7 @@ To disable: Set SINGLE_USER_AUTO_LOGIN=0 in your .env file
 		}
 		tlsConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
+			NextProtos:   []string{"h2", "http/1.1"},
 		}
 		slog.Info("TLS certificates loaded", "cert", cfg.SSLCertFile, "key", cfg.SSLKeyFile)
 	}


### PR DESCRIPTION
Explicitly set NextProtos to ['h2', 'http/1.1'] in the shared tls.Config. This is required because creating a tls.NewListener manually bypasses the automatic HTTP/2 configuration that normally happens in http.ServeTLS.