### PR TITLE
feat: add option to skip boot animation

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -401,6 +401,7 @@ type DeviceInfo struct {
 	SSID               *string      `json:"ssid"`
 	WifiPowerSave      *int         `json:"wifi_power_save"`
 	SkipDisplayVersion *bool        `json:"skip_display_version"`
+	SkipBootAnimation  *bool        `json:"skip_boot_animation"`
 	APMode             *bool        `json:"ap_mode"`
 	PreferIPv6         *bool        `json:"prefer_ipv6"`
 	SwapColors         *bool        `json:"swap_colors"`

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -83,6 +83,7 @@ type DeviceInfo struct {
 	SSID               *string `json:"ssid,omitempty"`
 	WifiPowerSave      *int    `json:"wifiPowerSave,omitempty"`
 	SkipDisplayVersion *bool   `json:"skipDisplayVersion,omitempty"`
+	SkipBootAnimation  *bool   `json:"skipBootAnimation,omitempty"`
 	APMode             *bool   `json:"apMode,omitempty"`
 	PreferIPv6         *bool   `json:"preferIPv6,omitempty"`
 	SwapColors         *bool   `json:"swapColors,omitempty"`
@@ -103,6 +104,7 @@ func (s *Server) toDevicePayload(d *data.Device) DevicePayload {
 		SSID:               d.Info.SSID,
 		WifiPowerSave:      d.Info.WifiPowerSave,
 		SkipDisplayVersion: d.Info.SkipDisplayVersion,
+		SkipBootAnimation:  d.Info.SkipBootAnimation,
 		APMode:             d.Info.APMode,
 		PreferIPv6:         d.Info.PreferIPv6,
 		SwapColors:         d.Info.SwapColors,
@@ -674,6 +676,7 @@ func (s *Server) handleRebootDeviceAPI(w http.ResponseWriter, r *http.Request) {
 // FirmwareSettingsUpdate represents the updatable firmware settings via API.
 type FirmwareSettingsUpdate struct {
 	SkipDisplayVersion *bool   `json:"skipDisplayVersion"`
+	SkipBootAnimation  *bool   `json:"skipBootAnimation"`
 	PreferIPv6         *bool   `json:"preferIPv6"`
 	APMode             *bool   `json:"apMode"`
 	SwapColors         *bool   `json:"swapColors"`
@@ -697,6 +700,9 @@ func (s *Server) handleUpdateFirmwareSettingsAPI(w http.ResponseWriter, r *http.
 
 	if update.SkipDisplayVersion != nil {
 		payload["skip_display_version"] = *update.SkipDisplayVersion
+	}
+	if update.SkipBootAnimation != nil {
+		payload["skip_boot_animation"] = *update.SkipBootAnimation
 	}
 	if update.PreferIPv6 != nil {
 		payload["prefer_ipv6"] = *update.PreferIPv6

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -177,6 +177,7 @@ func TestHandleGetDevice(t *testing.T) {
 	device.Info.SSID = new("Test SSID")
 	device.Info.WifiPowerSave = new(1)
 	device.Info.SkipDisplayVersion = new(true)
+	device.Info.SkipBootAnimation = new(true)
 	device.Info.APMode = new(true)
 	device.Info.PreferIPv6 = new(true)
 	device.Info.SwapColors = new(true)
@@ -212,6 +213,9 @@ func TestHandleGetDevice(t *testing.T) {
 	}
 	if payload.Info.SkipDisplayVersion == nil || !*payload.Info.SkipDisplayVersion {
 		t.Errorf("Expected SkipDisplayVersion to be true, got %v", payload.Info.SkipDisplayVersion)
+	}
+	if payload.Info.SkipBootAnimation == nil || !*payload.Info.SkipBootAnimation {
+		t.Errorf("Expected SkipBootAnimation to be true, got %v", payload.Info.SkipBootAnimation)
 	}
 	if payload.Info.APMode == nil || !*payload.Info.APMode {
 		t.Errorf("Expected APMode to be true, got %v", payload.Info.APMode)
@@ -645,6 +649,7 @@ func TestHandleUpdateFirmwareSettingsAPI(t *testing.T) {
 	// Construct JSON request body
 	payload := FirmwareSettingsUpdate{
 		SkipDisplayVersion: new(true),
+		SkipBootAnimation:  new(true),
 		WifiPowerSave:      new(2),
 		ImageURL:           new("http://example.com/test.png"),
 	}
@@ -680,11 +685,14 @@ func TestHandleUpdateFirmwareSettingsAPI(t *testing.T) {
 			t.Fatalf("failed to unmarshal payload from broadcaster: %v", err)
 		}
 
-		if len(receivedPayload) != 3 {
-			t.Errorf("expected 3 fields in payload, got %d", len(receivedPayload))
+		if len(receivedPayload) != 4 {
+			t.Errorf("expected 4 fields in payload, got %d", len(receivedPayload))
 		}
 		if val, ok := receivedPayload["skip_display_version"].(bool); !ok || !val {
 			t.Errorf("expected skip_display_version to be true, got %v", receivedPayload["skip_display_version"])
+		}
+		if val, ok := receivedPayload["skip_boot_animation"].(bool); !ok || !val {
+			t.Errorf("expected skip_boot_animation to be true, got %v", receivedPayload["skip_boot_animation"])
 		}
 		if val, ok := receivedPayload["wifi_power_save"].(float64); !ok || val != 2 {
 			t.Errorf("expected wifi_power_save to be 2, got %v", receivedPayload["wifi_power_save"])

--- a/internal/server/handlers_device.go
+++ b/internal/server/handlers_device.go
@@ -1018,7 +1018,7 @@ func (s *Server) handleUpdateFirmwareSettings(w http.ResponseWriter, r *http.Req
 	payload := make(map[string]any)
 
 	// Boolean fields
-	boolFields := []string{"skip_display_version", "prefer_ipv6", "ap_mode", "swap_colors"}
+	boolFields := []string{"skip_display_version", "skip_boot_animation", "prefer_ipv6", "ap_mode", "swap_colors"}
 	for _, field := range boolFields {
 		if val := r.FormValue(field); val != "" {
 			payload[field] = val == "true"

--- a/internal/server/websockets.go
+++ b/internal/server/websockets.go
@@ -35,6 +35,7 @@ type ClientInfo struct {
 	SSID               *string `json:"ssid"`
 	WifiPowerSave      *int    `json:"wifi_power_save"`
 	SkipDisplayVersion *bool   `json:"skip_display_version"`
+	SkipBootAnimation  *bool   `json:"skip_boot_animation"`
 	APMode             *bool   `json:"ap_mode"`
 	PreferIPv6         *bool   `json:"prefer_ipv6"`
 	SwapColors         *bool   `json:"swap_colors"`
@@ -141,6 +142,9 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 				}
 				if msg.ClientInfo.SkipDisplayVersion != nil {
 					device.Info.SkipDisplayVersion = msg.ClientInfo.SkipDisplayVersion
+				}
+				if msg.ClientInfo.SkipBootAnimation != nil {
+					device.Info.SkipBootAnimation = msg.ClientInfo.SkipBootAnimation
 				}
 				if msg.ClientInfo.APMode != nil {
 					device.Info.APMode = msg.ClientInfo.APMode

--- a/web/templates/manager/update.html
+++ b/web/templates/manager/update.html
@@ -935,6 +935,21 @@
             </tr>
             <tr>
                 <td>
+                    <label class="device-settings-label">{{ t .Localizer "Skip Boot Animation" }}</label>
+                </td>
+                <td>
+                    <label class="switch">
+                        <input type="checkbox"
+                               {{- if derefOr .Device.Info.SkipBootAnimation false }}
+                               checked
+                               {{- end }}
+                               onchange="updateFirmwareSettings({skip_boot_animation: this.checked})">
+                        <span class="slider round"></span>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <td>
                     <label class="device-settings-label">{{ t .Localizer "Prefer IPv6" }}</label>
                 </td>
                 <td>


### PR DESCRIPTION
I have a Tronbyt S3 on my nightstand and the boot animation is very bright. I'd like to be able to disable it for this device.

Requires https://github.com/tronbyt/firmware-esp32/pull/138