### PR TITLE
Fix OTA capability check and separate user apps/repo paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The entire backend has been rewritten in Go (1.25+). This change offers:
     *   `reset-password`: Manually reset a user's password.
     *   `health`: Perform health checks against the running server.
 *   **Passkey Authentication:** Added support for passkey authentication (requires HTTPS on some browsers) for more secure and convenient logins.
-*   **Over-The-Air (OTA) Updates:** Devices running compatible firmware can now be updated directly from the web interface. Updates are delivered via WebSocket commands or HTTP headers, streamlining the firmware management process.
+*   **Over-The-Air (OTA) Updates:** Devices running compatible firmware can now be updated directly from the web interface. Updates are delivered via WebSocket commands or HTTP headers, streamlining the firmware management process. Requires device firmware version >= 1.4.4.
 *   **App Configuration Export/Import:** Users can now export app configurations to a JSON file and import them back into existing app installations. This makes it easy to backup configurations or replicate complex setups across different apps.
 *   **ZIP-packaged App Support:** Users can now upload and run apps packaged as ZIP files. This enables more complex apps that split logic across multiple files, reference external assets like images, and include metadata via manifest files.
 

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/mod/semver"
 )
 
 // --- Enums & Value Types ---
@@ -647,4 +649,19 @@ func (d *Device) GetEffectiveBrightness() int {
 		brightness = int(*d.DimBrightness)
 	}
 	return brightness
+}
+
+func (d *Device) OTACapable() bool {
+	if !d.Type.SupportsFirmware() {
+		return false
+	}
+	v := d.Info.FirmwareVersion
+	if v == "" {
+		return false
+	}
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+
+	return semver.Compare(v, "v1.4.4") >= 0
 }

--- a/internal/gitutils/git.go
+++ b/internal/gitutils/git.go
@@ -125,6 +125,13 @@ func EnsureRepo(path string, repoURL string, token string, update bool) error {
 	// Repo exists, open it
 	r, err := git.PlainOpen(path)
 	if err != nil {
+		if errors.Is(err, git.ErrRepositoryNotExists) {
+			slog.Warn("Directory exists but is not a valid git repo, re-cloning", "path", path)
+			if err := os.RemoveAll(path); err != nil {
+				return fmt.Errorf("failed to remove invalid repo directory: %w", err)
+			}
+			return EnsureRepo(path, repoURL, token, update)
+		}
 		// If not a git repo, maybe remove and re-clone?
 		// For safety, error out.
 		return fmt.Errorf("failed to open repo: %w", err)

--- a/internal/server/handlers_user.go
+++ b/internal/server/handlers_user.go
@@ -186,7 +186,7 @@ func (s *Server) handleSetUserRepo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	appsPath := filepath.Join(s.DataDir, "users", user.Username, "apps")
+	appsPath := filepath.Join(s.DataDir, "users", user.Username, "repo")
 	if err := gitutils.EnsureRepo(appsPath, repoURL, s.Config.GitHubToken, true); err != nil {
 		slog.Error("Failed to sync user repo", "error", err)
 	}
@@ -198,7 +198,7 @@ func (s *Server) handleRefreshUserRepo(w http.ResponseWriter, r *http.Request) {
 	user := GetUser(r)
 
 	if user.AppRepoURL != "" {
-		appsPath := filepath.Join(s.DataDir, "users", user.Username, "apps")
+		appsPath := filepath.Join(s.DataDir, "users", user.Username, "repo")
 		if err := gitutils.EnsureRepo(appsPath, user.AppRepoURL, s.Config.GitHubToken, true); err != nil {
 			slog.Error("Failed to refresh user repo", "error", err)
 		}

--- a/web/templates/manager/update.html
+++ b/web/templates/manager/update.html
@@ -535,7 +535,7 @@
         </table>
       </div>
 
-      {{ if .FirmwareAvailable }}
+      {{ if and .FirmwareAvailable .Device.OTACapable }}
             <div class="device-settings-section">
               <h2>{{ t .Localizer "Firmware Update" }}</h2>
               <div style="padding: 10px;">


### PR DESCRIPTION
- internal/data: Add OTACapable method to Device checking for firmware >= 1.4.4
- web/templates: Update firmware update UI to check for OTA capability
- internal/gitutils: Fix EnsureRepo to handle non-repo directories by re-cloning
- internal/server: Move user git repo sync location to 'repo' directory to avoid conflict with 'apps' uploads
- internal/apps: Update ListUserApps to scan both 'apps' and 'repo' directories
- CHANGELOG: Update OTA requirements note