### PR TITLE
fix: Support .webp-only apps in user library

### DIFF
--- a/internal/apps/apps.go
+++ b/internal/apps/apps.go
@@ -207,10 +207,15 @@ func scanUserAppsDir(dataDir, username, subDir, defaultSummary string) ([]AppMet
 				continue // Skip to next app directory
 			}
 			var starFile string
+			var webpFile string
 			for _, f := range files {
 				if filepath.Ext(f.Name()) == ".star" {
 					starFile = f.Name()
 					break
+				}
+				// Also check for a webp file with the same name as the app
+				if f.Name() == appName+".webp" {
+					webpFile = f.Name()
 				}
 			}
 
@@ -235,6 +240,17 @@ func scanUserAppsDir(dataDir, username, subDir, defaultSummary string) ([]AppMet
 					userApp.Date = info.ModTime().Format("2006-01-02 15:04")
 				}
 
+				apps = append(apps, userApp)
+			} else if webpFile != "" {
+				// No .star file, but we have a .webp file matching the app name
+				userApp.FileName = webpFile
+				userApp.Path = filepath.Join("users", username, subDir, appName, webpFile)
+				userApp.Preview = webpFile
+
+				// Use file mod time as date
+				if info, err := os.Stat(filepath.Join(appDir, webpFile)); err == nil {
+					userApp.Date = info.ModTime().Format("2006-01-02 15:04")
+				}
 				apps = append(apps, userApp)
 			}
 		}

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -301,10 +301,12 @@ func (s *Server) handleConfigAppGet(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Invalid app path", http.StatusBadRequest)
 			return
 		} else {
-			schemaBytes, err = renderer.GetSchema(appPath, 64, 32, device.Type.Supports2x())
-			if err != nil {
-				slog.Error("Failed to get app schema", "error", err)
-				// Fall through with empty schema
+			if !strings.HasSuffix(strings.ToLower(appPath), ".webp") {
+				schemaBytes, err = renderer.GetSchema(appPath, 64, 32, device.Type.Supports2x())
+				if err != nil {
+					slog.Error("Failed to get app schema", "error", err)
+					// Fall through with empty schema
+				}
 			}
 		}
 	}

--- a/internal/server/render_utils.go
+++ b/internal/server/render_utils.go
@@ -60,6 +60,15 @@ func (s *Server) RenderApp(ctx context.Context, device *data.Device, app *data.A
 		filters = s.getEffectiveFilters(device, app)
 	}
 
+	// 2. Static WebP App
+	if strings.HasSuffix(strings.ToLower(appPath), ".webp") {
+		content, err := os.ReadFile(appPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read static webp app: %w", err)
+		}
+		return content, nil, nil
+	}
+
 	return renderer.Render(
 		ctx,
 		appPath,


### PR DESCRIPTION
- Update scanUserAppsDir to detect apps defined by a single .webp file.
- Update RenderApp to return file content directly for .webp apps.
- Skip schema generation in handleConfigAppGet for .webp apps to prevent errors.