### PR TITLE
feat: refactor admin index and simplify device data handling

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -636,7 +636,7 @@ func (d *Device) GetTimezone() string {
 }
 
 // GetNightModeIsActive checks if night mode is currently active for a device.
-func (d *Device) GetNightModeIsActive() bool {
+func (d Device) GetNightModeIsActive() bool {
 	if !d.NightModeEnabled {
 		return false
 	}
@@ -672,7 +672,7 @@ func (d *Device) GetNightModeIsActive() bool {
 }
 
 // GetDimModeIsActive checks if dim mode is active (dimming without full night mode).
-func (d *Device) GetDimModeIsActive() bool {
+func (d Device) GetDimModeIsActive() bool {
 	dimTime := d.DimTime
 	if dimTime == nil || *dimTime == "" {
 		return false
@@ -750,4 +750,13 @@ func (d *Device) GetApp(iname string) *App {
 		}
 	}
 	return nil
+}
+
+// BrightnessUIScale returns the current brightness level (0-5) for the UI.
+func (d Device) BrightnessUIScale() int {
+	var customScale map[int]int
+	if d.CustomBrightnessScale != "" {
+		customScale = ParseCustomBrightnessScale(d.CustomBrightnessScale)
+	}
+	return d.Brightness.UIScale(customScale)
 }

--- a/internal/server/funcmap.go
+++ b/internal/server/funcmap.go
@@ -185,7 +185,7 @@ func tmplDerefOr(v any, def string) string {
 	return fmt.Sprintf("%v", rv.Interface())
 }
 
-func tmplIsPinned(device *data.Device, iname string) bool {
+func tmplIsPinned(device data.Device, iname string) bool {
 	if device.PinnedApp == nil {
 		return false
 	}

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -27,12 +27,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type DeviceWithUIScale struct {
-	Device            *data.Device
-	BrightnessUI      int
-	NightBrightnessUI int
-}
-
 type ColorFilterOption struct {
 	Value string
 	Name  string
@@ -45,13 +39,13 @@ type DeviceTypeOption struct {
 
 // TemplateData is a struct to pass data to HTML templates.
 type TemplateData struct {
-	User                *data.User
-	Users               []data.User // For admin view
-	Config              *config.TemplateConfig
-	Flashes             []string
-	DevicesWithUIScales []DeviceWithUIScale
-	Item                *DeviceWithUIScale // For single item partials
-	Localizer           *i18n.Localizer    // Pass Localizer directly
+	User      *data.User
+	Users     []data.User // For admin view
+	Config    *config.TemplateConfig
+	Flashes   []string
+	Devices   []data.Device
+	Item      *data.Device    // For single item partials
+	Localizer *i18n.Localizer // Pass Localizer directly
 
 	UpdateAvailable  bool
 	LatestReleaseURL string
@@ -92,6 +86,7 @@ type TemplateData struct {
 	IsAutoLoginActive     bool // Indicate if single-user auto-login is active
 	UserCount             int  // Number of users, for registration logic
 	DeleteOnCancel        bool // Indicate if app should be deleted on cancel
+	ReadOnly              bool // Indicate if the view should be read-only
 	Partial               string
 }
 

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -650,6 +650,18 @@
   "Delete User?": {
     "other": "Benutzer löschen?"
   },
+  "Delete User": {
+    "other": "Benutzer löschen"
+  },
+  "No devices found for this user.": {
+    "other": "Keine Geräte für diesen Benutzer gefunden."
+  },
+  "Failed to delete user": {
+    "other": "Benutzer konnte nicht gelöscht werden"
+  },
+  "Error deleting user": {
+    "other": "Fehler beim Löschen des Benutzers"
+  },
   "Edit": {
     "other": "Bearbeiten"
   },

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -650,6 +650,18 @@
   "Delete User?": {
     "other": "Delete User?"
   },
+  "Delete User": {
+    "other": "Delete User"
+  },
+  "No devices found for this user.": {
+    "other": "No devices found for this user."
+  },
+  "Failed to delete user": {
+    "other": "Failed to delete user"
+  },
+  "Error deleting user": {
+    "other": "Error deleting user"
+  },
   "Edit": {
     "other": "Edit"
   },

--- a/web/static/js/manager.js
+++ b/web/static/js/manager.js
@@ -193,7 +193,7 @@ function refreshDeviceCard(deviceId, movedAppIname = null) {
   }
 
   // Fetch the updated device card content
-  fetch(`/?device_id=${deviceId}&partial=device_card`)
+  fetch(`/?device_id=${deviceId}&partial=device_card`, { headers: { 'Cache-Control': 'no-cache' } })
     .then(response => response.text())
     .then(html => {
       // Create a temporary DOM element to parse the response
@@ -1501,6 +1501,8 @@ function restoreDevicePreferences(deviceId) {
   const listBtn = document.getElementById(`listViewBtn-${deviceId}`);
   const gridBtn = document.getElementById(`gridViewBtn-${deviceId}`);
   const collapsedBtn = document.getElementById(`collapsedViewBtn-${deviceId}`);
+
+  if (!appsList || !listBtn || !gridBtn || !collapsedBtn) return;
 
   // Restore view mode
   if (prefs.viewMode === 'grid') {

--- a/web/templates/manager/adminindex.html
+++ b/web/templates/manager/adminindex.html
@@ -3,7 +3,10 @@
 {{ end }}
 {{ define "title" }}{{ t .Localizer "Tronbyt Manager" }}{{ end }}
 {{ define "header" }}
-<h1>{{ t .Localizer "Tronbyt Manager" }}</h1>
+<!-- Add viewport meta tag -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- Include external CSS and JS -->
+<link rel="stylesheet" href="/static/css/manager.css">
 {{ end }}
 {{ define "content" }}
 {{ if .User }}
@@ -13,88 +16,25 @@
 <hr>
 {{ end }}
 {{ range .Users }}
-<div class="w3-card-4 w3-padding">
-    <header>
-        <h1>{{ .Username }}</h1>
-        {{ if ne .Username $.User.Username }}
-        <button class="w3-button w3-red w3-round"
-                onclick="deleteUser('{{ .Username }}')">
-            <i class="fa-solid fa-trash"></i> {{ t $.Localizer "Delete" }}
-        </button>
-        {{ end }}
-    </header>
-    {{ if .Devices }}
-    {{ range .Devices }}
-    <div class="w3-card-4 w3-padding">
-        <article>
-            <header>
-                <h1>{{ .Name }}</h1>
-                <table>
-                    <tr>
-                        <td>
-                            <a class="w3-button w3-teal w3-round"
-                               style="min-width: 100px"
-                               href="/devices/{{ .ID }}/update"><i class="fa-solid fa-pen-to-square" aria-hidden="true"></i> {{ t $.Localizer "Edit" }}</a>
-                            <a class="w3-button w3-teal w3-round"
-                               style="min-width: 100px"
-                               href="/devices/{{ .ID }}/addapp"><i class="fa-solid fa-circle-plus" aria-hidden="true"></i> {{ t $.Localizer "Add App" }}</a>
-                        </td>
-                    </tr>
-                </table>
-            </header>
-            <p class="body">{{ t $.Localizer "API ID:" }} {{ .ImgURL }}</p>
-            {{ if .Notes }}
-            <p class="body">{{ t $.Localizer "Notes:" }} {{ .Notes }}</p>
-            {{ end }}
-            {{ if .Apps }}
-            {{ $device := . }}
-            {{ range .Apps }}
-            <div class="w3-card-4 w3-padding">
-                <table width="100%">
-                    <tr width="100%">
-                        <td>
-                            <div class="post">
-                                <header>
-                                    <h1>{{ .Iname }} &nbsp({{ t $.Localizer "installation id" }})</h1>
-                                    <h1>
-                                        {{ if .Enabled }}
-                                        <enabled>&nbsp -- {{ t $.Localizer "Enabled" }} --</enabled>
-                                    {{ else }}
-                                        <disabled>&nbsp -- {{ t $.Localizer "Disabled" }} --</disabled>
-                                        {{ end }}
-                                    </h1>
-                                </header>
-                                <p class="body">{{ t $.Localizer "App:" }} {{ .Name }}</p>
-                                <p class="body">{{ t $.Localizer "Render Interval (minutes):" }} {{ .UInterval }}</p>
-                                <p class="body">{{ t $.Localizer "Display Time (secs):" }} {{ .DisplayTime }}</p>
-                                {{ if .Notes }}
-                                <p class="body">{{ t $.Localizer "Notes:" }} {{ .Notes }}</p>
-                                {{ end }}
-                            </div>
-                        </td>
-                        <td>
-                            <br>
-                            <div class="app-img">
-                                <img width="400"
-                                     height="200"
-                                     src="/devices/{{ $device.ID }}/{{ .Iname }}/appwebp"
-                                     alt="{{ t $.Localizer "Preview" }}">
-                            </div>
-                            <br>
-                            {{ t $.Localizer "Last Rendered:" }} {{ duration .LastRenderDur }}
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <hr>
-            {{ end }}
-            {{ end }}
-        </article>
-    </div>
-    <hr>
-    {{ end }}
+<div class="w3-container w3-blue-grey w3-padding w3-round user-header">
+    <h2 class="user-header-title">{{ .Username }}</h2>
+    {{ if ne .Username $.User.Username }}
+    <button class="w3-button w3-red w3-round"
+            onclick="deleteUser('{{ .Username }}')">
+        <i class="fa-solid fa-trash"></i> {{ t $.Localizer "Delete User" }}
+    </button>
     {{ end }}
 </div>
+{{ if .Devices }}
+{{ $userDevices := .Devices }}
+{{ range .Devices }}
+{{ template "device_card" (dict "Item" . "Localizer" $.Localizer "Devices" $userDevices "ReadOnly" true) }}
+<hr>
+{{ end }}
+{{ else }}
+<p class="no-devices-message">{{ t $.Localizer "No devices found for this user." }}</p>
+<hr>
+{{ end }}
 {{ end }}
 <script>
     function deleteUser(username) {
@@ -106,11 +46,11 @@
             if (response.ok || response.redirected) {
                 window.location.reload();
             } else {
-                alert('Failed to delete user');
+                alert('{{ t .Localizer "Failed to delete user" }}');
             }
         }).catch(err => {
             console.error(err);
-            alert('Error deleting user');
+            alert('{{ t .Localizer "Error deleting user" }}');
         });
     }
 </script>

--- a/web/templates/manager/index.html
+++ b/web/templates/manager/index.html
@@ -15,8 +15,8 @@
    href="/devices/create"><i class="fa-solid fa-circle-plus" aria-hidden="true"></i> {{ t .Localizer "New Tronbyt" }}</a>
 <hr>
 {{ end }}
-{{ range .DevicesWithUIScales }}
-{{ template "device_card" (dict "Item" . "Localizer" $.Localizer "DevicesWithUIScales" $.DevicesWithUIScales) }}
+{{ range .Devices }}
+{{ template "device_card" (dict "Item" . "Localizer" $.Localizer "Devices" $.Devices) }}
 <hr>
 {{ end }}
 {{ end }}

--- a/web/templates/partials/app_card.html
+++ b/web/templates/partials/app_card.html
@@ -1,7 +1,9 @@
 {{ define "app_card" }}
 <!-- App Card Component -->
 <div class="w3-card-4 w3-padding app-card"
+     {{ if not .ReadOnly }}
      draggable="true"
+     {{ end }}
      data-iname="{{ .App.Iname }}">
     <div class="app-card-content">
         <!-- Left: Preview Image -->
@@ -54,6 +56,7 @@
                 <p>{{ t .Localizer "Notes:" }} {{ .App.Notes }}</p>
                 {{ end }}
             </div>
+            {{ if not .ReadOnly }}
             <div class="app-actions">
                 <!-- Primary Actions Row -->
                 <div class="app-actions-primary">
@@ -69,13 +72,12 @@
                             onclick="duplicateApp('{{ .Device.ID }}', '{{ .App.Iname }}')">
                         <i class="fa-solid fa-copy" aria-hidden="true"></i> {{ t .Localizer "Duplicate" }}
                     </button>
-                    {{ if gt (len .DevicesWithUIScales) 1 }}
+                    {{ if gt (len .Devices) 1 }}
                     <div class="copy-to-dropdown">
                         <select class="action w3-button w3-indigo w3-round custom-select"
                                 onchange="if(this.value) { duplicateAppToDevice('{{ .Device.ID }}', '{{ .App.Iname }}', this.value, null, false); this.selectedIndex=0; }">
                             <option value="" disabled selected>{{ t .Localizer "Copy to..." }}</option>
-                            {{ range $item := .DevicesWithUIScales }}
-                            {{ $target_device := $item.Device }}
+                            {{ range $target_device := .Devices }}
                             {{ if ne $target_device.ID $.Device.ID }}
                             <option value="{{ $target_device.ID }}">{{ $target_device.Name }}</option>
                             {{ end }}
@@ -123,6 +125,7 @@
                     {{ end }}
                 </div>
             </div>
+            {{ end }}
         </div>
     </div>
 </div>

--- a/web/templates/partials/device_card.html
+++ b/web/templates/partials/device_card.html
@@ -1,6 +1,6 @@
 {{ define "device_card" }}
 <!-- Device Card Component -->
-<div id="device-card-{{ .Item.Device.ID }}"
+<div id="device-card-{{ .Item.ID }}"
      class="w3-card-4 w3-padding device-container">
     <article>
         <div>
@@ -9,13 +9,13 @@
                     <td colspan="2">
                         <header>
                             <h1>
-                                <a href="{{ .Item.Device.ImgURL }}" target="_blank" class="device-link">{{ .Item.Device.Name }}</a>
-                                {{ if and .Item.Device.PinnedApp (ne (deref .Item.Device.PinnedApp) "") }}
+                                <a href="{{ .Item.ImgURL }}" target="_blank" class="device-link">{{ .Item.Name }}</a>
+                                {{ if and .Item.PinnedApp (ne (deref .Item.PinnedApp) "") }}
                                 <span class="pinned-badge">
                                     <i class="fa-solid fa-thumbtack" aria-hidden="true"></i> {{ t .Localizer "Pinned:" }}
-                                    {{ $pinned := deref .Item.Device.PinnedApp }}
+                                    {{ $pinned := deref .Item.PinnedApp }}
                                     {{ $pinnedName := "" }}
-                                    {{ range .Item.Device.Apps }}
+                                    {{ range .Item.Apps }}
                                     {{ if eq .Iname $pinned }}
                                     {{ $pinnedName = printf "%s-%s" .Name .Iname }}
                                     {{ end }}
@@ -27,12 +27,12 @@
                                     {{ end }}
                                 </span>
                                 {{ end }}
-                                {{ if .Item.Device.GetNightModeIsActive }}
+                                {{ if .Item.GetNightModeIsActive }}
                                 <span class="night-mode-badge"
                                       title="{{ t .Localizer "Night Mode Active" }}">
                                     <i class="fa-solid fa-moon" aria-hidden="true"></i> {{ t .Localizer "Night Mode" }}
                                 </span>
-                                {{ else if .Item.Device.GetDimModeIsActive }}
+                                {{ else if .Item.GetDimModeIsActive }}
                                 <span class="dim-mode-badge" title="{{ t .Localizer "Dim Mode Active" }}">
                                     <i class="fa-solid fa-circle-half-stroke" aria-hidden="true"></i> {{ t .Localizer "Dim Mode" }}
                                 </span>
@@ -42,9 +42,9 @@
                     </td>
                     <td rowspan="4" width="40%">
                         <div class="app-img">
-                            <img id="currentWebp-{{ .Item.Device.ID }}"
-                                 data-src="/devices/{{ .Item.Device.ID }}/current"
-                                 src="/devices/{{ .Item.Device.ID }}/current"
+                            <img id="currentWebp-{{ .Item.ID }}"
+                                 data-src="/devices/{{ .Item.ID }}/current"
+                                 src="/devices/{{ .Item.ID }}/current"
                                  alt="{{ t .Localizer "Preview" }}"
                                  width="128"
                                  height="64">
@@ -53,44 +53,43 @@
                         <div class="device-info-box">
                             <button class="device-info-toggle"
                                     aria-expanded="false"
-                                    aria-controls="device-info-content-{{ .Item.Device.ID }}">
+                                    aria-controls="device-info-content-{{ .Item.ID }}">
                                 <i class="fas fa-chevron-down"></i> {{ t .Localizer "Device Info" }}
                             </button>
-                            <div id="device-info-content-{{ .Item.Device.ID }}"
-                                 class="device-info-content">
+                            <div id="device-info-content-{{ .Item.ID }}" class="device-info-content">
                                 <table class="device-info-table">
-                                    {{ if .Item.Device.Info.FirmwareVersion }}
+                                    {{ if .Item.Info.FirmwareVersion }}
                                     <tr>
                                         <td>{{ t $.Localizer "Firmware Version:" }}</td>
-                                        <td>{{ .Item.Device.Info.FirmwareVersion }}</td>
+                                        <td>{{ .Item.Info.FirmwareVersion }}</td>
                                     </tr>
                                     {{ end }}
-                                    {{ if .Item.Device.Info.FirmwareType }}
+                                    {{ if .Item.Info.FirmwareType }}
                                     <tr>
                                         <td>{{ t $.Localizer "Firmware Type:" }}</td>
-                                        <td>{{ .Item.Device.Info.FirmwareType }}</td>
+                                        <td>{{ .Item.Info.FirmwareType }}</td>
                                     </tr>
                                     {{ end }}
-                                    {{ if .Item.Device.Info.ProtocolVersion }}
+                                    {{ if .Item.Info.ProtocolVersion }}
                                     <tr>
                                         <td>{{ t $.Localizer "Protocol Version:" }}</td>
-                                        <td>{{ deref .Item.Device.Info.ProtocolVersion }}</td>
+                                        <td>{{ deref .Item.Info.ProtocolVersion }}</td>
                                     </tr>
                                     {{ end }}
-                                    {{ if .Item.Device.Info.MACAddress }}
+                                    {{ if .Item.Info.MACAddress }}
                                     <tr>
                                         <td>{{ t $.Localizer "MAC Address:" }}</td>
-                                        <td>{{ .Item.Device.Info.MACAddress }}</td>
+                                        <td>{{ .Item.Info.MACAddress }}</td>
                                     </tr>
                                     {{ end }}
                                     <tr>
                                         <td>{{ t $.Localizer "Protocol Type:" }}</td>
-                                        <td>{{ .Item.Device.Info.ProtocolType }}</td>
+                                        <td>{{ .Item.Info.ProtocolType }}</td>
                                     </tr>
-                                    {{ if .Item.Device.LastSeen }}
+                                    {{ if .Item.LastSeen }}
                                     <tr>
                                         <td>{{ t $.Localizer "Last Seen:" }}</td>
-                                        <td>{{ timeago $.Localizer .Item.Device.LastSeen }}</td>
+                                        <td>{{ timeago $.Localizer .Item.LastSeen }}</td>
                                     </tr>
                                     {{ end }}
                                 </table>
@@ -102,48 +101,56 @@
                     <td>
                         <label>{{ t .Localizer "Brightness" }}</label>
                         =
-                        <span id="brightnessValue-{{ .Item.Device.ID }}">{{ .Item.BrightnessUI }}</span>
-                        <div class="brightness-panel" id="brightness-panel-{{ .Item.Device.ID }}">
+                        <span id="brightnessValue-{{ .Item.ID }}">{{ .Item.BrightnessUIScale }}</span>
+                        {{ if not .ReadOnly }}
+                        <div class="brightness-panel" id="brightness-panel-{{ .Item.ID }}">
                             {{ range $i := seq 0 5 }}
                             <button type="button"
-                                    class="brightness-btn {{ if eq $.Item.BrightnessUI $i }}active{{ end }}"
+                                    class="brightness-btn {{ if eq $.Item.BrightnessUIScale $i }}active{{ end }}"
                                     data-brightness="{{ $i }}"
-                                    onclick="setBrightness('{{ $.Item.Device.ID }}', {{ $i }})">{{ $i }}</button>
+                                    onclick="setBrightness('{{ $.Item.ID }}', {{ $i }})">{{ $i }}</button>
                             {{ end }}
                         </div>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <label for="default_interval-{{ .Item.Device.ID }}">{{ t .Localizer "App Cycle Time (Seconds)" }}</label>
-                        = <span id="intervalValue-{{ .Item.Device.ID }}">{{
-                        .Item.Device.DefaultInterval }} </span> s
-                        <br>
-                        <input type="range"
-                               name="default_interval"
-                               id="default_interval-{{ .Item.Device.ID }}"
-                               min="1"
-                               max="30"
-                               value="{{ .Item.Device.DefaultInterval }}"
-                               oninput="updateIntervalValue('{{ .Item.Device.ID }}', this.value)"
-                               onmouseup="updateInterval('{{ .Item.Device.ID }}', this.value)">
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <a class="w3-button w3-teal w3-round"
-                           style="min-width: 100px"
-                           href="/devices/{{ .Item.Device.ID }}/addapp"><i class="fa-solid fa-circle-plus" aria-hidden="true"></i> {{ t .Localizer "Add App" }}</a>
-                        <a class="w3-button w3-teal w3-round"
-                           style="min-width: 100px"
-                           href="/devices/{{ .Item.Device.ID }}/update"><i class="fa-solid fa-pen-to-square" aria-hidden="true"></i> {{ t .Localizer "Edit Device" }}</a>
-                        {{ if .Item.Device.Type.SupportsFirmware }}
-                        <a class="w3-button w3-teal w3-round"
-                           style="min-width: 100px"
-                           href="/devices/{{ .Item.Device.ID }}/firmware"><i class="fa-solid fa-microchip" aria-hidden="true"></i> {{ t .Localizer "Firmware" }}</a>
                         {{ end }}
                     </td>
                 </tr>
+                <tr>
+                    <td>
+                        <label for="default_interval-{{ .Item.ID }}">{{ t .Localizer "App Cycle Time (Seconds)" }}</label>
+                        = <span id="intervalValue-{{ .Item.ID }}">{{
+                        .Item.DefaultInterval }} </span> s
+                        <br>
+                        <input type="range"
+                               name="default_interval"
+                               id="default_interval-{{ .Item.ID }}"
+                               min="1"
+                               max="30"
+                               value="{{ .Item.DefaultInterval }}"
+                               {{ if .ReadOnly }}
+                               disabled
+                               {{ else }}
+                               oninput="updateIntervalValue('{{ .Item.ID }}', this.value)"
+                               onmouseup="updateInterval('{{ .Item.ID }}', this.value)"
+                               {{ end }}>
+                    </td>
+                </tr>
+                {{ if not .ReadOnly }}
+                <tr>
+                    <td>
+                        <a class="w3-button w3-teal w3-round"
+                           style="min-width: 100px"
+                           href="/devices/{{ .Item.ID }}/addapp"><i class="fa-solid fa-circle-plus" aria-hidden="true"></i> {{ t .Localizer "Add App" }}</a>
+                        <a class="w3-button w3-teal w3-round"
+                           style="min-width: 100px"
+                           href="/devices/{{ .Item.ID }}/update"><i class="fa-solid fa-pen-to-square" aria-hidden="true"></i> {{ t .Localizer "Edit Device" }}</a>
+                        {{ if .Item.Type.SupportsFirmware }}
+                        <a class="w3-button w3-teal w3-round"
+                           style="min-width: 100px"
+                           href="/devices/{{ .Item.ID }}/firmware"><i class="fa-solid fa-microchip" aria-hidden="true"></i> {{ t .Localizer "Firmware" }}</a>
+                        {{ end }}
+                    </td>
+                </tr>
+                {{ end }}
             </table>
             <!-- View Toggle Row -->
             <div class="view-toggle-row"
@@ -154,32 +161,34 @@
                      style="display: flex;
                             align-items: center">
                     <span style="margin-right: 10px; font-weight: bold;">{{ t .Localizer "View:" }}</span>
-                    <button id="listViewBtn-{{ .Item.Device.ID }}"
+                    <button id="listViewBtn-{{ .Item.ID }}"
                             class="w3-button w3-blue w3-round view-toggle-btn active"
-                            onclick="switchToListView('{{ .Item.Device.ID }}')"
+                            onclick="switchToListView('{{ .Item.ID }}')"
                             title="{{ t .Localizer "List View" }}">
                         <i class="fas fa-list"></i> {{ t .Localizer "List" }}
                     </button>
-                    <button id="gridViewBtn-{{ .Item.Device.ID }}"
+                    <button id="gridViewBtn-{{ .Item.ID }}"
                             class="w3-button w3-blue w3-round view-toggle-btn"
-                            onclick="switchToGridView('{{ .Item.Device.ID }}')"
+                            onclick="switchToGridView('{{ .Item.ID }}')"
                             title="{{ t .Localizer "Grid View" }}">
                         <i class="fas fa-th"></i> {{ t .Localizer "Grid" }}
                     </button>
-                    <button id="collapsedViewBtn-{{ .Item.Device.ID }}"
+                    <button id="collapsedViewBtn-{{ .Item.ID }}"
                             class="w3-button w3-blue w3-round view-toggle-btn"
-                            onclick="switchToCollapsedView('{{ .Item.Device.ID }}')"
+                            onclick="switchToCollapsedView('{{ .Item.ID }}')"
                             title="{{ t .Localizer "Collapsed View" }}">
                         <i class="fas fa-chevron-up"></i> {{ t .Localizer "Collapsed" }}
                     </button>
                 </div>
+                {{ if not .ReadOnly }}
                 <div class="instruction-text" style="color: #666; font-style: italic;">
                     {{ t .Localizer "Drag apps to reorder or copy from/to another device" }}
                 </div>
+                {{ end }}
             </div>
-            <div id="appsList-{{ .Item.Device.ID }}" class="visible apps-list-view">
-                {{ range .Item.Device.Apps }}
-                {{ template "app_card" (dict "App" . "Device" $.Item.Device "Localizer" $.Localizer "DevicesWithUIScales" $.DevicesWithUIScales) }}
+            <div id="appsList-{{ .Item.ID }}" class="visible apps-list-view">
+                {{ range .Item.Apps }}
+                {{ template "app_card" (dict "App" . "Device" $.Item "Localizer" $.Localizer "Devices" $.Devices "ReadOnly" $.ReadOnly) }}
                 <hr class="list-view-separator">
                 {{ end }}
             </div>


### PR DESCRIPTION
- **Admin Index Refactor**: Updated `adminindex.html` to use the shared `device_card` and `app_card` partials, providing a consistent look and feel with the main dashboard. Added a `ReadOnly` mode to these partials to disable interactive elements (buttons, dragging) in the admin view.
- **Simplify Data Structures**: Removed `AdminUsersWithDevices` and `DeviceWithUIScale` wrapper structs. The `TemplateData` now uses `[]data.User` and `[]data.Device` directly.
- **Model Improvements**: Added `BrightnessUIScale()` method to `data.Device` to encapsulate UI brightness logic. Changed `GetNightModeIsActive`, `GetDimModeIsActive`, and `BrightnessUIScale` to use value receivers, fixing template evaluation errors when devices are passed as interfaces.
- **Template Updates**: Updated `device_card.html` and `app_card.html` to work with direct `data.Device` objects and the renamed `Devices` list.