### PR TITLE
fix: fix migration for broken timestamps in Python backend

### DIFF
--- a/internal/legacy/converter.go
+++ b/internal/legacy/converter.go
@@ -76,7 +76,7 @@ func (ld *LegacyDevice) ToDataDevice(username string) data.Device {
 	if ld.DimTime != nil {
 		nd.DimTime = ld.DimTime
 	}
-	if ld.Timezone != nil {
+	if ld.Timezone != nil && strings.ToLower(*ld.Timezone) != "none" {
 		nd.Timezone = ld.Timezone
 	}
 	if ld.Locale != nil {
@@ -101,7 +101,7 @@ func (ld *LegacyDevice) ToDataDevice(username string) data.Device {
 			Lat:         ParseFloat(ld.Location.Lat),
 			Lng:         ParseFloat(ld.Location.Lng),
 		}
-		if ld.Location.Timezone != nil {
+		if ld.Location.Timezone != nil && strings.ToLower(*ld.Location.Timezone) != "none" {
 			nd.Location.Timezone = *ld.Location.Timezone
 		}
 	}


### PR DESCRIPTION
The migration functions from the legacy Python backend to the new Go backend are not accounting for broken timestamps from the Python version, allowing for "None" values to slip through.

This PR fixes the migration functions to account for this. Note this does not exist already migrated backends, but there is a relatively simple workaround for that:

```sh
export TZ="Europe/Berlin"
sqlite tronbyt.db "UPDATE devices SET timezone = '$TZ' WHERE timezone = 'None';"
```

I haven't really tested the migration locally. If you have any tips on how I could get my hands on a quick testing Python database, let me know. Otherwise, I'll take some time tomorrow to test this change before I merge this.