### PR TITLE
fix(server): nil config values passed to pixlet as `<nil>`

### DIFF
--- a/internal/server/render_utils.go
+++ b/internal/server/render_utils.go
@@ -268,7 +268,7 @@ func normalizeConfig(input map[string]any) map[string]string {
 	for k, v := range input {
 		if str, ok := v.(string); ok {
 			config[k] = str
-		} else {
+		} else if v != nil {
 			if b, err := json.Marshal(v); err == nil {
 				config[k] = string(b)
 			} else {


### PR DESCRIPTION
Any `nil` config values get serialized to `<nil>` before being passed to Pixlet. This PR makes those values get ignored.