### PR TITLE
chore: suppress some `context canceled` logs

### DIFF
--- a/internal/data/gorm_logger.go
+++ b/internal/data/gorm_logger.go
@@ -60,10 +60,11 @@ func (l *GORMSlogLogger) Trace(ctx context.Context, begin time.Time, fc func() (
 	}
 
 	if err != nil && l.LogLevel >= logger.Error {
-		if l.IgnoreRecordNotFoundError && errors.Is(err, gorm.ErrRecordNotFound) {
-			return
+		level := slog.LevelError
+		if (l.IgnoreRecordNotFoundError && errors.Is(err, gorm.ErrRecordNotFound)) || errors.Is(err, context.Canceled) {
+			level = slog.LevelDebug
 		}
-		slog.ErrorContext(ctx, "GORM query error", append(fields, slog.Any("error", err))...)
+		slog.Log(ctx, level, "GORM query error", append(fields, slog.Any("error", err))...)
 	} else if elapsed > l.SlowThreshold && l.SlowThreshold != 0 && l.LogLevel >= logger.Warn {
 		slog.WarnContext(ctx, "GORM slow query", fields...)
 	} else if l.LogLevel >= logger.Info { // GORM logger.Info maps to slog.LevelDebug for SQL

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -128,10 +128,14 @@ func (s *Server) RequireLogin(next http.HandlerFunc) http.HandlerFunc {
 			First(r.Context())
 
 		if err != nil {
-			if !errors.Is(err, gorm.ErrRecordNotFound) {
-				slog.Error("Database error checking session user", "username", username, "error", err)
-			} else {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
 				slog.Info("User in session not found in DB", "username", username)
+			} else {
+				level := slog.LevelError
+				if errors.Is(err, context.Canceled) {
+					level = slog.LevelDebug
+				}
+				slog.Log(r.Context(), level, "Database error checking session user", "username", username, "error", err)
 			}
 			http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 			return


### PR DESCRIPTION
Changes some `context canceled` log levels to debug when the page is quickly refreshed.