### PR TITLE
feat: add option to show full app animation

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -541,11 +541,12 @@ type App struct {
 	RecurrenceStartDate *string        `json:"recurrence_start_date"` // YYYY-MM-DD
 	RecurrenceEndDate   *string        `json:"recurrence_end_date"`   // YYYY-MM-DD
 
-	Config          JSONMap      `gorm:"type:text"         json:"config"`
-	EmptyLastRender bool         `json:"empty_last_render"`
-	RenderMessages  StringSlice  `gorm:"type:text"         json:"render_messages"`
-	AutoPin         bool         `json:"auto_pin"`
-	ColorFilter     *ColorFilter `json:"color_filter"`
+	Config            JSONMap      `gorm:"type:text"           json:"config"`
+	EmptyLastRender   bool         `json:"empty_last_render"`
+	RenderMessages    StringSlice  `gorm:"type:text"           json:"render_messages"`
+	AutoPin           bool         `json:"auto_pin"`
+	ColorFilter       *ColorFilter `json:"color_filter"`
+	ShowFullAnimation *bool        `json:"show_full_animation"`
 }
 
 type Device struct {

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -27,6 +27,7 @@ func Render(
 	timezone *string,
 	locale *string,
 	filters []string,
+	showFullAnimation *bool,
 ) ([]byte, []string, error) {
 	location := time.Local
 	if timezone != nil && *timezone != "" {
@@ -68,6 +69,7 @@ func Render(
 		loader.WithLocation(location),
 		loader.WithLanguage(lang),
 		loader.WithFilters(renderFilters),
+		loader.WithShowFullAnimation(showFullAnimation),
 	)
 }
 

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -351,14 +351,15 @@ func (s *Server) handleConfigAppGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.renderTemplate(w, r, "configapp", TemplateData{
-		User:               user,
-		Device:             device,
-		App:                app,
-		Schema:             template.JS(schemaBytes),
-		AppConfig:          app.Config,
-		DeleteOnCancel:     deleteOnCancel,
-		ColorFilterOptions: s.getColorFilterChoices(),
-		AppMetadata:        appMetadata,
+		User:                     user,
+		Device:                   device,
+		App:                      app,
+		Schema:                   template.JS(schemaBytes),
+		AppConfig:                app.Config,
+		DeleteOnCancel:           deleteOnCancel,
+		ColorFilterOptions:       s.getColorFilterChoices(),
+		ShowFullAnimationOptions: s.getShowFullAnimationChoices(),
+		AppMetadata:              appMetadata,
 	})
 }
 
@@ -377,6 +378,7 @@ func (s *Server) handleConfigAppPost(w http.ResponseWriter, r *http.Request) {
 		Config              map[string]any `json:"config"`
 		UseCustomRecurrence bool           `json:"use_custom_recurrence"`
 		ColorFilter         string         `json:"color_filter"`
+		ShowFullAnimation   string         `json:"show_full_animation"`
 
 		StartTime string   `json:"start_time"`
 		EndTime   string   `json:"end_time"`
@@ -443,12 +445,22 @@ func (s *Server) handleConfigAppPost(w http.ResponseWriter, r *http.Request) {
 	// Handle Days slice
 	app.Days = payload.Days
 
-	if payload.ColorFilter != "" {
-		if payload.ColorFilter == "inherit" {
-			app.ColorFilter = nil
+	switch payload.ColorFilter {
+	case "", "inherit", "none":
+		app.ColorFilter = nil
+	default:
+		val := data.ColorFilter(payload.ColorFilter)
+		app.ColorFilter = &val
+	}
+
+	switch payload.ShowFullAnimation {
+	case "", "auto":
+		app.ShowFullAnimation = nil
+	default:
+		if val, err := strconv.ParseBool(payload.ShowFullAnimation); err != nil {
+			slog.Warn("Failed to parse ShowFullAnimation", "error", err)
 		} else {
-			val := data.ColorFilter(payload.ColorFilter)
-			app.ColorFilter = &val
+			app.ShowFullAnimation = &val
 		}
 	}
 

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -38,6 +38,11 @@ type ColorFilterOption struct {
 	Name  string
 }
 
+type ShowFullAnimationOption struct {
+	Value string
+	Name  string
+}
+
 type DeviceTypeOption struct {
 	Value data.DeviceType
 	Label string
@@ -82,14 +87,15 @@ type TemplateData struct {
 	AppMetadata *apps.AppMetadata
 
 	// Device Update Extras
-	ColorFilterOptions []ColorFilterOption
-	AvailableLocales   []string
-	DefaultImgURL      string
-	DefaultWsURL       string
-	FirmwareImgURL     string
-	BrightnessUI       int
-	NightBrightnessUI  int
-	DimBrightnessUI    int
+	ColorFilterOptions       []ColorFilterOption
+	ShowFullAnimationOptions []ShowFullAnimationOption
+	AvailableLocales         []string
+	DefaultImgURL            string
+	DefaultWsURL             string
+	FirmwareImgURL           string
+	BrightnessUI             int
+	NightBrightnessUI        int
+	DimBrightnessUI          int
 
 	// Firmware
 	FirmwareBinsAvailable     bool
@@ -253,6 +259,14 @@ func (s *Server) getDeviceTypeChoices(localizer *i18n.Localizer) []DeviceTypeOpt
 		})
 	}
 	return choices
+}
+
+func (s *Server) getShowFullAnimationChoices() []ShowFullAnimationOption {
+	return []ShowFullAnimationOption{
+		{Value: "auto", Name: "Auto (Chosen by the app)"},
+		{Value: "true", Name: "True"},
+		{Value: "false", Name: "False"},
+	}
 }
 
 func (s *Server) getColorFilterChoices() []ColorFilterOption {

--- a/internal/server/render_utils.go
+++ b/internal/server/render_utils.go
@@ -61,6 +61,12 @@ func (s *Server) RenderApp(ctx context.Context, device *data.Device, app *data.A
 		filters = s.getEffectiveFilters(device, app)
 	}
 
+	// App-level rendering overrides are optional when rendering previews.
+	var showFullAnimation *bool
+	if app != nil {
+		showFullAnimation = app.ShowFullAnimation
+	}
+
 	// 2. Static WebP App
 	if strings.HasSuffix(strings.ToLower(appPath), ".webp") {
 		content, err := os.ReadFile(appPath)
@@ -82,6 +88,7 @@ func (s *Server) RenderApp(ctx context.Context, device *data.Device, app *data.A
 		&deviceTimezone,
 		locale,
 		filters,
+		showFullAnimation,
 	)
 }
 

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -782,6 +782,24 @@
   "ColorFilterTooltip": {
     "other": "Wenden Sie benutzerdefinierte Filter auf das Bild an:\n            Keine: Keine Transformation\n            Gedimmt: Verdunkelt das Bild gleichmäßig, während der Farbton erhalten bleibt\n            Rotverschiebung: CCT-abgeleitete chromatische Adaptationsmatrix ~3400K Ziel\n            Warm: Fügt einen subtilen warmen, orange/gelben Farbton hinzu\n            Sonnenuntergang: Emuliert tiefes Pink/Orange eines Sonnenuntergangs\n            Sepia: Fügt einen warmen, antiken Braunton hinzu, der gealterte Fotografien imitiert\n            Vintage: Gedämpfte, braun/grüne nostalgische Töne\n            Dämmerung: Helligkeit verblasst, fügt einen rötlichen Stich hinzu\n            Kühl: Fügt einen kühlen, bläulichen Farbton hinzu\n            Schwarz & Weiß: Konvertiert das Bild in perzeptives Graustufen unter Verwendung von Luminanzgewichten\n            Eis: Blasse Entsättigung mit bläulichem Stich\n            Mondlicht: Gedämpftes Blau-Grau, Nachtbeleuchtungseffekt\n            Neon: Erhöht den Kontrast, Magenta-Blau Cyberpunk\n            Pastell: Mildert Töne, sanfte Glanzlichterverstärkung"
   },
+  "Show Full Animation": {
+    "other": "Vollständige Animation anzeigen"
+  },
+  "ShowFullAnimationTooltip": {
+    "other": "Animationen, die länger als die Gerätezykluszeit dauern, werden normalerweise abgeschnitten. Aktivieren Sie dies, damit die App die vollständige Animation anzeigen kann, auch wenn sie die Zykluszeit überschreitet."
+  },
+  "Auto (Chosen by the app)": {
+    "other": "Automatisch (Von der App gewählt)"
+  },
+  "True": {
+    "other": "Wahr"
+  },
+  "False": {
+    "other": "Falsch"
+  },
+  "Override whether the full animation is shown": {
+    "other": "Überschreibt, ob diese App ihre vollständige Animation anzeigt"
+  },
   "Override device color filter": {
     "other": "Geräte-Farbfilter überschreiben"
   },

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -785,6 +785,24 @@
   "ColorFilterTooltip": {
     "other": "Apply custom filters to the image:\n            None: No transformation\n            Dimmed: Darkens image uniformly while preserving hue\n            Redshift: CCT-derived chromatic adaptation matrix ~3400K target\n            Warm: Adds a subtle warm, orange/yellow hue\n            Sunset: Emulates deep pink/orange of a setting sun\n            Sepia: Adds a warm, antique brown tone mimicking aged photographs\n            Vintage: Muted, brown/green nostalgic tones\n            Dusk: Fades brightness, adds reddish cast\n            Cool: Adds a cool, blue tint\n            Black & White: Converts image to perceptual grayscale using luminance weights\n            Ice: Pale desaturation with bluish cast\n            Moonlight: Dim blue-gray, night lighting effect\n            Neon: Boosts contrast, magenta-blue cyberpunk\n            Pastel: Softens tones, gentle highlight boost"
   },
+  "Show Full Animation": {
+    "other": "Show Full Animation"
+  },
+  "ShowFullAnimationTooltip": {
+    "other": "Animations longer than the device cycle time are normally cut short. Enable this to let the app finish its full animation, even if it exceeds the cycle time."
+  },
+  "Auto (Chosen by the app)": {
+    "other": "Auto (Chosen by the app)"
+  },
+  "True": {
+    "other": "True"
+  },
+  "False": {
+    "other": "False"
+  },
+  "Override whether the full animation is shown": {
+    "other": "Override whether this app shows its full animation"
+  },
   "Override device color filter": {
     "other": "Override device color filter"
   },

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -188,6 +188,33 @@
                 </select>
             </td>
         </tr>
+        <!-- Show Full Animation -->
+        <tr>
+            <td>
+                <label for="show_full_animation">{{ t .Localizer "Show Full Animation" }}</label>
+                <span class="tooltip-icon"
+                      title="{{ t .Localizer "ShowFullAnimationTooltip" }}">ⓘ</span>
+                <small>{{ t .Localizer "Override whether the full animation is shown" }}</small>
+            </td>
+            <td>
+                {{- $sfa := "auto" }}
+                {{- if ne .App.ShowFullAnimation nil }}
+                {{- if deref .App.ShowFullAnimation }}
+                {{- $sfa = "true" }}
+                {{- else }}
+                {{- $sfa = "false" }}
+                {{- end }}
+                {{- end }}
+                <select name="show_full_animation"
+                        id="show_full_animation"
+                        class="form-control">
+                    {{ range .ShowFullAnimationOptions }}
+                    <option value="{{ .Value }}" {{ if eq $sfa .Value }} selected {{ end }}>{{ t $.Localizer .Name }}
+                    </option>
+                    {{ end }}
+                </select>
+            </td>
+        </tr>
         <!-- Notes -->
         <tr>
             <td>
@@ -1437,6 +1464,7 @@
           start_time: document.getElementById('start_time').value,
           end_time: document.getElementById('end_time').value,
           color_filter: document.getElementById('color_filter').value,
+          show_full_animation: document.getElementById('show_full_animation').value,
           days: days,
 
           use_custom_recurrence: document.getElementById('use_custom_recurrence').checked,
@@ -1500,6 +1528,7 @@
                   start_time: { type: 'value', default: '' },
                   end_time: { type: 'value', default: '' },
                   color_filter: { type: 'value', default: 'inherit' },
+                  show_full_animation: { type: 'value', default: 'auto' },
                   use_custom_recurrence: { type: 'checked' },
                   recurrence_type: { type: 'value', default: 'daily' },
                   recurrence_interval: { type: 'value', default: '1' },


### PR DESCRIPTION
Adds an option to override `show_full_animation` for an app, allowing an app to be rendered for longer than the device's cycle time.

<img width="651" height="139" alt="image" src="https://github.com/user-attachments/assets/3e691181-1a8d-4a06-b664-933a4547789e" />

See #752