### PR TITLE
fix: improve temp dir handling, firmware updates, and test isolation

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -190,6 +190,10 @@ func main() {
 	dataDir := flag.String("data", cfg.DataDir, "Path to data directory")
 	flag.Parse()
 
+	// Update config with flag values
+	cfg.DataDir = *dataDir
+	cfg.DBDSN = *dbDSN
+
 	if len(flag.Args()) > 0 {
 		cmd := flag.Arg(0)
 		switch cmd {
@@ -296,8 +300,6 @@ func main() {
 	runtime.InitCache(cache)
 
 	srv := server.NewServer(db, cfg)
-	srv.DataDir = *dataDir
-	srv.Config = cfg // Pass the loaded configuration
 
 	// Firmware Update (production only)
 	if cfg.Production == "1" {

--- a/internal/server/firmware.go
+++ b/internal/server/firmware.go
@@ -81,10 +81,10 @@ func (s *Server) UpdateFirmwareBinaries() error {
 	if resp.StatusCode != http.StatusOK {
 		// If we hit a rate limit (403) or other error, check if we have any cached firmware.
 		// If so, we can proceed without failing completely.
-		if resp.StatusCode == http.StatusForbidden {
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
 			releasesDir := filepath.Join(s.DataDir, "firmware", "releases")
 			if entries, err := os.ReadDir(releasesDir); err == nil && len(entries) > 0 {
-				slog.Warn("GitHub API rate limit exceeded (403). Using cached firmware releases.", "count", len(entries))
+				slog.Warn("GitHub API rate limit exceeded. Using cached firmware releases.", "count", len(entries))
 				return nil
 			}
 		}

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -57,10 +57,12 @@ func newTestServerAPI(t *testing.T) *Server {
 		t.Fatalf("Failed to seed system_apps_repo: %v", err)
 	}
 
-	cfg := &config.Settings{}
+	cfg := &config.Settings{
+		Production: "0",
+		DataDir:    t.TempDir(),
+	}
 
 	s := NewServer(db, cfg)
-	s.DataDir = t.TempDir()
 
 	// Setup common test user and device
 	adminUser := data.User{

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -1101,12 +1101,7 @@ func (s *Server) parseManifest(tempExtractDir string) (string, error) {
 func (s *Server) handleZipUpload(w http.ResponseWriter, r *http.Request, user *data.User, device *data.Device, file io.Reader, header *multipart.FileHeader, appName string) error {
 	userAppsDir := filepath.Join(s.DataDir, "users", user.Username, "apps")
 
-	// Create temp dir inside DataDir for containerized environments where /tmp may not exist
-	tmpDir := filepath.Join(s.DataDir, "tmp")
-	if err := os.MkdirAll(tmpDir, 0755); err != nil {
-		slog.Error("Failed to create tmp directory", "error", err)
-		return err
-	}
+	tmpDir := s.GetTmpDir()
 
 	// Save the zip file temporarily
 	tempZip, err := os.CreateTemp(tmpDir, "upload-*.zip")

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -26,7 +26,8 @@ func TestMetricsEndpoint(t *testing.T) {
 
 	// Setup Server
 	cfg := &config.Settings{
-		DataDir: t.TempDir(),
+		DataDir:    t.TempDir(),
+		Production: "0",
 	}
 	s := NewServer(db, cfg)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -29,10 +29,12 @@ func newTestServer(t *testing.T) *Server {
 	db.Create(&data.Setting{Key: "secret_key", Value: "testsecret"})
 	db.Create(&data.Setting{Key: "system_apps_repo", Value: ""})
 
-	cfg := &config.Settings{}
+	cfg := &config.Settings{
+		Production: "0",
+		DataDir:    t.TempDir(),
+	}
 
 	s := NewServer(db, cfg)
-	s.DataDir = t.TempDir()
 	return s
 }
 


### PR DESCRIPTION
- Centralize temporary directory management in Server.GetTmpDir()
- Clean up and recreate 'tmp' directory on server startup to prevent stale files
- Update handleZipUpload to use centralized tmp dir
- Fix DataDir initialization in main.go to respect flags before server creation
- Restore asynchronous firmware update in main.go to avoid blocking startup
- Ensure firmware updates only run in Production mode (Config.Production == "1")
- Initialize tests with Production="0" to prevent accidental network calls