### PR TITLE
fix(data): postgres driver stores the incorrect device type

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -63,6 +63,13 @@ func (dt DeviceType) String() string {
 	}
 }
 
+// Value returns the slug to be stored in the database.
+// Without this, the Postgres driver will incorrectly store
+// the value of DeviceType.String.
+func (dt DeviceType) Value() (driver.Value, error) {
+	return string(dt), nil
+}
+
 type ProtocolType string
 
 const (


### PR DESCRIPTION
When using a Postgres database, the device type cannot be changed. The device type dropdown always shows MatrixPortal S3 (first value) and other values cannot be selected.

Turns out, the Postgres driver sees that `DeviceType` implements `fmt.Stringer`, resulting in the human-readable string being stored in the database.

To fix this, this PR adds `DeviceType.Value()` implementing the `driver.Valuer` interface, so that the driver stores the correct value.

Ideally, this struct (and others like it) should be a proper enum type using something like [golang.org/x/tools/cmd/stringer](https://pkg.go.dev/golang.org/x/tools/cmd/stringer), but I can do this in another PR if desired. This one is just to fix the bug.