### PR TITLE
fix(gitutils): use fetch+reset for reliable shallow repo updates

### DIFF
--- a/internal/gitutils/git.go
+++ b/internal/gitutils/git.go
@@ -165,6 +165,10 @@ func EnsureRepo(path string, url string, update bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to get HEAD: %w", err)
 	}
+
+	if !headRef.Name().IsBranch() {
+		return fmt.Errorf("repository in detached HEAD state at %s, cannot determine branch to update", headRef.Hash().String())
+	}
 	branchName := headRef.Name().Short()
 
 	// Find the commit hash of that branch on the remote


### PR DESCRIPTION
Replaces `git pull` with `git fetch` (depth 1) followed by `git reset --hard` to remote HEAD. This approach is robust against history mismatches in shallow clones, preventing "object not found" errors.

Also:
- Redirects git progress output to structured logging (slog).