### PR TITLE
allow for API pushed app deletion based on installationID

### DIFF
--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -822,22 +822,35 @@ func (s *Server) handlePatchInstallation(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleDeleteInstallationAPI(w http.ResponseWriter, r *http.Request) {
-	iname := filepath.Base(r.PathValue("iname"))
+	installID := filepath.Base(r.PathValue("iname"))
 
 	device := GetDevice(r)
-	if _, err := gorm.G[data.App](s.DB).Where("device_id = ? AND iname = ?", device.ID, iname).Delete(r.Context()); err != nil {
+
+	// First try to find the app by iname (server-generated ID)
+	app, err := gorm.G[data.App](s.DB).Where("device_id = ? AND iname = ?", device.ID, installID).First(r.Context())
+	if err != nil {
+		// If not found by iname, try to find by installationID (stored in path as "pushed:{installationID}")
+		app, err = gorm.G[data.App](s.DB).Where("device_id = ? AND path = ?", device.ID, "pushed:"+installID).First(r.Context())
+		if err != nil {
+			http.Error(w, "App not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	// Delete the app
+	if _, err := gorm.G[data.App](s.DB).Where("id = ?", app.ID).Delete(r.Context()); err != nil {
 		http.Error(w, "Failed to delete app", http.StatusInternalServerError)
 		return
 	}
 
-	// Clean up files
+	// Clean up files using the actual iname
 	webpDir, err := s.ensureDeviceImageDir(device.ID)
 	if err != nil {
 		slog.Error("Failed to get device webp directory for app delete cleanup", "device_id", device.ID, "error", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
-	matches, _ := filepath.Glob(filepath.Join(webpDir, fmt.Sprintf("*-%s.webp", iname)))
+	matches, _ := filepath.Glob(filepath.Join(webpDir, fmt.Sprintf("*-%s.webp", app.Iname)))
 	for _, match := range matches {
 		if err := os.Remove(match); err != nil {
 			slog.Error("Failed to remove webp file", "path", match, "error", err)

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -850,6 +850,15 @@ func (s *Server) handleDeleteInstallationAPI(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
+	// Clean up pushed app image if applicable
+	if app.Pushed && app.Path != nil && len(*app.Path) > 7 && (*app.Path)[:7] == "pushed:" {
+		pushedID := (*app.Path)[7:]
+		pushedWebpPath := filepath.Join(webpDir, "pushed", pushedID+".webp")
+		if err := os.Remove(pushedWebpPath); err != nil && !os.IsNotExist(err) {
+			slog.Error("Failed to remove pushed webp file", "path", pushedWebpPath, "error", err)
+		}
+	}
+
 	matches, _ := filepath.Glob(filepath.Join(webpDir, fmt.Sprintf("*-%s.webp", app.Iname)))
 	for _, match := range matches {
 		if err := os.Remove(match); err != nil {

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -749,6 +749,46 @@ func TestHandleDeleteInstallationAPI(t *testing.T) {
 	}
 }
 
+func TestHandleDeleteInstallationAPI_ByInstallationID(t *testing.T) {
+	s := newTestServerAPI(t)
+	apiKey := "test_api_key"
+	deviceID := "testdevice"
+	installationID := "my-custom-pushed-app"
+	pushedPath := "pushed:" + installationID
+
+	// Add a pushed app with a numeric iname but custom installationID in path
+	app := data.App{
+		DeviceID:    deviceID,
+		Iname:       "999", // Server-generated numeric iname
+		Name:        "pushed",
+		UInterval:   10,
+		DisplayTime: 0,
+		Enabled:     true,
+		Order:       0,
+		Pushed:      true,
+		Path:        &pushedPath,
+	}
+	if err := gorm.G[data.App](s.DB).Create(context.Background(), &app); err != nil {
+		t.Fatalf("Failed to create pushed app: %v", err)
+	}
+
+	// Delete using the user-supplied installationID (not the numeric iname)
+	req := newAPIRequest("DELETE", fmt.Sprintf("/v0/devices/%s/installations/%s", deviceID, installationID), apiKey, nil)
+	rr := httptest.NewRecorder()
+
+	s.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("handler returned wrong status code: got %v want %v, body: %s",
+			rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	// Verify app is deleted
+	if _, err := gorm.G[data.App](s.DB).Where("device_id = ? AND iname = ?", deviceID, "999").First(context.Background()); err == nil {
+		t.Errorf("App was not deleted")
+	}
+}
+
 func TestHandlePatchDeviceDeviceKey(t *testing.T) {
 	s := newTestServerAPI(t)
 	apiKey := "device_api_key"


### PR DESCRIPTION
Currently pushed apps with installationID cannot be deleted without looking up the iname generated by the server.  This PR allows for deletion of a pushed app based on installationID