### PR TITLE
fix: handle Unix epoch in humanizeTime

### DIFF
--- a/internal/server/funcmap.go
+++ b/internal/server/funcmap.go
@@ -80,12 +80,12 @@ func humanizeTime(localizer *i18n.Localizer, ts any, prefix string) string {
 		}
 		t = time.Unix(v, 0)
 	case time.Time:
-		if v.IsZero() {
+		if v.IsZero() || v.Unix() == 0 {
 			return tmplT(localizer, "Never")
 		}
 		t = v
 	case *time.Time:
-		if v == nil || v.IsZero() {
+		if v == nil || v.IsZero() || v.Unix() == 0 {
 			return tmplT(localizer, "Never")
 		}
 		t = *v

--- a/internal/server/funcmap_test.go
+++ b/internal/server/funcmap_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
+)
+
+func TestHumanizeTime(t *testing.T) {
+	bundle := i18n.NewBundle(language.English)
+	localizer := i18n.NewLocalizer(bundle, "en")
+
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{
+			name:     "Zero Time",
+			input:    time.Time{},
+			expected: "Never",
+		},
+		{
+			name:     "Nil Pointer",
+			input:    (*time.Time)(nil),
+			expected: "Never",
+		},
+		{
+			name:     "Int64 Zero",
+			input:    int64(0),
+			expected: "Never",
+		},
+		{
+			name:     "Epoch Time",
+			input:    time.Unix(0, 0),
+			expected: "Never",
+		},
+		{
+			name:     "Epoch Time UTC",
+			input:    time.Unix(0, 0).UTC(),
+			expected: "Never",
+		},
+		{
+			name:     "Epoch Pointer",
+			input:    func() *time.Time { t := time.Unix(0, 0); return &t }(),
+			expected: "Never",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Using "TimeAgo" as prefix since it uses humanizeTime internally
+			result := humanizeTime(localizer, tt.input, "TimeAgo")
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
- Update humanizeTime to treat Unix epoch as "Never"
- Add unit tests for humanizeTime