### PR TITLE
feat: Add custom app zip upload functionality

### DIFF
--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -1,15 +1,19 @@
 package server
 
 import (
+	"archive/zip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
 	"log/slog"
 	"maps"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -31,6 +35,8 @@ type AppManifest struct {
 	Broken       *bool   `yaml:"broken,omitempty"`
 	BrokenReason *string `yaml:"brokenReason,omitempty"`
 }
+
+var packageNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 func (s *Server) handleAddAppGet(w http.ResponseWriter, r *http.Request) {
 	user := GetUser(r)
@@ -1046,7 +1052,7 @@ func (s *Server) handleUploadAppPost(w http.ResponseWriter, r *http.Request) {
 
 	filename := filepath.Base(header.Filename)
 	ext := filepath.Ext(filename)
-	if ext != ".star" && ext != ".webp" {
+	if ext != ".star" && ext != ".webp" && ext != ".zip" {
 		http.Error(w, "Invalid file type", http.StatusBadRequest)
 		return
 	}
@@ -1060,9 +1066,19 @@ func (s *Server) handleUploadAppPost(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid app name", http.StatusBadRequest)
 		return
 	}
-	if err := os.MkdirAll(appDir, 0755); err != nil {
-		slog.Error("Failed to create app dir", "error", err)
+	previewDir := filepath.Join(s.DataDir, "apps")
+	if err := os.MkdirAll(previewDir, 0755); err != nil {
+		slog.Error("Failed to create preview dir", "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	// Handle zip files specifically
+	if ext == ".zip" {
+		if err := s.handleZipUpload(w, r, user, device, file, header, appName); err != nil {
+			slog.Error("Failed to handle zip upload", "error", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -1085,11 +1101,6 @@ func (s *Server) handleUploadAppPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = dst.Sync()
-
-	previewDir := filepath.Join(s.DataDir, "apps")
-	if err := os.MkdirAll(previewDir, 0755); err != nil {
-		slog.Error("Failed to create preview dir", "error", err)
-	}
 
 	switch ext {
 	case ".star":
@@ -1133,6 +1144,246 @@ func (s *Server) handleUploadAppPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, fmt.Sprintf("/devices/%s/addapp", device.ID), http.StatusSeeOther)
+}
+
+func (s *Server) parseManifest(tempExtractDir string) (string, error) {
+	manifestPath := filepath.Join(tempExtractDir, "manifest.yaml")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("Failed to read manifest.yaml", "error", err)
+		}
+		return "", nil // No manifest or read failed, continue with default name
+	}
+
+	var m apps.Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		slog.Warn("Failed to parse manifest.yaml", "error", err)
+		return "", nil
+	}
+
+	if m.PackageName != "" && packageNameRegex.MatchString(m.PackageName) {
+		return m.PackageName, nil
+	}
+	return "", nil
+}
+
+func (s *Server) handleZipUpload(w http.ResponseWriter, r *http.Request, user *data.User, device *data.Device, file io.Reader, header *multipart.FileHeader, appName string) error {
+	userAppsDir := filepath.Join(s.DataDir, "users", user.Username, "apps")
+	previewDir := filepath.Join(s.DataDir, "apps")
+	if err := os.MkdirAll(previewDir, 0755); err != nil {
+		slog.Error("Failed to create preview dir", "error", err)
+		return err
+	}
+
+	// Save the zip file temporarily
+	tempZip, err := os.CreateTemp("", "upload-*.zip")
+	if err != nil {
+		slog.Error("Failed to create temp zip file", "error", err)
+		return err
+	}
+	defer func() {
+		if err := os.Remove(tempZip.Name()); err != nil {
+			slog.Error("Failed to remove temp zip file", "error", err)
+		}
+	}()
+
+	if _, err := io.Copy(tempZip, file); err != nil {
+		slog.Error("Failed to write temp zip file", "error", err)
+		if cerr := tempZip.Close(); cerr != nil {
+			slog.Error("Failed to close temp zip file after error", "error", cerr)
+		}
+		return err
+	}
+	if err := tempZip.Close(); err != nil {
+		slog.Error("Failed to close temp zip file", "error", err)
+		return err
+	}
+
+	// Create a temp dir for extraction
+	tempExtractDir, err := os.MkdirTemp("", "app-extract-*")
+	if err != nil {
+		slog.Error("Failed to create temp extract dir", "error", err)
+		return err
+	}
+	defer func() {
+		if err := os.RemoveAll(tempExtractDir); err != nil {
+			slog.Error("Failed to remove temp extract dir", "error", err)
+		}
+	}()
+
+	// Unzip contents to temp dir
+	if err := s.unzip(tempZip.Name(), tempExtractDir); err != nil {
+		slog.Error("Failed to unzip file", "error", err)
+		return err
+	}
+
+	if parsedName, _ := s.parseManifest(tempExtractDir); parsedName != "" {
+		appName = parsedName
+	}
+
+	// Re-calculate appDir with potentially new appName
+	appDir, err := securejoin.SecureJoin(userAppsDir, appName)
+	if err != nil {
+		slog.Warn("Path traversal attempt blocked", "error", err)
+		return err
+	}
+
+	// Replace existing directory
+	if err := os.RemoveAll(appDir); err != nil {
+		slog.Error("Failed to remove existing app dir", "path", appDir, "error", err)
+		return err
+	}
+	if err := os.MkdirAll(appDir, 0755); err != nil {
+		slog.Error("Failed to create app dir", "error", err)
+		return err
+	}
+
+	// Copy files from tempExtractDir to appDir
+	if err := copyDir(tempExtractDir, appDir); err != nil {
+		slog.Error("Failed to copy extracted files", "error", err)
+		return err
+	}
+
+	s.generatePreview(r.Context(), device, appDir, previewDir, appName)
+
+	http.Redirect(w, r, fmt.Sprintf("/devices/%s/addapp", device.ID), http.StatusSeeOther)
+	return nil
+}
+
+func (s *Server) generatePreview(ctx context.Context, device *data.Device, appDir, previewDir, appName string) {
+	// Check for a .webp preview image to copy
+	var webpPath string
+	entries, err := os.ReadDir(appDir)
+	if err != nil {
+		slog.Error("Failed to read app dir for preview generation", "path", appDir, "error", err)
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			if strings.HasSuffix(entry.Name(), ".webp") {
+				if webpPath == "" || entry.Name() == appName+".webp" {
+					webpPath = filepath.Join(appDir, entry.Name())
+				}
+			}
+		}
+	}
+
+	previewPath := filepath.Join(previewDir, fmt.Sprintf("%s.webp", appName))
+	if webpPath != "" {
+		// If a webp exists, copy it to preview
+		// Note: The UI expects [AppName].webp in the previews dir
+		if err := copyFile(webpPath, previewPath); err != nil {
+			slog.Error("Failed to copy preview image from zip", "error", err)
+		}
+	} else {
+		// If no webp, try to render the app directory
+		imgBytes, _, err := s.RenderApp(ctx, device, nil, appDir, nil)
+		if err == nil && len(imgBytes) > 0 {
+			if err := os.WriteFile(previewPath, imgBytes, 0644); err != nil {
+				slog.Error("Failed to write preview image", "error", err)
+			}
+		} else {
+			slog.Error("Failed to render preview", "error", err)
+		}
+	}
+}
+
+func copyDir(src string, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		dstPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			// Skip symlinks for safety
+			return nil
+		}
+
+		return copyFile(path, dstPath)
+	})
+}
+
+func (s *Server) unzip(src, dest string) error {
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			slog.Error("Failed to close zip reader", "error", err)
+		}
+	}()
+	for _, f := range r.File {
+		// securejoin to prevent zip slip
+		fpath, err := securejoin.SecureJoin(dest, f.Name)
+		if err != nil {
+			return err
+		}
+
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(fpath, f.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err = os.MkdirAll(filepath.Dir(fpath), 0755); err != nil {
+			return err
+		}
+
+		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return err
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			// Ensure outFile is closed if rc.Open() fails
+			if closeErr := outFile.Close(); closeErr != nil {
+				slog.Error("Failed to close extracted file after rc.Open() failed", "error", closeErr)
+			}
+			return err
+		}
+
+		_, err = io.Copy(outFile, rc)
+		copyErr := err // Preserve copy error
+
+		// Attempt to close both files, logging errors if they occur
+		outFileCloseErr := outFile.Close()
+		rcCloseErr := rc.Close()
+
+		// Prioritize copy error
+		if copyErr != nil {
+			if outFileCloseErr != nil {
+				slog.Error("Failed to close extracted file after copy error", "error", outFileCloseErr)
+			}
+			if rcCloseErr != nil {
+				slog.Error("Failed to close zip file reader after copy error", "error", rcCloseErr)
+			}
+			return copyErr
+		}
+
+		// If copy was successful, return close errors if any
+		if outFileCloseErr != nil {
+			return outFileCloseErr
+		}
+		if rcCloseErr != nil {
+			return rcCloseErr
+		}
+	}
+	return nil
 }
 
 func (s *Server) handleDeleteUpload(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_app_test.go
+++ b/internal/server/handlers_app_test.go
@@ -1,10 +1,16 @@
 package server
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -154,5 +160,262 @@ func TestHandleConfigAppPost_TimeFormat(t *testing.T) {
 		t.Error("Expected EndTime to be '22:30', but it was nil")
 	} else if *updatedApp.EndTime != "22:30" {
 		t.Errorf("Expected EndTime '22:30', got %q", *updatedApp.EndTime)
+	}
+}
+
+func TestHandleUploadAppPost_Zip(t *testing.T) {
+	s := newTestServer(t)
+
+	user := data.User{Username: "testuser"}
+	s.DB.Create(&user)
+	device := data.Device{ID: "testdevice", Username: "testuser"}
+	s.DB.Create(&device)
+
+	// Create a ZIP file in memory
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	// Add .star file
+	f, err := zw.Create("testapp.star")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Write([]byte("print('hello world')"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add .webp file (dummy content)
+	f, err = zw.Create("testapp.webp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Write([]byte("fake image data"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add manifest.yaml
+	f, err = zw.Create("manifest.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Write([]byte("packageName: manifest-app"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Prepare Multipart Request
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "testapp.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.Copy(part, &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	req, _ := http.NewRequest(http.MethodPost, "/devices/testdevice/uploadapp", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	ctx := context.WithValue(req.Context(), userContextKey, &user)
+	ctx = context.WithValue(ctx, deviceContextKey, &device)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(s.handleUploadAppPost)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("handler returned wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	// Verify Extraction - should be in manifest-app based on packageName
+	appDir := filepath.Join(s.DataDir, "users", "testuser", "apps", "manifest-app")
+	if _, err := os.Stat(filepath.Join(appDir, "testapp.star")); os.IsNotExist(err) {
+		t.Error("testapp.star not found in extracted dir (expected manifest-app dir)")
+	}
+	if _, err := os.Stat(filepath.Join(appDir, "testapp.webp")); os.IsNotExist(err) {
+		t.Error("testapp.webp not found in extracted dir")
+	}
+	if _, err := os.Stat(filepath.Join(appDir, "manifest.yaml")); os.IsNotExist(err) {
+		t.Error("manifest.yaml not found in extracted dir")
+	}
+
+	// Verify Preview - should match appName (manifest-app)
+	previewPath := filepath.Join(s.DataDir, "apps", "manifest-app.webp")
+	if _, err := os.Stat(previewPath); os.IsNotExist(err) {
+		t.Error("Preview image not found in apps/manifest-app.webp")
+	}
+}
+
+func TestHandleUploadAppPost_Zip_EdgeCases(t *testing.T) {
+	s := newTestServer(t)
+
+	user := data.User{Username: "testuser"}
+	s.DB.Create(&user)
+	device := data.Device{ID: "testdevice", Username: "testuser"}
+	s.DB.Create(&device)
+
+	tests := []struct {
+		name           string
+		zipContent     map[string]string
+		zipFilename    string
+		expectDirName  string // Name of the directory in users/testuser/apps/
+		expectFiles    []string
+		expectedStatus int
+	}{
+		{
+			name: "No Manifest",
+			zipContent: map[string]string{
+				"script.star": "print('hello')",
+			},
+			zipFilename:    "nomanifest.zip",
+			expectDirName:  "nomanifest",
+			expectFiles:    []string{"script.star"},
+			expectedStatus: http.StatusSeeOther,
+		},
+		{
+			name: "Invalid PackageName",
+			zipContent: map[string]string{
+				"script.star": "print('hello')",
+				"manifest.yaml": "packageName: 'invalid name!'",
+			},
+			zipFilename:    "invalidpkg.zip",
+			expectDirName:  "invalidpkg",
+			expectFiles:    []string{"script.star", "manifest.yaml"},
+			expectedStatus: http.StatusSeeOther,
+		},
+		{
+			name: "Only Star",
+			zipContent: map[string]string{
+				"onlystar.star": "print('hello')",
+			},
+			zipFilename:    "onlystar.zip",
+			expectDirName:  "onlystar",
+			expectFiles:    []string{"onlystar.star"},
+			expectedStatus: http.StatusSeeOther,
+		},
+		{
+			name: "Only Webp",
+			zipContent: map[string]string{
+				"image.webp": "fake image data",
+			},
+			zipFilename:    "onlywebp.zip",
+			expectDirName:  "onlywebp",
+			expectFiles:    []string{"image.webp"},
+			expectedStatus: http.StatusSeeOther,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create ZIP
+			var buf bytes.Buffer
+			zw := zip.NewWriter(&buf)
+			for name, content := range tc.zipContent {
+				f, err := zw.Create(name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, err = f.Write([]byte(content))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := zw.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			// Create Request
+			body := &bytes.Buffer{}
+			writer := multipart.NewWriter(body)
+			part, err := writer.CreateFormFile("file", tc.zipFilename)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = io.Copy(part, &buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			req, _ := http.NewRequest(http.MethodPost, "/devices/testdevice/uploadapp", body)
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+
+			ctx := context.WithValue(req.Context(), userContextKey, &user)
+			ctx = context.WithValue(ctx, deviceContextKey, &device)
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(s.handleUploadAppPost)
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tc.expectedStatus {
+				t.Errorf("handler returned wrong status code: got %v want %v", rr.Code, tc.expectedStatus)
+			}
+
+			if tc.expectDirName != "" {
+				appDir := filepath.Join(s.DataDir, "users", "testuser", "apps", tc.expectDirName)
+				if _, err := os.Stat(appDir); os.IsNotExist(err) {
+					t.Errorf("App directory %s not found", appDir)
+				}
+
+				for _, f := range tc.expectFiles {
+					if _, err := os.Stat(filepath.Join(appDir, f)); os.IsNotExist(err) {
+						t.Errorf("File %s not found in app directory", f)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestHandleUploadAppPost_CorruptedZip(t *testing.T) {
+	s := newTestServer(t)
+	user := data.User{Username: "testuser"}
+	s.DB.Create(&user)
+	device := data.Device{ID: "testdevice", Username: "testuser"}
+	s.DB.Create(&device)
+
+	// Create a corrupted zip (just random bytes)
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "corrupt.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = part.Write([]byte("this is not a zip file"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, "/devices/testdevice/uploadapp", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	ctx := context.WithValue(req.Context(), userContextKey, &user)
+	ctx = context.WithValue(ctx, deviceContextKey, &device)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(s.handleUploadAppPost)
+	handler.ServeHTTP(rr, req)
+
+	// Expecting 500 Internal Server Error because unzip fails
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("handler returned wrong status code for corrupt zip: got %v want %v", rr.Code, http.StatusInternalServerError)
 	}
 }

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -482,8 +482,8 @@
   "Upload App": {
     "other": "App hochladen"
   },
-  "Select File (.star or .webp)": {
-    "other": "Datei auswählen (.star oder .webp)"
+  "Select File (.star, .webp or .zip)": {
+    "other": "Datei auswählen (.star, .webp oder .zip)"
   },
   "Sign in with Passkey": {
     "other": "Mit Passkey anmelden"
@@ -533,8 +533,8 @@
   "Loading apps...": {
     "other": "Lade Apps…"
   },
-  "Upload .star or .webp file": {
-    "other": ".star oder .webp Datei hochladen"
+  "Upload app": {
+    "other": "App hochladen"
   },
   "App Selection": {
     "other": "App-Auswahl"

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -482,8 +482,8 @@
   "Upload App": {
     "other": "Upload App"
   },
-  "Select File (.star or .webp)": {
-    "other": "Select File (.star or .webp)"
+  "Select File (.star, .webp or .zip)": {
+    "other": "Select File (.star, .webp or .zip)"
   },
   "Sign in with Passkey": {
     "other": "Sign in with Passkey"
@@ -533,8 +533,8 @@
   "Loading apps...": {
     "other": "Loading apps..."
   },
-  "Upload .star or .webp file": {
-    "other": "Upload .star or .webp file"
+  "Upload app": {
+    "other": "Upload app"
   },
   "App Selection": {
     "other": "App Selection"

--- a/web/templates/manager/addapp.html
+++ b/web/templates/manager/addapp.html
@@ -15,7 +15,7 @@
   <p>{{ t .Localizer "Loading apps..." }}</p>
 </div>
 
-<a class="w3-button w3-purple w3-round w3-padding" href="/devices/{{ .Device.ID }}/uploadapp"><i class="fa-solid fa-cloud-arrow-up" aria-hidden="true"></i> {{ t .Localizer "Upload .star or .webp file" }}</a>
+<a class="w3-button w3-purple w3-round w3-padding" href="/devices/{{ .Device.ID }}/uploadapp"><i class="fa-solid fa-cloud-arrow-up" aria-hidden="true"></i> {{ t .Localizer "Upload app" }}</a>
 
 <form method="post" id="main_form">
   <label for="name">{{ t .Localizer "App Selection" }}</label>

--- a/web/templates/manager/uploadapp.html
+++ b/web/templates/manager/uploadapp.html
@@ -6,8 +6,8 @@
 <h1>{{ t .Localizer "Upload App" }}</h1>
 <div class="w3-card-4 w3-padding">
     <form method="post" enctype="multipart/form-data">
-        <label>{{ t .Localizer "Select File (.star or .webp)" }}</label>
-        <input class="w3-input" type="file" name="file" accept=".star,.webp" required>
+        <label>{{ t .Localizer "Select File (.star, .webp or .zip)" }}</label>
+        <input class="w3-input" type="file" name="file" accept=".star,.webp,.zip" required>
         <br>
         <button class="w3-button w3-green" type="submit">{{ t .Localizer "Upload" }}</button>
     </form>


### PR DESCRIPTION
This commit introduces the ability for users to upload custom applications as .zip files. The server will now:
- Accept .zip files in addition to .star and .webp for app uploads.
- Securely extract the contents of the zip file to a temporary directory.
- Parse `manifest.yaml` (if present) within the zip to determine the `packageName`.
- Use the `packageName` (if valid) as the application's directory name, overwriting any existing directory with the same name for a clean installation.
- Automatically detect and use the primary .star script and .webp preview image within the extracted directory.
- Render a preview image for the uploaded application.

The web UI's upload form has been updated to reflect the new .zip acceptance. New tests have been added to verify the functionality, including manifest parsing and file extraction.

Resolves #585, #524