### PR TITLE
fix(docker): replace hardcoded CMD flags with ENV variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,5 +56,9 @@ EXPOSE 8000
 # Use the Go-based entrypoint wrapper
 ENTRYPOINT ["/boot"]
 
+# Default environment variables
+ENV DB_DSN=data/tronbyt.db
+ENV DATA_DIR=data
+
 # Default command to execute the main server binary
-CMD ["/app/tronbyt-server", "-db", "data/tronbyt.db", "-data", "data"]
+CMD ["/app/tronbyt-server"]


### PR DESCRIPTION
Hardcoded flags in the Dockerfile CMD were taking precedence over environment variables. This moves the default configuration to ENV instructions (`DB_DSN` and `DATA_DIR`) and removes the flags, ensuring environment variables are checked correctly at runtime.