### PR TITLE
feat: implement brightness and interval update endpoints

### DIFF
--- a/internal/server/handlers_device_test.go
+++ b/internal/server/handlers_device_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -126,5 +127,158 @@ func TestHandleDeleteDevice(t *testing.T) {
 	s.DB.Model(&data.App{}).Where("device_id = ?", "testdevice").Count(&count)
 	if count != 0 {
 		t.Errorf("App not deleted (cascade failed)")
+	}
+}
+
+func TestHandleUpdateBrightness(t *testing.T) {
+	s := newTestServer(t)
+
+	user := data.User{Username: "testuser"}
+	s.DB.Create(&user)
+	device := data.Device{
+		ID:         "testdevice",
+		Username:   "testuser",
+		Name:       "Test Device",
+		Brightness: data.Brightness(20),
+	}
+	s.DB.Create(&device)
+
+	bUI := 4 // Define bUI here
+
+	form := url.Values{}
+	form.Add("brightness", strconv.Itoa(bUI))
+
+	req, _ := http.NewRequest(http.MethodPost, "/devices/testdevice/update_brightness", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	ctx := context.WithValue(req.Context(), userContextKey, &user)
+	ctx = context.WithValue(ctx, deviceContextKey, &device)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(s.handleUpdateBrightness)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", rr.Code, http.StatusOK)
+	}
+
+	var updatedDevice data.Device
+	s.DB.First(&updatedDevice, "id = ?", "testdevice")
+
+	expectedBrightness := data.BrightnessFromUIScale(bUI, nil) // For UI 4, this should be 35
+	if updatedDevice.Brightness != expectedBrightness {
+		t.Errorf("Brightness not updated correctly: got %v want %v", updatedDevice.Brightness, expectedBrightness)
+	}
+}
+
+func TestHandleUpdateBrightness_Invalid(t *testing.T) {
+	s := newTestServer(t)
+
+	user := data.User{Username: "testuser"}
+	s.DB.Create(&user)
+	device := data.Device{
+		ID:         "testdevice",
+		Username:   "testuser",
+		Name:       "Test Device",
+		Brightness: data.Brightness(20),
+	}
+	s.DB.Create(&device)
+
+	testCases := []string{"-1", "6", "abc"}
+
+	for _, tc := range testCases {
+		form := url.Values{}
+		form.Add("brightness", tc)
+
+		req, _ := http.NewRequest(http.MethodPost, "/devices/testdevice/update_brightness", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		ctx := context.WithValue(req.Context(), userContextKey, &user)
+		ctx = context.WithValue(ctx, deviceContextKey, &device)
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(s.handleUpdateBrightness)
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("handler returned wrong status code for input %s: got %v want %v", tc, rr.Code, http.StatusBadRequest)
+		}
+	}
+}
+
+func TestHandleUpdateInterval(t *testing.T) {
+	s := newTestServer(t)
+
+	user := data.User{Username: "testuser"}
+	s.DB.Create(&user)
+	device := data.Device{
+		ID:              "testdevice",
+		Username:        "testuser",
+		DefaultInterval: 15,
+	}
+	s.DB.Create(&device)
+
+	form := url.Values{}
+	form.Add("interval", "30")
+
+	req, _ := http.NewRequest(http.MethodPost, "/devices/testdevice/update_interval", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	ctx := context.WithValue(req.Context(), userContextKey, &user)
+	ctx = context.WithValue(ctx, deviceContextKey, &device)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(s.handleUpdateInterval)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", rr.Code, http.StatusOK)
+	}
+
+	var updatedDevice data.Device
+	s.DB.First(&updatedDevice, "id = ?", "testdevice")
+	if updatedDevice.DefaultInterval != 30 {
+		t.Errorf("Interval not updated, got %d", updatedDevice.DefaultInterval)
+	}
+}
+
+func TestHandleUpdateInterval_Invalid(t *testing.T) {
+	s := newTestServer(t)
+
+	user := data.User{Username: "testuser"}
+	s.DB.Create(&user)
+	device := data.Device{
+		ID:              "testdevice",
+		Username:        "testuser",
+		DefaultInterval: 15,
+	}
+	s.DB.Create(&device)
+
+	testCases := []string{"-1", "0", "abc"}
+
+	for _, tc := range testCases {
+		form := url.Values{}
+		form.Add("interval", tc)
+
+		req, _ := http.NewRequest(http.MethodPost, "/devices/testdevice/update_interval", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		ctx := context.WithValue(req.Context(), userContextKey, &user)
+		ctx = context.WithValue(ctx, deviceContextKey, &device)
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(s.handleUpdateInterval)
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("handler returned wrong status code for input %s: got %v want %v", tc, rr.Code, http.StatusBadRequest)
+		}
+		if !strings.Contains(rr.Body.String(), "Interval must be 1 or greater") {
+			t.Errorf("handler returned wrong error message for input %s: got %s want %s", tc, rr.Body.String(), "Interval must be 1 or greater")
+		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -211,6 +211,9 @@ func (s *Server) routes() {
 	s.Router.HandleFunc("GET /devices/create", s.RequireLogin(s.handleCreateDeviceGet))
 	s.Router.HandleFunc("POST /devices/create", s.RequireLogin(s.handleCreateDevicePost))
 
+	s.Router.HandleFunc("POST /devices/{id}/update_brightness", s.RequireLogin(s.RequireDevice(s.handleUpdateBrightness)))
+	s.Router.HandleFunc("POST /devices/{id}/update_interval", s.RequireLogin(s.RequireDevice(s.handleUpdateInterval)))
+
 	s.Router.HandleFunc("GET /devices/{id}/addapp", s.RequireLogin(s.RequireDevice(s.handleAddAppGet)))
 	s.Router.HandleFunc("POST /devices/{id}/addapp", s.RequireLogin(s.RequireDevice(s.handleAddAppPost)))
 


### PR DESCRIPTION
- Add `handleUpdateBrightness` and `handleUpdateInterval` handlers.
- Register routes for brightness and interval updates.
- Update frontend to use new endpoints and handle `device_updated` WS events.
- Add unit tests for the new handlers.