### PR TITLE
feat: add sntp_server and syslog_addr firmware settings

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -406,6 +406,8 @@ type DeviceInfo struct {
 	SwapColors         *bool        `json:"swap_colors"`
 	ImageURL           *string      `json:"image_url"`
 	Hostname           *string      `json:"hostname"`
+	SNTPServer         *string      `json:"sntp_server"`
+	SyslogAddr         *string      `json:"syslog_addr"`
 }
 
 func (i DeviceInfo) Value() (driver.Value, error) {

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -88,6 +88,8 @@ type DeviceInfo struct {
 	SwapColors         *bool   `json:"swapColors,omitempty"`
 	ImageURL           *string `json:"imageUrl,omitempty"`
 	Hostname           *string `json:"hostname,omitempty"`
+	SNTPServer         *string `json:"sntpServer,omitempty"`
+	SyslogAddr         *string `json:"syslogAddr,omitempty"`
 }
 
 // toDevicePayload converts a data.Device model to a DevicePayload for API responses.
@@ -106,6 +108,8 @@ func (s *Server) toDevicePayload(d *data.Device) DevicePayload {
 		SwapColors:         d.Info.SwapColors,
 		ImageURL:           d.Info.ImageURL,
 		Hostname:           d.Info.Hostname,
+		SNTPServer:         d.Info.SNTPServer,
+		SyslogAddr:         d.Info.SyslogAddr,
 	}
 
 	var lastSeen *string
@@ -668,6 +672,8 @@ type FirmwareSettingsUpdate struct {
 	WifiPowerSave      *int    `json:"wifiPowerSave"`
 	ImageURL           *string `json:"imageUrl"`
 	Hostname           *string `json:"hostname"`
+	SNTPServer         *string `json:"sntpServer"`
+	SyslogAddr         *string `json:"syslogAddr"`
 }
 
 func (s *Server) handleUpdateFirmwareSettingsAPI(w http.ResponseWriter, r *http.Request) {
@@ -701,6 +707,12 @@ func (s *Server) handleUpdateFirmwareSettingsAPI(w http.ResponseWriter, r *http.
 	}
 	if update.Hostname != nil {
 		payload["hostname"] = *update.Hostname
+	}
+	if update.SNTPServer != nil {
+		payload["sntp_server"] = *update.SNTPServer
+	}
+	if update.SyslogAddr != nil {
+		payload["syslog_addr"] = *update.SyslogAddr
 	}
 
 	if len(payload) == 0 {

--- a/internal/server/handlers_device.go
+++ b/internal/server/handlers_device.go
@@ -928,6 +928,12 @@ func (s *Server) handleUpdateFirmwareSettings(w http.ResponseWriter, r *http.Req
 	if val := r.FormValue("hostname"); val != "" {
 		payload["hostname"] = val
 	}
+	if val := r.FormValue("sntp_server"); val != "" {
+		payload["sntp_server"] = val
+	}
+	if val := r.FormValue("syslog_addr"); val != "" {
+		payload["syslog_addr"] = val
+	}
 
 	if len(payload) == 0 {
 		http.Error(w, "No settings provided", http.StatusBadRequest)

--- a/internal/server/websockets.go
+++ b/internal/server/websockets.go
@@ -40,6 +40,8 @@ type ClientInfo struct {
 	SwapColors         *bool   `json:"swap_colors"`
 	ImageURL           *string `json:"image_url"`
 	Hostname           *string `json:"hostname"`
+	SNTPServer         *string `json:"sntp_server"`
+	SyslogAddr         *string `json:"syslog_addr"`
 }
 
 type WSEvent struct {
@@ -147,6 +149,12 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 				}
 				if msg.ClientInfo.Hostname != nil {
 					device.Info.Hostname = msg.ClientInfo.Hostname
+				}
+				if msg.ClientInfo.SNTPServer != nil {
+					device.Info.SNTPServer = msg.ClientInfo.SNTPServer
+				}
+				if msg.ClientInfo.SyslogAddr != nil {
+					device.Info.SyslogAddr = msg.ClientInfo.SyslogAddr
 				}
 
 				if _, err := gorm.G[data.Device](s.DB).Where("id = ?", device.ID).Update(context.Background(), "info", device.Info); err != nil {

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -1586,11 +1586,29 @@
   "Hostname": {
     "other": "Hostname"
   },
+  "SNTP Server": {
+    "other": "SNTP-Server"
+  },
+  "Syslog Address": {
+    "other": "Syslog-Adresse"
+  },
+  "SNTP Server:": {
+    "other": "SNTP-Server:"
+  },
+  "Syslog Address:": {
+    "other": "Syslog-Adresse:"
+  },
   "Sync current Image URL to device via WebSocket": {
     "other": "Aktuelle Bild-URL via WebSocket an Gerät senden"
   },
   "Sync Hostname to device via WebSocket": {
     "other": "Hostname via WebSocket an Gerät senden"
+  },
+  "Sync SNTP Server to device via WebSocket": {
+    "other": "SNTP-Server via WebSocket an Gerät senden"
+  },
+  "Sync Syslog Address to device via WebSocket": {
+    "other": "Syslog-Adresse via WebSocket an Gerät senden"
   },
   "Swap Colors": {
     "other": "Farben tauschen"

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -1577,11 +1577,29 @@
   "Hostname": {
     "other": "Hostname"
   },
+  "SNTP Server": {
+    "other": "SNTP Server"
+  },
+  "Syslog Address": {
+    "other": "Syslog Address"
+  },
+  "SNTP Server:": {
+    "other": "SNTP Server:"
+  },
+  "Syslog Address:": {
+    "other": "Syslog Address:"
+  },
   "Sync current Image URL to device via WebSocket": {
     "other": "Sync current Image URL to device via WebSocket"
   },
   "Sync Hostname to device via WebSocket": {
     "other": "Sync Hostname to device via WebSocket"
+  },
+  "Sync SNTP Server to device via WebSocket": {
+    "other": "Sync SNTP Server to device via WebSocket"
+  },
+  "Sync Syslog Address to device via WebSocket": {
+    "other": "Sync Syslog Address to device via WebSocket"
   },
   "Swap Colors": {
     "other": "Swap Colors"

--- a/web/templates/manager/update.html
+++ b/web/templates/manager/update.html
@@ -742,6 +742,44 @@
                 </tr>
                 <tr>
                     <td>
+                        <label class="device-settings-label">{{ t .Localizer "SNTP Server" }}</label>
+                    </td>
+                    <td>
+                        <div class="firmware-setting-control">
+                            <input type="text"
+                                   id="reported_sntp_server"
+                                   value="{{ derefOr .Device.Info.SNTPServer "" }}"
+                                   class="device-settings-input firmware-setting-input">
+                            <button type="button"
+                                    class="w3-button w3-small w3-blue firmware-setting-button"
+                                    onclick="updateFirmwareSettings({sntp_server: document.getElementById('reported_sntp_server').value})"
+                                    title="{{ t .Localizer "Sync SNTP Server to device via WebSocket" }}">
+                                <i class="fa-solid fa-sync"></i>
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <label class="device-settings-label">{{ t .Localizer "Syslog Address" }}</label>
+                    </td>
+                    <td>
+                        <div class="firmware-setting-control">
+                            <input type="text"
+                                   id="reported_syslog_addr"
+                                   value="{{ derefOr .Device.Info.SyslogAddr "" }}"
+                                   class="device-settings-input firmware-setting-input">
+                            <button type="button"
+                                    class="w3-button w3-small w3-blue firmware-setting-button"
+                                    onclick="updateFirmwareSettings({syslog_addr: document.getElementById('reported_syslog_addr').value})"
+                                    title="{{ t .Localizer "Sync Syslog Address to device via WebSocket" }}">
+                                <i class="fa-solid fa-sync"></i>
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <label class="device-settings-label">{{ t .Localizer "Swap Colors" }}</label>
                     </td>
                     <td>

--- a/web/templates/partials/device_card.html
+++ b/web/templates/partials/device_card.html
@@ -88,6 +88,18 @@
                                         <td>{{ .Item.Info.Hostname }}</td>
                                     </tr>
                                     {{ end }}
+                                    {{ if .Item.Info.SNTPServer }}
+                                    <tr>
+                                        <td>{{ t $.Localizer "SNTP Server:" }}</td>
+                                        <td>{{ .Item.Info.SNTPServer }}</td>
+                                    </tr>
+                                    {{ end }}
+                                    {{ if .Item.Info.SyslogAddr }}
+                                    <tr>
+                                        <td>{{ t $.Localizer "Syslog Address:" }}</td>
+                                        <td>{{ .Item.Info.SyslogAddr }}</td>
+                                    </tr>
+                                    {{ end }}
                                     {{ if .Item.Info.SSID }}
                                     <tr>
                                         <td>{{ t $.Localizer "WiFi SSID:" }}</td>


### PR DESCRIPTION
Adds optional SNTP Server and Syslog Address fields to DeviceInfo, API, Websockets, and Web UI (device update page and info card).