### PR TITLE
feat: add name support for WebAuthn passkeys

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -418,6 +418,7 @@ type WebAuthnCredential struct {
 	ID              string `gorm:"primaryKey"                            json:"id"`
 	UserID          string `gorm:"index"                                 json:"user_id"`
 	User            User   `gorm:"foreignKey:UserID;references:Username" json:"-"`
+	Name            string `json:"name"` // User-friendly name
 	PublicKey       []byte `json:"public_key"`
 	AttestationType string `json:"attestation_type"`
 	Transport       string `json:"transport"`     // Comma-separated

--- a/internal/server/webauthn.go
+++ b/internal/server/webauthn.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"log/slog"
 	"tronbyt-server/internal/data"
@@ -206,6 +207,7 @@ func (s *Server) handleWebAuthnRegisterFinish(w http.ResponseWriter, r *http.Req
 	newCred := data.WebAuthnCredential{
 		ID:              base64.URLEncoding.EncodeToString(credential.ID),
 		UserID:          user.Username,
+		Name:            fmt.Sprintf("Passkey %s UTC", time.Now().UTC().Format("2006-01-02 15:04:05")),
 		PublicKey:       credential.PublicKey,
 		AttestationType: credential.AttestationType,
 		Transport:       joinTransports(credential.Transport),

--- a/web/templates/auth/edit.html
+++ b/web/templates/auth/edit.html
@@ -374,7 +374,7 @@
                            padding: 8px">
                     <div style="display: flex; align-items: center; gap: 10px;">
                         <i class="fa-solid fa-key"></i>
-                        <span>{{ .Authenticator }}{{ if ne .AttestationType "none" }} ({{ .AttestationType }}){{ end }}</span>
+                        <span>{{ or .Name .Authenticator }}{{ if ne .AttestationType "none" }} ({{ .AttestationType }}){{ end }}</span>
                     </div>
                     <button onclick="deletePasskey('{{ .ID }}')"
                             class="w3-button w3-tiny w3-red w3-round"


### PR DESCRIPTION
- Add Name field to WebAuthnCredential model
- Automatically name new passkeys with timestamp
- Update edit profile template to display passkey name or authenticator ID