### PR TITLE
Fix: generate unique numeric iname for pushed apps

### DIFF
--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -444,8 +444,8 @@ func (s *Server) savePushedImage(deviceID, installID string, data []byte) error 
 
 func (s *Server) ensurePushedApp(ctx context.Context, deviceID, installID string) error {
 	// Check if app exists by matching on installID (for pushed apps, we need to look up by installID)
-	// Since installID might be non-numeric (e.g., "pushed-hasssolarlocal1"), we check via path/file
-	count, err := gorm.G[data.App](s.DB).Where("device_id = ? AND pushed = ? AND path LIKE ?", deviceID, true, "%"+installID+"%").Count(ctx, "*")
+	// Since installID might be non-numeric (e.g., "pushed:hasssolarlocal1"), we check via path/file
+	count, err := gorm.G[data.App](s.DB).Where("device_id = ? AND pushed = ? AND path = ?", deviceID, true, "pushed:"+installID).Count(ctx, "*")
 	if err != nil {
 		slog.Error("Failed to check if app exists for image push", "error", err)
 		return err

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -443,8 +443,9 @@ func (s *Server) savePushedImage(deviceID, installID string, data []byte) error 
 }
 
 func (s *Server) ensurePushedApp(ctx context.Context, deviceID, installID string) error {
-	// Check if install exists
-	count, err := gorm.G[data.App](s.DB).Where("device_id = ? AND iname = ?", deviceID, installID).Count(ctx, "*")
+	// Check if app exists by matching on installID (for pushed apps, we need to look up by installID)
+	// Since installID might be non-numeric (e.g., "pushed-hasssolarlocal1"), we check via path/file
+	count, err := gorm.G[data.App](s.DB).Where("device_id = ? AND pushed = ? AND path LIKE ?", deviceID, true, "%"+installID+"%").Count(ctx, "*")
 	if err != nil {
 		slog.Error("Failed to check if app exists for image push", "error", err)
 		return err
@@ -453,14 +454,25 @@ func (s *Server) ensurePushedApp(ctx context.Context, deviceID, installID string
 		return nil
 	}
 
+	// Generate a numeric iname for the pushed app (same as regular apps)
+	newIname, err := generateUniqueIname(s.DB, deviceID)
+	if err != nil {
+		slog.Error("Failed to generate iname for pushed app", "error", err)
+		return err
+	}
+
+	// Store installID in path so we can match on it later
+	installPath := "pushed:" + installID
+
 	newApp := data.App{
 		DeviceID:    deviceID,
-		Iname:       installID,
+		Iname:       newIname,
 		Name:        "pushed",
 		UInterval:   10,
 		DisplayTime: 0,
 		Enabled:     true,
 		Pushed:      true,
+		Path:        &installPath,
 	}
 
 	maxOrder, err := getMaxAppOrder(s.DB, deviceID)

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -257,13 +257,19 @@ func TestHandlePushImage(t *testing.T) {
 	}
 
 	// Verify the app was created and image saved
-	app, err := gorm.G[data.App](s.DB).Where("device_id = ? AND iname = ?", deviceID, installID).First(context.Background())
+	// New pushed apps get a numeric iname, so check by path containing installID
+	app, err := gorm.G[data.App](s.DB).Where("device_id = ? AND path = ?", deviceID, "pushed:"+installID).First(context.Background())
 	if err != nil {
 		t.Fatalf("Expected app to be created, but got error: %v", err)
 	}
 
 	if !app.Pushed {
 		t.Error("Expected app to be marked as pushed")
+	}
+
+	// Verify the iname is numeric (the new behavior for pushed apps)
+	if app.Iname == "" || app.Iname[0] < '0' || app.Iname[0] > '9' {
+		t.Errorf("Expected numeric iname for pushed app, got %s", app.Iname)
 	}
 
 	// Verify image file exists


### PR DESCRIPTION
When a device pushes an image to the server, the external installationID was being used directly as the app's iname. This caused issues when duplicate app operations tried to find the maximum numeric iname:

    ERROR: invalid input syntax for type integer: "hasssolarlocal1"

This SQL error occurred because:

1. External integrations (e.g., Home Assistant) pass non-numeric installationIDs like 'hasssolarlocal1'
2. These were stored as-is in the iname column
3. Later operations like app duplication call generateUniqueIname() which uses: SELECT COALESCE(MAX(CAST(iname AS INTEGER)), 99)
4. PostgreSQL fails when any row contains non-numeric iname values

The fix:

1. For pushed apps, store the external installID in the Path field with a 'pushed:' prefix (e.g., 'pushed:hasssolarlocal1') for tracking
2. Generate a proper numeric iname using generateUniqueIname(), same as regular Pixlet apps (e.g., '100', '101', '102')
3. Check for existing pushed apps by matching the path field instead of iname field

This ensures all apps have numeric inames while preserving the external installation ID for proper image matching and deduplication.

File changes:
- handlers_api.go: ensurePushedApp now generates numeric iname and stores installID in path
- handlers_api_test.go: updated test to verify numeric iname