### PR TITLE
fix: improve git repo recovery and sqlite locking resilience

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -80,17 +80,13 @@ func openDB(dsn, logLevel string) (*gorm.DB, error) {
 		db, err = gorm.Open(mysql.Open(dsn), gormConfig)
 	} else {
 		slog.Info("Using SQLite DB", "path", dsn)
-		if !strings.Contains(dsn, "_busy_timeout") {
-			if strings.Contains(dsn, "?") {
-				dsn += "&_busy_timeout=5000"
-			} else {
-				dsn += "?_busy_timeout=5000"
-			}
-		}
 		db, err = gorm.Open(sqlite.Open(dsn), gormConfig)
 		if err == nil {
 			if err := db.Exec("PRAGMA journal_mode=WAL;").Error; err != nil {
 				slog.Warn("Failed to set WAL mode for SQLite", "error", err)
+			}
+			if err := db.Exec("PRAGMA busy_timeout=5000;").Error; err != nil {
+				slog.Warn("Failed to set busy timeout for SQLite", "error", err)
 			}
 		}
 	}

--- a/deploy/googlecloud/startup.sh
+++ b/deploy/googlecloud/startup.sh
@@ -98,10 +98,6 @@ chown -R 1000:1000 ./data ./redis_data
 echo "Creating .env file..."
 
 cat <<EOF > .env
-SERVER_PORT=8000
-SYSTEM_APPS_REPO=https://github.com/tidbyt/community
-PRODUCTION=1
-ENABLE_USER_REGISTRATION=0
 REDIS_URL=redis://redis:6379
 EOF
 

--- a/internal/gitutils/git.go
+++ b/internal/gitutils/git.go
@@ -206,7 +206,11 @@ func EnsureRepo(path string, repoURL string, token string, update bool) error {
 	remoteRefName := plumbing.ReferenceName(fmt.Sprintf("refs/remotes/origin/%s", branchName))
 	remoteRef, err := r.Reference(remoteRefName, true)
 	if err != nil {
-		return fmt.Errorf("failed to find remote ref %s: %w", remoteRefName, err)
+		slog.Warn("Failed to find remote ref, re-cloning", "ref", remoteRefName, "error", err)
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("failed to remove broken repo: %w", err)
+		}
+		return EnsureRepo(path, repoURL, token, update)
 	}
 
 	// Hard Reset the worktree to the remote commit

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -43,6 +43,11 @@ func MigrateLegacyDB(oldDBPath, newDBLocation, dataDir string) error {
 	} else {
 		slog.Info("Using SQLite for new DB")
 		newDB, err = gorm.Open(sqlite.Open(newDBLocation), &gorm.Config{})
+		if err == nil {
+			if err := newDB.Exec("PRAGMA busy_timeout=5000;").Error; err != nil {
+				slog.Warn("Failed to set busy timeout for new SQLite DB", "error", err)
+			}
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
- internal/gitutils: auto-recover from 'reference not found' errors by re-cloning
- cmd/server: use PRAGMA busy_timeout instead of DSN manipulation for SQLite
- internal/migration: add busy_timeout to migration DB connection
- deploy/googlecloud: remove hardcoded env defaults in startup script