### PR TITLE
download matrixportal merged to use with injection

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -654,8 +654,10 @@ func (dt DeviceType) MergedFilename(swapColors bool) string {
 	switch dt {
 	case DeviceTidbytGen1, DeviceTidbytGen2:
 		return "tidbyt-gen1_merged.bin"
-	case DeviceTronbytS3, DeviceTronbytS3Wide, DeviceMatrixPortal, DeviceMatrixPortalWS:
+	case DeviceTronbytS3, DeviceTronbytS3Wide:
 		return "tronbyt-S3_merged.bin"
+	case DeviceMatrixPortal, DeviceMatrixPortalWS:
+		return "matrixportal-s3_merged.bin"
 	default:
 		return ""
 	}

--- a/internal/server/firmware.go
+++ b/internal/server/firmware.go
@@ -149,8 +149,9 @@ func (s *Server) UpdateFirmwareBinaries() error {
 		"matrixportal-s3_firmware.bin":           "matrixportal-s3.bin",
 		"matrixportal-s3-waveshare_firmware.bin": "matrixportal-s3-waveshare.bin",
 		// Merged binaries (bootloader + partition + app, flashable at 0x0)
-		"tidbyt-gen1_merged.bin": "tidbyt-gen1_merged.bin",
-		"tronbyt-s3_merged.bin":  "tronbyt-S3_merged.bin",
+		"tidbyt-gen1_merged.bin":     "tidbyt-gen1_merged.bin",
+		"tronbyt-s3_merged.bin":      "tronbyt-S3_merged.bin",
+		"matrixportal-s3_merged.bin": "matrixportal-s3_merged.bin",
 	}
 
 	for _, release := range releases {


### PR DESCRIPTION
matrixportal needs it's own merged template for injection due to 8MB flash instead of 16MB