### PR TITLE
chore: improve default log formatting

### DIFF
--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
+	"time"
 	"tronbyt-server/cmd/server/boot"
 	"tronbyt-server/cmd/server/health"
 	"tronbyt-server/cmd/server/migrate"
@@ -12,6 +14,8 @@ import (
 	"tronbyt-server/cmd/server/updatesystemapps"
 	"tronbyt-server/internal/config"
 
+	"github.com/lmittmann/tint"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
 
@@ -43,8 +47,17 @@ func New() *cobra.Command {
 func preRun(cmd *cobra.Command, _ []string) error {
 	cmd.SilenceUsage = true
 
+	var color bool
+	if f, ok := cmd.ErrOrStderr().(*os.File); ok {
+		color = isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+	}
+
 	// Initialize slog before anything else that might log
-	slog.SetDefault(slog.New(slog.NewTextHandler(cmd.ErrOrStderr(), nil)))
+	slog.SetDefault(slog.New(tint.NewHandler(cmd.ErrOrStderr(), &tint.Options{
+		Level:      slog.LevelInfo,
+		TimeFormat: time.RFC3339,
+		NoColor:    !color,
+	})))
 
 	// Load configuration early to get default DB path
 	cfg, err := config.LoadSettings()
@@ -70,14 +83,17 @@ func preRun(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Create handler options with the parsed level
-	loggerHandlerOpts := &slog.HandlerOptions{
-		Level: level,
-	}
 	var logHandler slog.Handler
 	if cfg.LogFormat == "json" {
-		logHandler = slog.NewJSONHandler(cmd.ErrOrStderr(), loggerHandlerOpts)
+		logHandler = slog.NewJSONHandler(cmd.ErrOrStderr(), &slog.HandlerOptions{
+			Level: level,
+		})
 	} else {
-		logHandler = slog.NewTextHandler(cmd.ErrOrStderr(), loggerHandlerOpts)
+		logHandler = tint.NewHandler(cmd.ErrOrStderr(), &tint.Options{
+			Level:      level,
+			TimeFormat: time.RFC3339,
+			NoColor:    !color,
+		})
 	}
 	slog.SetDefault(slog.New(logHandler))
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/gorilla/sessions v1.4.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
+	github.com/lmittmann/tint v1.1.3
+	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-sqlite3 v1.14.42
 	github.com/nicksnyder/go-i18n/v2 v2.6.1
 	github.com/prometheus/client_golang v1.23.2
@@ -91,7 +93,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nathan-osman/go-sunrise v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,8 @@ github.com/kyokomi/emoji/v2 v2.2.13 h1:GhTfQa67venUUvmleTNFnb+bi7S3aocF7ZCXU9fSO
 github.com/kyokomi/emoji/v2 v2.2.13/go.mod h1:JUcn42DTdsXJo1SWanHh4HKDEyPaR5CqkmoirZZP9qE=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/lmittmann/tint v1.1.3 h1:Hv4EaHWXQr+GTFnOU4VKf8UvAtZgn0VuKT+G0wFlO3I=
+github.com/lmittmann/tint v1.1.3/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=


### PR DESCRIPTION
Adds https://github.com/lmittmann/tint for the text log formatter. This adds colored logs when the output is a terminal and a format that closer matches slog's default logger.