### PR TITLE
chore(config): refactor config to use bools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,19 +2,19 @@
 
 # This is the port that docker will expose externally.  default is 8000
 # SERVER_PORT=443
-# PRODUCTION=1
+# PRODUCTION=true
 # LOG_LEVEL=INFO
-# ENABLE_PPROF=0
+# ENABLE_PPROF=false
 # SYSTEM_APPS_REPO="https://github.com/tronbyt/apps.git"
 
 # User Registration Settings
-# Set to "1" to enable open user registration (anyone can create an account)
-# Set to "0" (default) to only allow admin users to create new accounts
-# ENABLE_USER_REGISTRATION=1
+# Set to "true" to enable open user registration (anyone can create an account)
+# Set to "false" (default) to only allow admin users to create new accounts
+# ENABLE_USER_REGISTRATION=true
 # MAX_USERS=100 # Default is 100
 
 # Single-User Auto-Login Mode
-# Set to "1" to automatically log in when exactly 1 user exists (from private networks only)
+# Set to "true" to automatically log in when exactly 1 user exists (from private networks only)
 # Only works from: localhost, 192.168.x.x, 10.x.x.x, 172.16.x.x
 # Public IPs still require authentication
-# SINGLE_USER_AUTO_LOGIN=1
+# SINGLE_USER_AUTO_LOGIN=true

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The `tronbyt-server` binary supports additional commands for administration:
     ```bash
     curl http://localhost:8000/metrics
     ```
-*   **`/debug/pprof/`**: Exposes Go pprof endpoints when `ENABLE_PPROF=1` is set. Disabled by default.
+*   **`/debug/pprof/`**: Exposes Go pprof endpoints when `ENABLE_PPROF=true` is set. Disabled by default.
 
 **Quick Start Guide:**
 1.  Access the web app at `http://localhost:8000`.
@@ -66,7 +66,7 @@ The `tronbyt-server` binary supports additional commands for administration:
 
 **Ports:** The web app is exposed on port `8000`.
 
-**User Registration:** By default, only the admin can create new user accounts. Open user registration can be enabled by setting `ENABLE_USER_REGISTRATION=1` in the `.env` file.
+**User Registration:** By default, only the admin can create new user accounts. Open user registration can be enabled by setting `ENABLE_USER_REGISTRATION=true` in the `.env` file.
 
 **Updating:**
 *   Docker containers: `docker compose pull && docker compose up -d`.
@@ -83,7 +83,7 @@ If you are upgrading from the Python version (v1.x) and using the default SQLite
 *   For native development:
     *   Run directly: `go run ./cmd/server`.
     *   With live-reloading (using [Air](https://github.com/air-verse/air)):
-        Run: `PRODUCTION=0 go tool air`
+        Run: `PRODUCTION=false go tool air`
 
 **Configuration:**
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -265,7 +265,7 @@ func main() {
 
 	// Clone/Update System Apps Repo
 	systemAppsDir := filepath.Join(*dataDir, "system-apps")
-	shouldUpdate := cfg.Production == "1"
+	shouldUpdate := cfg.Production
 	if err := gitutils.EnsureRepo(systemAppsDir, cfg.SystemAppsRepo, cfg.GitHubToken, shouldUpdate); err != nil {
 		slog.Error("Failed to update system apps repo", "error", err)
 		// Continue anyway
@@ -303,7 +303,7 @@ func main() {
 	srv := server.NewServer(db, cfg)
 
 	// Firmware Update (production only)
-	if cfg.Production == "1" {
+	if cfg.Production {
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -322,7 +322,7 @@ func main() {
 	userCount, err := gorm.G[data.User](db).Count(context.Background(), "*")
 	if err != nil {
 		slog.Error("Failed to count users for auto-login warning", "error", err)
-	} else if cfg.SingleUserAutoLogin == "1" && userCount == 1 {
+	} else if cfg.SingleUserAutoLogin && userCount == 1 {
 		slog.Warn(`
 ======================================================================
 ⚠️  SINGLE-USER AUTO-LOGIN MODE IS ENABLED

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -16,7 +16,7 @@ services:
     environment:
       - PUID=${UID:-1000}
       - PGID=${GID:-${UID:-1000}}
-      - ENABLE_PPROF=1
+      - ENABLE_PPROF=true
       - SYSTEM_APPS_REPO
       - PRODUCTION
       - LOG_LEVEL

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,12 +11,12 @@ import (
 type Settings struct {
 	DBDSN                  string `env:"DB_DSN"                   envDefault:"data/tronbyt.db"`
 	DataDir                string `env:"DATA_DIR"                 envDefault:"data"`
-	Production             string `env:"PRODUCTION"               envDefault:"1"`
-	EnableUserRegistration string `env:"ENABLE_USER_REGISTRATION" envDefault:"1"`
-	EnablePprof            string `env:"ENABLE_PPROF"             envDefault:"0"`
-	MaxUsers               int    `env:"MAX_USERS"                envDefault:"0"`
-	SingleUserAutoLogin    string `env:"SINGLE_USER_AUTO_LOGIN"   envDefault:"0"`
-	SystemAppsAutoRefresh  string `env:"SYSTEM_APPS_AUTO_REFRESH" envDefault:"0"`
+	Production             bool   `env:"PRODUCTION"               envDefault:"true"`
+	EnableUserRegistration bool   `env:"ENABLE_USER_REGISTRATION" envDefault:"true"`
+	EnablePprof            bool   `env:"ENABLE_PPROF"`
+	MaxUsers               int    `env:"MAX_USERS"`
+	SingleUserAutoLogin    bool   `env:"SINGLE_USER_AUTO_LOGIN"`
+	SystemAppsAutoRefresh  bool   `env:"SYSTEM_APPS_AUTO_REFRESH"`
 	SystemAppsRepo         string `env:"SYSTEM_APPS_REPO"         envDefault:"https://github.com/tronbyt/apps.git"`
 	GitHubToken            string `env:"GITHUB_TOKEN"`
 	RedisURL               string `env:"REDIS_URL"`
@@ -27,15 +27,15 @@ type Settings struct {
 	SSLCertFile            string `env:"TRONBYT_SSL_CERTFILE"`
 	TrustedProxies         string `env:"TRONBYT_TRUSTED_PROXIES"  envDefault:"*"`
 	LogLevel               string `env:"LOG_LEVEL"                envDefault:"INFO"`
-	EnableUpdateChecks     string `env:"ENABLE_UPDATE_CHECKS"     envDefault:"1"`
+	EnableUpdateChecks     bool   `env:"ENABLE_UPDATE_CHECKS"     envDefault:"true"`
 }
 
 // TemplateConfig holds configuration values needed in templates.
 type TemplateConfig struct {
-	EnableUserRegistration string
-	SingleUserAutoLogin    string
-	SystemAppsAutoRefresh  string
-	Production             string
+	EnableUserRegistration bool
+	SingleUserAutoLogin    bool
+	SystemAppsAutoRefresh  bool
+	Production             bool
 }
 
 func LoadSettings() (*Settings, error) {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -37,7 +37,7 @@ func (s *Server) handleLoginGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Auto-Login Check
-	if s.Config.SingleUserAutoLogin == "1" {
+	if s.Config.SingleUserAutoLogin {
 		count, err := gorm.G[data.User](s.DB).Count(r.Context(), "*")
 		if err == nil && count == 1 {
 			if s.isTrustedNetwork(r) {
@@ -153,7 +153,7 @@ func (s *Server) handleRegisterGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.Config.EnableUserRegistration != "1" && count > 0 {
+	if !s.Config.EnableUserRegistration && count > 0 {
 		session, _ := s.Store.Get(r, "session-name")
 		currentUsername, ok := session.Values["username"].(string)
 		if !ok {
@@ -190,7 +190,7 @@ func (s *Server) handleRegisterPost(w http.ResponseWriter, r *http.Request) {
 
 	localizer := s.getLocalizer(r)
 
-	if s.Config.EnableUserRegistration != "1" && count > 0 {
+	if !s.Config.EnableUserRegistration && count > 0 {
 		session, _ := s.Store.Get(r, "session-name")
 		currentUsername, ok := session.Values["username"].(string)
 		if !ok {

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -58,9 +58,9 @@ func newTestServerAPI(t *testing.T) *Server {
 	}
 
 	cfg := &config.Settings{
-		Production:         "0",
 		DataDir:            t.TempDir(),
-		EnableUpdateChecks: "0",
+		Production:         false,
+		EnableUpdateChecks: false,
 	}
 
 	s := NewServer(db, cfg)

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -1364,7 +1364,7 @@ func (s *Server) handleUnmarkAppBroken(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) updateAppBrokenStatus(w http.ResponseWriter, r *http.Request, broken bool) {
-	if s.Config.Production == "1" {
+	if s.Config.Production {
 		http.Error(w, "Not allowed in production mode", http.StatusForbidden)
 		return
 	}

--- a/internal/server/handlers_system.go
+++ b/internal/server/handlers_system.go
@@ -57,7 +57,7 @@ func (s *Server) checkForUpdates() {
 }
 
 func (s *Server) autoRefreshSystemRepo() {
-	if s.Config.SystemAppsAutoRefresh != "1" {
+	if !s.Config.SystemAppsAutoRefresh {
 		return
 	}
 
@@ -66,7 +66,7 @@ func (s *Server) autoRefreshSystemRepo() {
 	ticker := time.NewTicker(12 * time.Hour)
 	defer ticker.Stop()
 	for range ticker.C {
-		if s.Config.SystemAppsAutoRefresh != "1" {
+		if !s.Config.SystemAppsAutoRefresh {
 			slog.Info("System apps auto-refresh disabled, stopping ticker")
 			return
 		}
@@ -89,7 +89,7 @@ func (s *Server) refreshSystemRepo() error {
 }
 
 func (s *Server) doUpdateCheck() {
-	if s.Config.EnableUpdateChecks != "1" {
+	if !s.Config.EnableUpdateChecks {
 		return
 	}
 

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -165,7 +165,7 @@ func (s *Server) renderTemplate(w http.ResponseWriter, r *http.Request, name str
 	if err != nil {
 		slog.Error("Failed to count users for auto-login check", "error", err)
 	} else {
-		tmplData.IsAutoLoginActive = (s.Config.SingleUserAutoLogin == "1" && userCount == 1)
+		tmplData.IsAutoLoginActive = s.Config.SingleUserAutoLogin && userCount == 1
 	}
 
 	// Get and clear flash messages

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -27,7 +27,7 @@ func TestMetricsEndpoint(t *testing.T) {
 	// Setup Server
 	cfg := &config.Settings{
 		DataDir:    t.TempDir(),
-		Production: "0",
+		Production: false,
 	}
 	s := NewServer(db, cfg)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -294,7 +294,7 @@ func (s *Server) routes() {
 	s.Router.Handle("GET /metrics", promhttp.HandlerFor(s.PromGatherer, promhttp.HandlerOpts{}))
 	s.Router.HandleFunc("GET /dots", s.handleDots)
 
-	if s.Config.EnablePprof == "1" {
+	if s.Config.EnablePprof {
 		slog.Info("Enabling pprof", "path", "/debug/pprof/")
 		s.Router.HandleFunc("GET /debug/pprof/", pprof.Index)
 		s.Router.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -18,7 +18,7 @@ import (
 
 type option func(s *config.Settings)
 
-func withPprof(value string) option {
+func withPprof(value bool) option {
 	return func(s *config.Settings) {
 		s.EnablePprof = value
 	}
@@ -40,9 +40,9 @@ func newTestServer(t *testing.T, opts ...option) *Server {
 	db.Create(&data.Setting{Key: "system_apps_repo", Value: ""})
 
 	cfg := &config.Settings{
-		Production:         "0",
 		DataDir:            t.TempDir(),
-		EnableUpdateChecks: "0",
+		Production:         false,
+		EnableUpdateChecks: false,
 	}
 
 	for _, opt := range opts {
@@ -96,7 +96,7 @@ func TestPprofRoutesDisabledByDefault(t *testing.T) {
 }
 
 func TestPprofRoutesEnabled(t *testing.T) {
-	s := newTestServer(t, withPprof("1"))
+	s := newTestServer(t, withPprof(true))
 
 	req, err := http.NewRequest(http.MethodGet, "/debug/pprof/", nil)
 	require.NoError(t, err)

--- a/web/templates/auth/register.html
+++ b/web/templates/auth/register.html
@@ -4,7 +4,7 @@
 {{ define "title" }}{{ t .Localizer "Register" }}{{ end }}
 {{ define "content" }}
 <h1>{{ t .Localizer "Register" }}</h1>
-{{ if eq .Config.SingleUserAutoLogin "1" }}
+{{ if .Config.SingleUserAutoLogin }}
 <div class="w3-panel w3-orange w3-border w3-border-orange w3-round-large"
      style="margin-bottom: 20px">
     <div style="display: flex; align-items: center; gap: 10px;">

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -89,7 +89,7 @@
         <li>
             <a href="/auth/login">{{ t .Localizer "Log In" }}</a>
         </li>
-        {{ if eq .Config.EnableUserRegistration "1" }}
+        {{ if .Config.EnableUserRegistration }}
         <li>
             <a href="/auth/register">{{ t .Localizer "Create User" }}</a>
         </li>
@@ -159,7 +159,7 @@
     <li>
         <a href="/auth/login" onclick="closeMobileMenu()">{{ t .Localizer "Log In" }}</a>
     </li>
-    {{ if eq .Config.EnableUserRegistration "1" }}
+    {{ if .Config.EnableUserRegistration }}
     <li>
         <a href="/auth/register" onclick="closeMobileMenu()">{{ t .Localizer "Create User" }}</a>
     </li>

--- a/web/templates/partials/app_list_grid.html
+++ b/web/templates/partials/app_list_grid.html
@@ -111,7 +111,7 @@
         <i class="fa-solid fa-trash" aria-hidden="true"></i> {{ t .Localizer "Delete" }}
     </a>
     {{ end }}
-    {{ if eq .ConfigProduction "0" }}
+    {{ if not .ConfigProduction }}
     {{ if .App.Broken }}
     <button class="unmark-broken-btn"
             onclick="unmarkAppAsBroken('{{ .App.FileName }}', '{{ .App.PackageName }}', event, {{ t .Localizer "UnmarkAppBrokenConfirm" (dict "AppName" .App.FileName) | json }});"


### PR DESCRIPTION
The `config.Settings` struct uses strings for boolean settings. This isn't ideal, and results in more complicated config checks throughout the app. It also takes slightly more memory to hold strings in memory vs bools.

Further, the env library we use parses bools using `strconv.ParseBool`, which accepts `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`, `false`, `False`, so this is not a breaking change as long as users have used the recommended values.