### PR TITLE
feat: show OTA also for HTTP connections

### DIFF
--- a/internal/server/handlers_device.go
+++ b/internal/server/handlers_device.go
@@ -253,19 +253,16 @@ func (s *Server) handleUpdateDeviceGet(w http.ResponseWriter, r *http.Request) {
 	// Check if specific firmware exists for this device
 	firmwareAvailable := false
 	firmwareVersion := "Unknown"
-	// Only offer firmware over HTTPS (the device requires it)
-	if r.URL.Scheme == "https" || r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-		binName := device.Type.FirmwareFilename(device.SwapColors)
-		if binName != "" {
-			firmwarePath := filepath.Join(s.DataDir, "firmware", binName)
-			if _, err := os.Stat(firmwarePath); err == nil {
-				firmwareAvailable = true
+	binName := device.Type.FirmwareFilename(device.SwapColors)
+	if binName != "" {
+		firmwarePath := filepath.Join(s.DataDir, "firmware", binName)
+		if _, err := os.Stat(firmwarePath); err == nil {
+			firmwareAvailable = true
 
-				// Read version
-				v := s.GetFirmwareVersion()
-				if v != "" {
-					firmwareVersion = v
-				}
+			// Read version
+			v := s.GetFirmwareVersion()
+			if v != "" {
+				firmwareVersion = v
 			}
 		}
 	}


### PR DESCRIPTION
Reverts #648 now that devices allow OTA updates over HTTP on the LAN: https://github.com/tronbyt/firmware-esp32/pull/103