### PR TITLE
catch email="none" during migration etc.

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -235,7 +235,7 @@ func main() {
 
 	// Sanitize data before migration (fixes v2.0.x empty email constraint issue)
 	if db.Migrator().HasTable(&data.User{}) {
-		if err := db.Model(&data.User{}).Where("email = ?", "").Update("email", nil).Error; err != nil {
+		if err := db.Model(&data.User{}).Where("email IN ?", []string{"", "none"}).Update("email", nil).Error; err != nil {
 			slog.Warn("Failed to sanitize empty emails", "error", err)
 		}
 	}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -8,6 +8,7 @@ services:
       - "${SERVER_PORT:-8000}:8000" # Map server port on the host to port 8000 in the container
     volumes:
       - ./tronbyt_server:/app/tronbyt_server # for development
+      - ./users:/app/users # for development
       - ./data:/app/data # for development
       - "/etc/localtime:/etc/localtime:ro" # used to sync docker with host time
     environment:

--- a/internal/legacy/converter.go
+++ b/internal/legacy/converter.go
@@ -18,7 +18,7 @@ var durationRegex = regexp.MustCompile(`^PT(?:(\d+(?:\.\d+)?)S)?$`)
 // ToDataUser converts a LegacyUser to the modern data.User format.
 func (lu *LegacyUser) ToDataUser() data.User {
 	var emailPtr *string
-	if lu.Email != "" {
+	if lu.Email != "" && lu.Email != "none" {
 		emailPtr = &lu.Email
 	}
 


### PR DESCRIPTION
emails might become "none" instead of "" and break uniqueness on migrate and index creation.