### PR TITLE
perf: sort apps and devices in DB query

### DIFF
--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -589,3 +589,9 @@ func (s *Server) sendRebootCommand(deviceID string) error {
 	s.Broadcaster.Notify(deviceID, DeviceCommandMessage{Payload: rebootPayloadJSON})
 	return nil
 }
+
+// orderedAppsPreload defines a GORM preload function to sort associated apps by their 'order' field.
+var orderedAppsPreload = func(db gorm.PreloadBuilder) error {
+	db.Order(clause.OrderByColumn{Column: clause.Column{Name: "order"}, Desc: false})
+	return nil
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -55,7 +55,7 @@ func (s *Server) APIAuthMiddleware(next http.Handler) http.Handler {
 				db.Order("name ASC")
 				return nil
 			}).
-			Preload("Devices.Apps", nil).
+			Preload("Devices.Apps", orderedAppsPreload).
 			Where("api_key = ?", apiKey).
 			First(r.Context())
 
@@ -72,7 +72,7 @@ func (s *Server) APIAuthMiddleware(next http.Handler) http.Handler {
 		}
 
 		// 2. Try to find Device by API Key
-		device, err := gorm.G[data.Device](s.DB).Preload("Apps", nil).Where("api_key = ?", apiKey).First(r.Context())
+		device, err := gorm.G[data.Device](s.DB).Preload("Apps", orderedAppsPreload).Where("api_key = ?", apiKey).First(r.Context())
 		if err != nil {
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
 				slog.Error("API auth: database error when finding device by key", "error", err)
@@ -85,7 +85,7 @@ func (s *Server) APIAuthMiddleware(next http.Handler) http.Handler {
 					db.Order("name ASC")
 					return nil
 				}).
-				Preload("Devices.Apps", nil).
+				Preload("Devices.Apps", orderedAppsPreload).
 				Where("username = ?", device.Username).
 				First(r.Context())
 
@@ -123,7 +123,7 @@ func (s *Server) RequireLogin(next http.HandlerFunc) http.HandlerFunc {
 				db.Order("name ASC")
 				return nil
 			}).
-			Preload("Devices.Apps", nil).
+			Preload("Devices.Apps", orderedAppsPreload).
 			Where("username = ?", username).
 			First(r.Context())
 


### PR DESCRIPTION
Optimized app and device sorting by moving it to the database query layer.

* Updated internal/server/middleware.go to sort Devices.Apps by order in APIAuthMiddleware and RequireLogin.
* Updated internal/server/handlers_user.go to sort Devices by name and Devices.Apps by order in handleAdminIndex.
* Removed manual sorting logic from handleIndex and handleAdminIndex in internal/server/handlers_user.go.