### PR TITLE
Make schedule fields accessible via API

### DIFF
--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -166,6 +166,19 @@ type AppPayload struct {
 	DisplayTimeSec    int    `json:"displayTimeSec"`
 	LastRenderAt      int64  `json:"lastRenderAt"`
 	IsInactive        bool   `json:"isInactive"`
+
+	// Schedule fields
+	StartTime *string  `json:"startTime"`
+	EndTime   *string  `json:"endTime"`
+	Days      []string `json:"days"`
+
+	// Recurrence fields
+	UseCustomRecurrence bool                `json:"useCustomRecurrence"`
+	RecurrenceType      data.RecurrenceType `json:"recurrenceType"`
+	RecurrenceInterval  int                 `json:"recurrenceInterval"`
+	RecurrencePattern   map[string]any      `json:"recurrencePattern"`
+	RecurrenceStartDate *string             `json:"recurrenceStartDate"`
+	RecurrenceEndDate   *string             `json:"recurrenceEndDate"`
 }
 
 func (s *Server) toAppPayload(device *data.Device, app *data.App) AppPayload {
@@ -180,6 +193,17 @@ func (s *Server) toAppPayload(device *data.Device, app *data.App) AppPayload {
 		DisplayTimeSec:    app.DisplayTime,
 		LastRenderAt:      app.LastRender.Unix(),
 		IsInactive:        app.EmptyLastRender,
+
+		StartTime: app.StartTime,
+		EndTime:   app.EndTime,
+		Days:      app.Days,
+
+		UseCustomRecurrence: app.UseCustomRecurrence,
+		RecurrenceType:      app.RecurrenceType,
+		RecurrenceInterval:  app.RecurrenceInterval,
+		RecurrencePattern:   app.RecurrencePattern,
+		RecurrenceStartDate: app.RecurrenceStartDate,
+		RecurrenceEndDate:   app.RecurrenceEndDate,
 	}
 }
 

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -556,6 +556,19 @@ type InstallationUpdate struct {
 	Pinned            *bool `json:"pinned"`
 	RenderIntervalMin *int  `json:"renderIntervalMin"`
 	DisplayTimeSec    *int  `json:"displayTimeSec"`
+
+	// Schedule fields
+	StartTime *string   `json:"startTime"`
+	EndTime   *string   `json:"endTime"`
+	Days      *[]string `json:"days"`
+
+	// Recurrence fields
+	UseCustomRecurrence *bool                `json:"useCustomRecurrence"`
+	RecurrenceType      *data.RecurrenceType `json:"recurrenceType"`
+	RecurrenceInterval  *int                 `json:"recurrenceInterval"`
+	RecurrencePattern   *map[string]any      `json:"recurrencePattern"`
+	RecurrenceStartDate *string              `json:"recurrenceStartDate"`
+	RecurrenceEndDate   *string              `json:"recurrenceEndDate"`
 }
 
 func (s *Server) handlePatchInstallation(w http.ResponseWriter, r *http.Request) {
@@ -619,6 +632,63 @@ func (s *Server) handlePatchInstallation(w http.ResponseWriter, r *http.Request)
 		if err := s.DB.Omit("Apps").Save(device).Error; err != nil {
 			http.Error(w, "Failed to update device pin status", http.StatusInternalServerError)
 			return
+		}
+	}
+
+	// Schedule fields
+	if update.StartTime != nil {
+		if *update.StartTime == "" {
+			app.StartTime = nil
+		} else {
+			parsed, err := parseTimeInput(*update.StartTime)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Invalid startTime: %v", err), http.StatusBadRequest)
+				return
+			}
+			app.StartTime = &parsed
+		}
+	}
+	if update.EndTime != nil {
+		if *update.EndTime == "" {
+			app.EndTime = nil
+		} else {
+			parsed, err := parseTimeInput(*update.EndTime)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Invalid endTime: %v", err), http.StatusBadRequest)
+				return
+			}
+			app.EndTime = &parsed
+		}
+	}
+	if update.Days != nil {
+		app.Days = *update.Days
+	}
+
+	// Recurrence fields
+	if update.UseCustomRecurrence != nil {
+		app.UseCustomRecurrence = *update.UseCustomRecurrence
+	}
+	if update.RecurrenceType != nil {
+		app.RecurrenceType = *update.RecurrenceType
+	}
+	if update.RecurrenceInterval != nil {
+		app.RecurrenceInterval = *update.RecurrenceInterval
+	}
+	if update.RecurrencePattern != nil {
+		app.RecurrencePattern = *update.RecurrencePattern
+	}
+	if update.RecurrenceStartDate != nil {
+		if *update.RecurrenceStartDate == "" {
+			app.RecurrenceStartDate = nil
+		} else {
+			app.RecurrenceStartDate = update.RecurrenceStartDate
+		}
+	}
+	if update.RecurrenceEndDate != nil {
+		if *update.RecurrenceEndDate == "" {
+			app.RecurrenceEndDate = nil
+		} else {
+			app.RecurrenceEndDate = update.RecurrenceEndDate
 		}
 	}
 

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -685,6 +685,15 @@ func (s *Server) handlePatchInstallation(w http.ResponseWriter, r *http.Request)
 		}
 	}
 	if update.Days != nil {
+		for _, day := range *update.Days {
+			switch day {
+			case "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday":
+				// valid
+			default:
+				http.Error(w, fmt.Sprintf("Invalid day: %s", day), http.StatusBadRequest)
+				return
+			}
+		}
 		app.Days = *update.Days
 	}
 

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -720,6 +720,10 @@ func (s *Server) handlePatchInstallation(w http.ResponseWriter, r *http.Request)
 		if *update.RecurrenceStartDate == "" {
 			app.RecurrenceStartDate = nil
 		} else {
+			if _, err := time.Parse("2006-01-02", *update.RecurrenceStartDate); err != nil {
+				http.Error(w, "Invalid recurrenceStartDate: must be YYYY-MM-DD", http.StatusBadRequest)
+				return
+			}
 			app.RecurrenceStartDate = update.RecurrenceStartDate
 		}
 	}
@@ -727,6 +731,10 @@ func (s *Server) handlePatchInstallation(w http.ResponseWriter, r *http.Request)
 		if *update.RecurrenceEndDate == "" {
 			app.RecurrenceEndDate = nil
 		} else {
+			if _, err := time.Parse("2006-01-02", *update.RecurrenceEndDate); err != nil {
+				http.Error(w, "Invalid recurrenceEndDate: must be YYYY-MM-DD", http.StatusBadRequest)
+				return
+			}
 			app.RecurrenceEndDate = update.RecurrenceEndDate
 		}
 	}

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -702,7 +702,13 @@ func (s *Server) handlePatchInstallation(w http.ResponseWriter, r *http.Request)
 		app.UseCustomRecurrence = *update.UseCustomRecurrence
 	}
 	if update.RecurrenceType != nil {
-		app.RecurrenceType = *update.RecurrenceType
+		switch *update.RecurrenceType {
+		case data.RecurrenceDaily, data.RecurrenceWeekly, data.RecurrenceMonthly, data.RecurrenceYearly:
+			app.RecurrenceType = *update.RecurrenceType
+		default:
+			http.Error(w, "Invalid recurrenceType", http.StatusBadRequest)
+			return
+		}
 	}
 	if update.RecurrenceInterval != nil {
 		app.RecurrenceInterval = *update.RecurrenceInterval

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -517,6 +517,127 @@ func TestHandlePatchInstallation(t *testing.T) {
 	}
 }
 
+func TestHandlePatchInstallationSchedule(t *testing.T) {
+	s := newTestServerAPI(t)
+	apiKey := "test_api_key"
+	deviceID := "testdevice"
+	installID := "scheduleapp"
+
+	// Add a dummy app to the device
+	app := data.App{
+		DeviceID:    deviceID,
+		Iname:       installID,
+		Name:        "Schedule App",
+		UInterval:   10,
+		DisplayTime: 10,
+		Enabled:     true,
+		Order:       0,
+	}
+	if err := gorm.G[data.App](s.DB).Create(context.Background(), &app); err != nil {
+		t.Fatalf("Failed to create dummy app: %v", err)
+	}
+
+	// Patch schedule fields
+	startTime := "09:00"
+	endTime := "17:00"
+	days := []string{"monday", "wednesday", "friday"}
+	useCustomRecurrence := true
+	recurrenceType := data.RecurrenceWeekly
+	recurrenceInterval := 2
+	recurrenceStartDate := "2026-01-01"
+	recurrenceEndDate := "2026-12-31"
+
+	update := InstallationUpdate{
+		StartTime:           &startTime,
+		EndTime:             &endTime,
+		Days:                &days,
+		UseCustomRecurrence: &useCustomRecurrence,
+		RecurrenceType:      &recurrenceType,
+		RecurrenceInterval:  &recurrenceInterval,
+		RecurrenceStartDate: &recurrenceStartDate,
+		RecurrenceEndDate:   &recurrenceEndDate,
+	}
+	body, _ := json.Marshal(update)
+	req := newAPIRequest("PATCH", fmt.Sprintf("/v0/devices/%s/installations/%s", deviceID, installID), apiKey, body)
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("handler returned wrong status code: got %v want %v: %s",
+			rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	// Verify updated app state from DB
+	updated, err := gorm.G[data.App](s.DB).Where("iname = ?", installID).First(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to fetch updated app state: %v", err)
+	}
+
+	if updated.StartTime == nil || *updated.StartTime != "09:00" {
+		t.Errorf("Expected startTime '09:00', got %v", updated.StartTime)
+	}
+	if updated.EndTime == nil || *updated.EndTime != "17:00" {
+		t.Errorf("Expected endTime '17:00', got %v", updated.EndTime)
+	}
+	if len(updated.Days) != 3 || updated.Days[0] != "monday" {
+		t.Errorf("Expected days [monday wednesday friday], got %v", updated.Days)
+	}
+	if !updated.UseCustomRecurrence {
+		t.Errorf("Expected useCustomRecurrence true, got false")
+	}
+	if updated.RecurrenceType != data.RecurrenceWeekly {
+		t.Errorf("Expected recurrenceType 'weekly', got %s", updated.RecurrenceType)
+	}
+	if updated.RecurrenceInterval != 2 {
+		t.Errorf("Expected recurrenceInterval 2, got %d", updated.RecurrenceInterval)
+	}
+	if updated.RecurrenceStartDate == nil || *updated.RecurrenceStartDate != "2026-01-01" {
+		t.Errorf("Expected recurrenceStartDate '2026-01-01', got %v", updated.RecurrenceStartDate)
+	}
+	if updated.RecurrenceEndDate == nil || *updated.RecurrenceEndDate != "2026-12-31" {
+		t.Errorf("Expected recurrenceEndDate '2026-12-31', got %v", updated.RecurrenceEndDate)
+	}
+
+	// Verify the response JSON also contains the schedule fields
+	var respApp data.App
+	if err := json.NewDecoder(rr.Body).Decode(&respApp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if respApp.StartTime == nil || *respApp.StartTime != "09:00" {
+		t.Errorf("Response startTime: expected '09:00', got %v", respApp.StartTime)
+	}
+
+	// Now test clearing schedule fields by sending empty strings
+	emptyStr := ""
+	clearUpdate := InstallationUpdate{
+		StartTime: &emptyStr,
+		EndTime:   &emptyStr,
+	}
+	body, _ = json.Marshal(clearUpdate)
+	req = newAPIRequest("PATCH", fmt.Sprintf("/v0/devices/%s/installations/%s", deviceID, installID), apiKey, body)
+	rr = httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("clear schedule: got status %v want %v: %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	cleared, err := gorm.G[data.App](s.DB).Where("iname = ?", installID).First(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to fetch cleared app state: %v", err)
+	}
+	if cleared.StartTime != nil {
+		t.Errorf("Expected startTime nil after clear, got %v", *cleared.StartTime)
+	}
+	if cleared.EndTime != nil {
+		t.Errorf("Expected endTime nil after clear, got %v", *cleared.EndTime)
+	}
+	// Days should still be set from the previous update
+	if len(cleared.Days) != 3 {
+		t.Errorf("Expected days to remain unchanged, got %v", cleared.Days)
+	}
+}
+
 func TestHandleDeleteInstallationAPI(t *testing.T) {
 	s := newTestServerAPI(t)
 	apiKey := "test_api_key"

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -974,6 +974,12 @@
   "Unpin App": {
     "other": "App entpinnen"
   },
+  "Set Schedule": {
+    "other": "Zeitplan festlegen"
+  },
+  "Clear Schedule": {
+    "other": "Zeitplan löschen"
+  },
   "Note:": {
     "other": "Notizen:"
   },

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -977,6 +977,12 @@
   "Unpin App": {
     "other": "Unpin App"
   },
+  "Set Schedule": {
+    "other": "Set Schedule"
+  },
+  "Clear Schedule": {
+    "other": "Clear Schedule"
+  },
   "Note:": {
     "other": "Note:"
   },

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -684,6 +684,24 @@
   -d '{"pinnedApp": ""}' \
   /v0/devices/{{ .Device.ID }}</pre>
             </div>
+            <!-- Set Schedule -->
+            <div style="margin-bottom: 20px;">
+                <h3>{{ t .Localizer "Set Schedule" }}</h3>
+                <pre>curl -X PATCH \
+  -H "Authorization: Bearer {{ .Device.APIKey }}" \
+  -H "Content-Type: application/json" \
+  -d '{"startTime": "09:00", "endTime": "17:00", "days": ["monday","tuesday","wednesday","thursday","friday"]}' \
+  /v0/devices/{{ .Device.ID }}/installations/{{ .App.Iname }}</pre>
+            </div>
+            <!-- Clear Schedule -->
+            <div style="margin-bottom: 20px;">
+                <h3 style="color: var(--danger-text);">{{ t .Localizer "Clear Schedule" }}</h3>
+                <pre>curl -X PATCH \
+  -H "Authorization: Bearer {{ .Device.APIKey }}" \
+  -H "Content-Type: application/json" \
+  -d '{"startTime": "", "endTime": "", "days": []}' \
+  /v0/devices/{{ .Device.ID }}/installations/{{ .App.Iname }}</pre>
+            </div>
             <small>
                 <strong>{{ t .Localizer "Note:" }}</strong> {{ t .Localizer "Replace YOUR_API_KEY with your device API key if not using the one shown above." }}
             </small>


### PR DESCRIPTION
## Summary
- Exposes app schedule configuration (`startTime`, `endTime`, `days`, and all recurrence fields) via the `PATCH /v0/devices/{id}/installations/{iname}` endpoint
- Previously these fields were only configurable through the web UI
- Adds curl examples for "Set Schedule" and "Clear Schedule" to the app config page
- Adds corresponding i18n keys for en/de

## Test plan
- [x] Added `TestHandlePatchInstallationSchedule` covering set, verify, and clear flows
- [x] Existing `TestHandlePatchInstallation` still passes
- [x] `go test ./internal/server/` passes
- [x] `go fmt` clean
- [x] Manually verified via local server

🤖 Generated with [Claude Code](https://claude.com/claude-code)