### PR TITLE
fix(rotation): handle night mode fallback when no app is selected

### DIFF
--- a/internal/server/rotation.go
+++ b/internal/server/rotation.go
@@ -204,7 +204,7 @@ func (s *Server) determineNextApp(ctx context.Context, device *data.Device, user
 		shouldDisplay := false
 		if isPinned {
 			shouldDisplay = true
-		} else if nightModeActive {
+		} else if nightModeActive && device.NightModeApp != "" {
 			shouldDisplay = isNightTarget
 		} else if isInterstitialPos {
 			shouldDisplay = true


### PR DESCRIPTION
This fixes a regression where enabling Night Mode without selecting a specific Night Mode app would cause the rotation to fail entirely, returning no app.