### PR TITLE
feat(cmd): add `update-system-apps` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ The `tronbyt-server` binary supports additional commands for administration:
     ./tronbyt-server health https://your-tronbyt-server.com/health
     ```
 
+*   **`update-system-apps`**: Updates the system apps repo.
+    ```bash
+    ./tronbyt-server update-system-apps
+    ```
+
 ### Monitoring
 
 *   **`/metrics`**: Exposes Prometheus-compatible metrics for monitoring the server's health and performance. This endpoint includes application-specific metrics (`tronbyt_*` for renders, device activity, HTTP requests, users/devices/apps counts), GORM database connection pool stats, and standard Go runtime metrics.

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -9,6 +9,7 @@ import (
 	"tronbyt-server/cmd/server/migrate"
 	"tronbyt-server/cmd/server/resetpassword"
 	"tronbyt-server/cmd/server/serve"
+	"tronbyt-server/cmd/server/updatesystemapps"
 	"tronbyt-server/internal/config"
 
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ func New() *cobra.Command {
 		serve.New(),
 		migrate.New(),
 		resetpassword.New(),
+		updatesystemapps.New(),
 		health.New(),
 	)
 

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -41,6 +41,8 @@ func New() *cobra.Command {
 }
 
 func preRun(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+
 	// Initialize slog before anything else that might log
 	slog.SetDefault(slog.New(slog.NewTextHandler(cmd.ErrOrStderr(), nil)))
 

--- a/cmd/server/health/cmd.go
+++ b/cmd/server/health/cmd.go
@@ -12,7 +12,7 @@ import (
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "health [url]",
-		Short: "Perform a health check",
+		Short: "Performs a health check against the running server",
 		RunE:  run,
 
 		SilenceUsage: true,

--- a/cmd/server/resetpassword/cmd.go
+++ b/cmd/server/resetpassword/cmd.go
@@ -15,7 +15,7 @@ import (
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reset-password username new_password",
-		Short: "Reset a user password",
+		Short: "Resets the password for a specified user",
 		RunE:  run,
 		Args:  cobra.ExactArgs(2),
 	}

--- a/cmd/server/updatesystemapps/cmd.go
+++ b/cmd/server/updatesystemapps/cmd.go
@@ -1,0 +1,30 @@
+package updatesystemapps
+
+import (
+	"fmt"
+	"tronbyt-server/internal/config"
+	"tronbyt-server/internal/gitutils"
+
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update-system-apps",
+		Short: "Updates the system apps repo.",
+		RunE:  run,
+	}
+}
+
+func run(cmd *cobra.Command, _ []string) error {
+	cfg, err := config.FromContext(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("failed to load settings: %w", err)
+	}
+
+	// Clone/Update System Apps Repo
+	if err := gitutils.EnsureRepo(cfg.SystemAppsDir(), cfg.SystemAppsRepo, cfg.GitHubToken, true); err != nil {
+		return fmt.Errorf("failed to update system apps repo: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Adds a `tronbyt-server update-system-apps` subcommand, which lets a user update the system apps repo on a cron.