### PR TITLE
feat: optimize dot matrix SVG generation

### DIFF
--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -859,7 +859,7 @@ func (s *Server) handleDots(w http.ResponseWriter, r *http.Request) {
 		radius = rVal
 	}
 
-	etag := fmt.Sprintf("\"%d-%d-%f\"", width, height, radius)
+	etag := fmt.Sprintf("\"%d-%d-%g\"", width, height, radius)
 	w.Header().Set("ETag", etag)
 	w.Header().Set("Cache-Control", "public, max-age=31536000")
 
@@ -870,18 +870,10 @@ func (s *Server) handleDots(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "image/svg+xml")
 
-	var sb strings.Builder
-	sb.WriteString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
-	sb.WriteString(fmt.Sprintf("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"%d\" height=\"%d\" fill=\"#fff\">\n", width, height))
+	rStr := strings.TrimPrefix(fmt.Sprintf("%g", radius), "0")
+	svg := fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" fill="#fff"><defs><pattern id="dot" width="1" height="1" patternUnits="userSpaceOnUse"><circle cx=".5" cy=".5" r="%s"/></pattern></defs><rect width="100%%" height="100%%" fill="url(#dot)"/></svg>`, width, height, rStr)
 
-	for y := 0; y < height; y++ {
-		for x := 0; x < width; x++ {
-			sb.WriteString(fmt.Sprintf("<circle cx=\"%f\" cy=\"%f\" r=\"%f\"/>", float64(x)+0.5, float64(y)+0.5, radius))
-		}
-	}
-	sb.WriteString("</svg>\n")
-
-	if _, err := w.Write([]byte(sb.String())); err != nil {
+	if _, err := w.Write([]byte(svg)); err != nil {
 		slog.Error("Failed to write dots SVG", "error", err)
 	}
 }

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -115,10 +115,7 @@ func TestHandleDots(t *testing.T) {
 			rr.Header().Get("Content-Type"), "image/svg+xml")
 	}
 
-	expectedSVG := `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="2" height="1" fill="#fff">
-<circle cx="0.500000" cy="0.500000" r="0.750000"/><circle cx="1.500000" cy="0.500000" r="0.750000"/></svg>
-`
+	expectedSVG := `<svg xmlns="http://www.w3.org/2000/svg" width="2" height="1" fill="#fff"><defs><pattern id="dot" width="1" height="1" patternUnits="userSpaceOnUse"><circle cx=".5" cy=".5" r=".75"/></pattern></defs><rect width="100%" height="100%" fill="url(#dot)"/></svg>`
 
 	if rr.Body.String() != expectedSVG {
 		t.Errorf("handler returned unexpected body: got %v want %v",


### PR DESCRIPTION
- Use SVG pattern instead of iterating over every dot to reduce response size and server load.
- Optimize float formatting for radius to be more concise.
- Use %g for ETag generation for better consistency.
- Update tests to match new SVG output format.