### PR TITLE
fix: Copy-to is hidden after pressing any action button

### DIFF
--- a/internal/server/handlers_user.go
+++ b/internal/server/handlers_user.go
@@ -48,8 +48,14 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Always pass ALL user.Devices so app_card can show "Copy to" dropdown with all devices
-	tmplData := TemplateData{User: user, Devices: user.Devices}
+	// Build lightweight device list for "Copy to" dropdown
+	allDevices := make([]DeviceSummary, len(user.Devices))
+	for i, d := range user.Devices {
+		allDevices[i] = DeviceSummary{ID: d.ID, Name: d.Name}
+	}
+
+	// Devices: filtered list for rendering, AllDevices: lightweight list for "Copy to" dropdown
+	tmplData := TemplateData{User: user, Devices: devices, AllDevices: allDevices}
 	if partial == "device_card" && len(devices) == 1 {
 		tmplData.Partial = "device_card"
 		tmplData.Item = &devices[0]

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -41,15 +41,22 @@ type DeviceTypeOption struct {
 	Label string
 }
 
+// DeviceSummary is a lightweight struct for "Copy to" dropdown targets.
+type DeviceSummary struct {
+	ID   string
+	Name string
+}
+
 // TemplateData is a struct to pass data to HTML templates.
 type TemplateData struct {
-	User      *data.User
-	Users     []data.User // For admin view
-	Config    *config.TemplateConfig
-	Flashes   []string
-	Devices   []data.Device
-	Item      *data.Device    // For single item partials
-	Localizer *i18n.Localizer // Pass Localizer directly
+	User       *data.User
+	Users      []data.User // For admin view
+	Config     *config.TemplateConfig
+	Flashes    []string
+	Devices    []data.Device   // Filtered devices for rendering
+	AllDevices []DeviceSummary // Lightweight list for "Copy to" dropdown
+	Item       *data.Device    // For single item partials
+	Localizer  *i18n.Localizer
 
 	UpdateAvailable  bool
 	LatestReleaseURL string

--- a/web/templates/manager/index.html
+++ b/web/templates/manager/index.html
@@ -16,7 +16,7 @@
 <hr>
 {{ end }}
 {{ range .Devices }}
-{{ template "device_card" (dict "Item" . "Localizer" $.Localizer "Devices" $.Devices) }}
+{{ template "device_card" (dict "Item" . "Localizer" $.Localizer "Devices" $.Devices "AllDevices" $.AllDevices) }}
 <hr>
 {{ end }}
 {{ end }}

--- a/web/templates/partials/device_card.html
+++ b/web/templates/partials/device_card.html
@@ -212,7 +212,7 @@
             </div>
             <div id="appsList-{{ .Item.ID }}" class="visible apps-list-view">
                 {{ range .Item.Apps }}
-                {{ template "app_card" (dict "App" . "Device" $.Item "Localizer" $.Localizer "Devices" $.Devices "ReadOnly" $.ReadOnly) }}
+                {{ template "app_card" (dict "App" . "Device" $.Item "Localizer" $.Localizer "Devices" $.AllDevices "ReadOnly" $.ReadOnly) }}
                 <hr class="list-view-separator">
                 {{ end }}
             </div>


### PR DESCRIPTION
When user has multiple devices and clicks any action button (pin, enable etc.) copy to is hidden until page refresh. 

When fetching a partial for a specific device, devices is filtered to only contain that one device. Then this is passed to the template as .Devices, which only has 1 element. The app_card template checks {{ if gt (len .Devices) 1 }} - and since there's only 1 device in the filtered list, the "Copy to" dropdown is hidden.

The fix is to pass all user devices to the template, not just the filtered one.