### PR TITLE
feat: support multiple firmware versions and improve download reliability

### DIFF
--- a/internal/firmware/firmware.go
+++ b/internal/firmware/firmware.go
@@ -20,9 +20,9 @@ const (
 	MergedAppOffset = 0x10000
 )
 
-func Generate(dataDir string, deviceType data.DeviceType, ssid, password, url string, swapColors bool) ([]byte, error) {
+func Generate(firmwareDir string, deviceType data.DeviceType, ssid, password, url string, swapColors bool) ([]byte, error) {
 	filename := deviceType.FirmwareFilename(swapColors)
-	path := filepath.Join(dataDir, "firmware", filename)
+	path := filepath.Join(firmwareDir, filename)
 
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -89,9 +89,9 @@ func Generate(dataDir string, deviceType data.DeviceType, ssid, password, url st
 // 1. Generating the injected firmware.bin using Generate()
 // 2. Reading the preamble (bootloader + partition table) from the merged binary
 // 3. Combining preamble + injected firmware.
-func GenerateMerged(dataDir string, deviceType data.DeviceType, ssid, password, url string, swapColors bool) ([]byte, error) {
+func GenerateMerged(firmwareDir string, deviceType data.DeviceType, ssid, password, url string, swapColors bool) ([]byte, error) {
 	// Generate the injected firmware binary
-	firmwareData, err := Generate(dataDir, deviceType, ssid, password, url, swapColors)
+	firmwareData, err := Generate(firmwareDir, deviceType, ssid, password, url, swapColors)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate firmware: %w", err)
 	}
@@ -101,7 +101,7 @@ func GenerateMerged(dataDir string, deviceType data.DeviceType, ssid, password, 
 	if mergedFilename == "" {
 		return nil, fmt.Errorf("merged firmware not available for device type %s", deviceType.String())
 	}
-	mergedPath := filepath.Join(dataDir, "firmware", mergedFilename)
+	mergedPath := filepath.Join(firmwareDir, mergedFilename)
 
 	mergedContent, err := os.ReadFile(mergedPath)
 	if err != nil {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -291,7 +291,11 @@ func (s *Server) handleEditUserGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	firmwareVersion := s.GetFirmwareVersion()
+	// Handle admin view specific data
+	var firmwareVersion string
+	if user.IsAdmin {
+		firmwareVersion = s.GetLatestFirmwareVersion()
+	}
 	if firmwareVersion == "" {
 		firmwareVersion = "unknown"
 	}

--- a/internal/server/firmware_test.go
+++ b/internal/server/firmware_test.go
@@ -57,16 +57,18 @@ func TestHandleFirmwareGeneratePost(t *testing.T) {
 	copy(dummyFirmware[300:], []byte(urlPlaceholder))
 
 	firmwareDir := filepath.Join(s.DataDir, "firmware")
-	if err := os.MkdirAll(firmwareDir, 0755); err != nil {
-		t.Fatalf("Failed to create firmware directory: %v", err)
+	releasesDir := filepath.Join(firmwareDir, "releases", "v1.0.0")
+	if err := os.MkdirAll(releasesDir, 0755); err != nil {
+		t.Fatalf("Failed to create firmware releases directory: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(firmwareDir, "tidbyt-gen1.bin"), dummyFirmware, 0644); err != nil {
+
+	if err := os.WriteFile(filepath.Join(releasesDir, "tidbyt-gen1.bin"), dummyFirmware, 0644); err != nil {
 		t.Fatalf("Failed to write dummy firmware file: %v", err)
 	}
 
 	// Create a dummy merged firmware file (at least MergedAppOffset = 0x10000 bytes)
 	mergedFirmware := make([]byte, 0x10000+len(dummyFirmware))
-	if err := os.WriteFile(filepath.Join(firmwareDir, "tidbyt-gen1_merged.bin"), mergedFirmware, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(releasesDir, "tidbyt-gen1_merged.bin"), mergedFirmware, 0644); err != nil {
 		t.Fatalf("Failed to write dummy merged firmware file: %v", err)
 	}
 

--- a/internal/server/handlers_device.go
+++ b/internal/server/handlers_device.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 
@@ -251,35 +250,27 @@ func (s *Server) handleUpdateDeviceGet(w http.ResponseWriter, r *http.Request) {
 	localizer := s.getLocalizer(r)
 
 	// Check if specific firmware exists for this device
-	firmwareAvailable := false
+	availableVersions := s.GetAvailableFirmwareVersions()
+	firmwareAvailable := len(availableVersions) > 0
 	firmwareVersion := "Unknown"
-	binName := device.Type.FirmwareFilename(device.SwapColors)
-	if binName != "" {
-		firmwarePath := filepath.Join(s.DataDir, "firmware", binName)
-		if _, err := os.Stat(firmwarePath); err == nil {
-			firmwareAvailable = true
-
-			// Read version
-			v := s.GetFirmwareVersion()
-			if v != "" {
-				firmwareVersion = v
-			}
-		}
+	if firmwareAvailable {
+		firmwareVersion = availableVersions[0]
 	}
 
 	s.renderTemplate(w, r, "update", TemplateData{
-		User:               user,
-		Device:             device,
-		DeviceTypeChoices:  s.getDeviceTypeChoices(localizer),
-		ColorFilterOptions: s.getColorFilterChoices(),
-		AvailableLocales:   locales,
-		DefaultImgURL:      s.getImageURL(r, device.ID),
-		DefaultWsURL:       s.getWebsocketURL(r, device.ID),
-		BrightnessUI:       bUI,
-		NightBrightnessUI:  nbUI,
-		DimBrightnessUI:    dbUI,
-		FirmwareAvailable:  firmwareAvailable,
-		FirmwareVersion:    firmwareVersion,
+		User:                      user,
+		Device:                    device,
+		DeviceTypeChoices:         s.getDeviceTypeChoices(localizer),
+		ColorFilterOptions:        s.getColorFilterChoices(),
+		AvailableLocales:          locales,
+		DefaultImgURL:             s.getImageURL(r, device.ID),
+		DefaultWsURL:              s.getWebsocketURL(r, device.ID),
+		BrightnessUI:              bUI,
+		NightBrightnessUI:         nbUI,
+		DimBrightnessUI:           dbUI,
+		FirmwareAvailable:         firmwareAvailable,
+		FirmwareVersion:           firmwareVersion,
+		AvailableFirmwareVersions: availableVersions,
 
 		Localizer: localizer,
 	})

--- a/internal/server/handlers_system.go
+++ b/internal/server/handlers_system.go
@@ -28,7 +28,8 @@ func (s *Server) handleUpdateFirmware(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Header.Get("Accept") == "application/json" {
-		version := s.GetFirmwareVersion()
+		// Firmware version info
+		version := s.GetLatestFirmwareVersion()
 		if version == "" {
 			version = "unknown"
 		}

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -89,16 +89,17 @@ type TemplateData struct {
 	DimBrightnessUI    int
 
 	// Firmware
-	FirmwareBinsAvailable bool
-	FirmwareAvailable     bool
-	FirmwareVersion       string
-	ServerVersion         string
-	CommitHash            string
-	IsAutoLoginActive     bool // Indicate if single-user auto-login is active
-	UserCount             int  // Number of users, for registration logic
-	DeleteOnCancel        bool // Indicate if app should be deleted on cancel
-	ReadOnly              bool // Indicate if the view should be read-only
-	Partial               string
+	FirmwareBinsAvailable     bool
+	FirmwareAvailable         bool
+	FirmwareVersion           string
+	AvailableFirmwareVersions []string
+	ServerVersion             string
+	CommitHash                string
+	IsAutoLoginActive         bool // Indicate if single-user auto-login is active
+	UserCount                 int  // Number of users, for registration logic
+	DeleteOnCancel            bool // Indicate if app should be deleted on cancel
+	ReadOnly                  bool // Indicate if the view should be read-only
+	Partial                   string
 }
 
 // CreateDeviceFormData represents the form data for creating a device.

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -417,7 +417,7 @@
     "other": "Firmware Verwaltung"
   },
   "Current Firmware": {
-    "other": "Aktuelle Firmware:"
+    "other": "Aktuelle Firmware"
   },
   "Version": {
     "other": "Version"
@@ -1517,11 +1517,11 @@
   "Firmware Update": {
     "other": "Firmware-Update"
   },
+  "Downloaded firmware version": {
+    "other": "Heruntergeladene Firmware-Version"
+  },
   "Device Version": {
     "other": "Geräte-Version"
-  },
-  "Available Version": {
-    "other": "Verfügbare Version"
   },
   "Swap Colors (Fix for some Tidbyt Gen 1 displays)": {
     "other": "Farben tauschen (Fix für manche Tidbyt Gen 1 Displays)"
@@ -1531,6 +1531,12 @@
   },
   "Install Latest Firmware": {
     "other": "Neueste Firmware installieren"
+  },
+  "Select Version": {
+    "other": "Version auswählen"
+  },
+  "Install Selected Firmware": {
+    "other": "Ausgewählte Firmware installieren"
   },
   "This will trigger an Over-The-Air update. The device will reboot. Continue?": {
     "other": "Dies startet ein Over-The-Air Update. Das Gerät wird neu starten. Fortfahren?"
@@ -1699,5 +1705,11 @@
   },
   "If you are changing WiFi credentials or the image URL on a previously flashed device, select \"Full Erase\" or \"Erase All Flash\" before flashing. Otherwise the old settings stored on the device will be used instead of the new ones.": {
     "other": "Wenn Sie die WLAN-Zugangsdaten oder die Bild-URL auf einem zuvor geflashten Gerät ändern, wählen Sie vor dem Flashen „Full Erase“ oder „Erase All Flash“. Andernfalls werden die alten auf dem Gerät gespeicherten Einstellungen anstelle der neuen verwendet."
+  },
+  "Add new apps to top of list": {
+    "other": "Neue Apps am Anfang der Liste hinzufügen"
+  },
+  "When enabled, newly added apps will appear at position #1 instead of at the end.": {
+    "other": "Wenn aktiviert, erscheinen neu hinzugefügte Apps an Position #1 anstatt am Ende."
   }
 }

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -1517,11 +1517,11 @@
   "Firmware Update": {
     "other": "Firmware Update"
   },
+  "Downloaded firmware version": {
+    "other": "Downloaded firmware version"
+  },
   "Device Version": {
     "other": "Device Version"
-  },
-  "Available Version": {
-    "other": "Available Version"
   },
   "Swap Colors (Fix for some Tidbyt Gen 1 displays)": {
     "other": "Swap Colors (Fix for some Tidbyt Gen 1 displays)"
@@ -1531,6 +1531,12 @@
   },
   "Install Latest Firmware": {
     "other": "Install Latest Firmware"
+  },
+  "Select Version": {
+    "other": "Select Version"
+  },
+  "Install Selected Firmware": {
+    "other": "Install Selected Firmware"
   },
   "This will trigger an Over-The-Air update. The device will reboot. Continue?": {
     "other": "This will trigger an Over-The-Air update. The device will reboot. Continue?"
@@ -1699,5 +1705,11 @@
   },
   "If you are changing WiFi credentials or the image URL on a previously flashed device, select \"Full Erase\" or \"Erase All Flash\" before flashing. Otherwise the old settings stored on the device will be used instead of the new ones.": {
     "other": "If you are changing WiFi credentials or the image URL on a previously flashed device, select \"Full Erase\" or \"Erase All Flash\" before flashing. Otherwise the old settings stored on the device will be used instead of the new ones."
+  },
+  "Add new apps to top of list": {
+    "other": "Add new apps to top of list"
+  },
+  "When enabled, newly added apps will appear at position #1 instead of at the end.": {
+    "other": "When enabled, newly added apps will appear at position #1 instead of at the end."
   }
 }

--- a/web/static/js/manager.js
+++ b/web/static/js/manager.js
@@ -1793,3 +1793,23 @@ function triggerOTA(deviceId, confirmMessage) {
     form.submit();
   }
 }
+
+function triggerOTAWithVersion(deviceId, confirmMessage) {
+  if (confirm(confirmMessage)) {
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = `/devices/${deviceId}/ota`;
+
+    const select = document.getElementById('firmware_version_select');
+    if (select) {
+        const versionInput = document.createElement('input');
+        versionInput.type = 'hidden';
+        versionInput.name = 'version';
+        versionInput.value = select.value;
+        form.appendChild(versionInput);
+    }
+
+    document.body.appendChild(form);
+    form.submit();
+  }
+}

--- a/web/templates/auth/edit.html
+++ b/web/templates/auth/edit.html
@@ -108,11 +108,10 @@
                 align-items: flex-start;
                 margin-bottom: 15px">
         <div style="flex: 1;">
-            <strong>{{ t .Localizer "Current Firmware" }}</strong>
             {{ if .FirmwareVersion }}
             <div style="margin-top: 8px;">
                 <div style="margin-bottom: 5px;" id="firmware-version">
-                    <strong>{{ t .Localizer "Version" }}:</strong> {{ .FirmwareVersion }}
+                    <strong>{{ t .Localizer "Downloaded firmware version" }}:</strong> {{ .FirmwareVersion }}
                 </div>
                 <div style="color: #888; font-size: 0.9em;">
                     {{ t .Localizer "Firmware is automatically updated when the server starts." }}
@@ -649,7 +648,7 @@
             .then(data => {
                 if (data.version) {
                     const el = document.getElementById('firmware-version');
-                    if (el) el.innerHTML = '<strong>{{ t .Localizer "Version" }}:</strong> ' + data.version;
+                    if (el) el.innerHTML = '<strong>{{ t .Localizer "Downloaded firmware version" }}:</strong> ' + data.version;
                 }
                 if (data.success) {
                     btn.innerHTML = '<i class="fa-solid fa-check"></i> {{ t .Localizer "Success" }}';

--- a/web/templates/manager/firmware.html
+++ b/web/templates/manager/firmware.html
@@ -29,7 +29,23 @@
 {{ if .FirmwareVersion }}
 <div class="firmware-info">
     <div>
-        <strong>{{ t .Localizer "Firmware Image Version" }}:</strong> {{ .FirmwareVersion }}
+        <strong>{{ t .Localizer "Firmware Image Version" }}:</strong>
+        {{ if .AvailableFirmwareVersions }}
+        <select name="version"
+                form="firmware-form"
+                class="device-settings-input"
+                style="width: auto;
+                       display: inline-block;
+                       margin-left: 10px;
+                       padding: 2px 5px">
+            {{ range .AvailableFirmwareVersions }}
+            <option value="{{ . }}" {{ if eq . $.FirmwareVersion }}selected{{ end }}>{{ . }}
+            </option>
+            {{ end }}
+        </select>
+    {{ else }}
+        {{ .FirmwareVersion }}
+        {{ end }}
     </div>
     {{ if .User.IsAdmin }}
     <div>

--- a/web/templates/manager/update.html
+++ b/web/templates/manager/update.html
@@ -651,30 +651,26 @@
             <p>
                 <strong>{{ t .Localizer "Device Version" }}:</strong> {{ if .Device.Info.FirmwareVersion }}{{ .Device.Info.FirmwareVersion }}{{ else }}{{ t .Localizer "Unknown" }}{{ end }}
             </p>
-            {{ if .FirmwareAvailable }}
-            <p>
-                <strong>{{ t .Localizer "Available Version" }}:</strong> {{ if .FirmwareVersion }}{{ .FirmwareVersion }}{{ else }}{{ t .Localizer "Unknown" }}{{ end }}
-            </p>
-            {{ if eq .Device.Type.Slug "tidbyt_gen1" }}
+            {{ if .AvailableFirmwareVersions }}
             <div style="margin-bottom: 10px;">
-                <label for="swap_colors" style="cursor: pointer;">
-                    <input type="checkbox"
-                           name="swap_colors"
-                           id="swap_colors"
-                           {{ if .Device.SwapColors }}
-                           checked
-                           {{ end }}>
-                    {{ t .Localizer "Swap Colors (Fix for some Tidbyt Gen 1 displays)" }}
+                <label for="firmware_version_select">
+                    <strong>{{ t .Localizer "Select Version" }}:</strong>
                 </label>
-                <p class="small-text">
-                    {{ t .Localizer "Note: Changing this setting will require saving before updating firmware." }}
-                </p>
+                <select id="firmware_version_select"
+                        class="device-settings-input"
+                        style="width: auto;
+                               display: inline-block;
+                               margin-left: 10px">
+                    {{ range .AvailableFirmwareVersions }}
+                    <option value="{{ . }}" {{ if eq . $.FirmwareVersion }}selected{{ end }}>{{ . }}
+                    </option>
+                    {{ end }}
+                </select>
             </div>
-            {{ end }}
             <button type="button"
                     class="w3-button w3-blue config-management-btn"
-                    onclick="triggerOTA('{{ .Device.ID }}', '{{ t .Localizer "This will trigger an Over-The-Air update. The device will reboot. Continue?" }}')">
-                <i class="fa-solid fa-cloud-arrow-down"></i> {{ t .Localizer "Install Latest Firmware" }}
+                    onclick="triggerOTAWithVersion('{{ .Device.ID }}', '{{ t .Localizer "This will trigger an Over-The-Air update. The device will reboot. Continue?" }}')">
+                <i class="fa-solid fa-cloud-arrow-down"></i> {{ t .Localizer "Install Selected Firmware" }}
             </button>
             <small class="small-text" style="display: block; margin-top: 5px;">{{ t .Localizer "Updates the device to the latest version available on the server." }}</small>
         {{ else }}


### PR DESCRIPTION
- Fetch and store last 5 firmware releases from GitHub
- Add version selection for OTA updates and firmware generation
- Optimize firmware downloads with ETag caching and atomic writes
- Handle GitHub API rate limits (403) gracefully by using cached files
- Update UI to show downloaded firmware version and allow selection

Fixes https://github.com/tronbyt/server/issues/699