### PR TITLE
display image and installationID for pushed apps

### DIFF
--- a/internal/server/funcmap.go
+++ b/internal/server/funcmap.go
@@ -20,23 +20,24 @@ import (
 
 func getFuncMap() template.FuncMap {
 	return template.FuncMap{
-		"seq":           tmplSeq,
-		"dict":          tmplDict,
-		"timeago":       tmplTimeAgo,
-		"timesince":     tmplTimeSince,
-		"duration":      tmplDuration,
-		"t":             tmplT,
-		"deref":         tmplDeref,
-		"derefOr":       tmplDerefOr,
-		"isPinned":      tmplIsPinned,
-		"json":          tmplJSON,
-		"string":        tmplString,
-		"substr":        tmplSubstr,
-		"split":         strings.Split,
-		"trim":          strings.TrimSpace,
-		"slice":         tmplSlice,
-		"contains":      tmplContains,
-		"webauthn_icon": tmplWebAuthnIcon,
+		"seq":            tmplSeq,
+		"dict":           tmplDict,
+		"timeago":        tmplTimeAgo,
+		"timesince":      tmplTimeSince,
+		"duration":       tmplDuration,
+		"t":              tmplT,
+		"deref":          tmplDeref,
+		"derefOr":        tmplDerefOr,
+		"isPinned":       tmplIsPinned,
+		"json":           tmplJSON,
+		"string":         tmplString,
+		"substr":         tmplSubstr,
+		"split":          strings.Split,
+		"trim":           strings.TrimSpace,
+		"slice":          tmplSlice,
+		"contains":       tmplContains,
+		"webauthn_icon":  tmplWebAuthnIcon,
+		"installationID": tmplInstallationID,
 	}
 }
 
@@ -224,6 +225,13 @@ func tmplSlice(args ...string) []string {
 
 func tmplContains(slice []string, item string) bool {
 	return slices.Contains(slice, item)
+}
+
+func tmplInstallationID(app data.App) string {
+	if app.Pushed && app.Path != nil && strings.HasPrefix(*app.Path, "pushed:") {
+		return strings.TrimPrefix(*app.Path, "pushed:")
+	}
+	return app.Iname
 }
 
 func tmplWebAuthnIcon(authenticator string, dark bool) template.URL {

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"tronbyt-server/internal/apps"
@@ -320,6 +321,28 @@ func (s *Server) handlePushApp(w http.ResponseWriter, r *http.Request) {
 		if appPath == "" {
 			http.Error(w, "App not found", http.StatusNotFound)
 			return
+		}
+	}
+
+	// For pushed apps (existing app with "pushed:" path), skip rendering and push existing image
+	if existingApp != nil && existingApp.Pushed {
+		if existingApp.Path != nil && strings.HasPrefix(*existingApp.Path, "pushed:") {
+			installationID := strings.TrimPrefix(*existingApp.Path, "pushed:")
+			pushedImagePath := filepath.Join(s.DataDir, "webp", device.ID, "pushed", installationID+".webp")
+			if imgBytes, err := os.ReadFile(pushedImagePath); err == nil {
+				// Notify device via Websocket (unless background)
+				if !dataReq.Background {
+					s.Broadcaster.Notify(device.ID, imgBytes)
+				}
+				if err := s.ensurePushedApp(r.Context(), device.ID, installationID); err != nil {
+					slog.Error("Error adding pushed app", "error", err)
+				}
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write([]byte("App pushed.")); err != nil {
+					slog.Error("Failed to write response", "error", err)
+				}
+				return
+			}
 		}
 	}
 

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -328,7 +328,7 @@ func (s *Server) handlePushApp(w http.ResponseWriter, r *http.Request) {
 	if existingApp != nil && existingApp.Pushed {
 		if existingApp.Path != nil && strings.HasPrefix(*existingApp.Path, "pushed:") {
 			installationID := strings.TrimPrefix(*existingApp.Path, "pushed:")
-			pushedImagePath := filepath.Join(s.DataDir, "webp", device.ID, "pushed", installationID+".webp")
+pushedImagePath, _ := securejoin.SecureJoin(filepath.Join(s.DataDir, "webp", device.ID, "pushed"), installationID+".webp")
 			if imgBytes, err := os.ReadFile(pushedImagePath); err == nil {
 				// Notify device via Websocket (unless background)
 				if !dataReq.Background {

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -328,7 +328,12 @@ func (s *Server) handlePushApp(w http.ResponseWriter, r *http.Request) {
 	if existingApp != nil && existingApp.Pushed {
 		if existingApp.Path != nil && strings.HasPrefix(*existingApp.Path, "pushed:") {
 			installationID := strings.TrimPrefix(*existingApp.Path, "pushed:")
-pushedImagePath, _ := securejoin.SecureJoin(filepath.Join(s.DataDir, "webp", device.ID, "pushed"), installationID+".webp")
+			pushedImagePath, err := securejoin.SecureJoin(filepath.Join(s.DataDir, "webp", device.ID, "pushed"), installationID+".webp")
+			if err != nil {
+				slog.Error("Failed to resolve pushed image path", "error", err)
+				http.Error(w, "Image not found", http.StatusNotFound)
+				return
+			}
 			if imgBytes, err := os.ReadFile(pushedImagePath); err == nil {
 				// Notify device via Websocket (unless background)
 				if !dataReq.Background {

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -554,6 +554,26 @@ func (s *Server) handleRenderConfigPreview(w http.ResponseWriter, r *http.Reques
 	device := GetDevice(r)
 	app := GetApp(r)
 
+	// For pushed apps, skip rendering and serve the existing image directly
+	if app.Pushed {
+		webpDir, err := s.ensureDeviceImageDir(id)
+		if err != nil {
+			slog.Error("Failed to get device webp directory for config preview", "device_id", id, "error", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		if app.Path != nil && strings.HasPrefix(*app.Path, "pushed:") {
+			installationID := strings.TrimPrefix(*app.Path, "pushed:")
+			path := filepath.Join(webpDir, "pushed", installationID+".webp")
+			if _, err := os.Stat(path); err == nil {
+				http.ServeFile(w, r, path)
+				return
+			}
+		}
+		s.sendDefaultImage(w, r, device)
+		return
+	}
+
 	// Check for 'config' query param
 	configParam := r.URL.Query().Get("config")
 	if configParam != "" {
@@ -627,6 +647,33 @@ func (s *Server) handleRenderConfigPreview(w http.ResponseWriter, r *http.Reques
 func (s *Server) handlePushPreview(w http.ResponseWriter, r *http.Request) {
 	device := GetDevice(r)
 	app := GetApp(r)
+
+	// For pushed apps, serve the existing image directly without rendering
+	if app.Pushed && app.Path != nil && strings.HasPrefix(*app.Path, "pushed:") {
+		installationID := strings.TrimPrefix(*app.Path, "pushed:")
+		webpDir, err := s.ensureDeviceImageDir(device.ID)
+		if err != nil {
+			slog.Error("Failed to get device webp directory for push preview", "device_id", device.ID, "error", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		pushedImagePath := filepath.Join(webpDir, "pushed", installationID+".webp")
+		imgBytes, err := os.ReadFile(pushedImagePath)
+		if err != nil {
+			slog.Error("Failed to read pushed image for preview", "path", pushedImagePath, "error", err)
+			http.Error(w, "Image not found", http.StatusNotFound)
+			return
+		}
+		// Push preview image to device (ephemeral)
+		if err := s.savePushedImage(device.ID, app.Iname, imgBytes); err != nil {
+			http.Error(w, "Failed to push preview", http.StatusInternalServerError)
+			return
+		}
+		// Notify device via Websocket (Broadcaster)
+		s.Broadcaster.Notify(device.ID, imgBytes)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 
 	// Parse Config from Body
 	var configBody map[string]any

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -550,7 +550,6 @@ func (s *Server) handleCurrentApp(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleRenderConfigPreview(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	iname := r.PathValue("iname")
 
 	device := GetDevice(r)
 	app := GetApp(r)
@@ -598,11 +597,24 @@ func (s *Server) handleRenderConfigPreview(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
+
+	// For pushed apps, look up by installationID (stored in path as "pushed:{installationID}")
+	if app.Pushed && app.Path != nil && strings.HasPrefix(*app.Path, "pushed:") {
+		installationID := strings.TrimPrefix(*app.Path, "pushed:")
+		path := filepath.Join(webpDir, "pushed", installationID+".webp")
+		if _, err := os.Stat(path); err == nil {
+			http.ServeFile(w, r, path)
+			return
+		}
+	}
+
+	// Standard app preview
 	filename := fmt.Sprintf("%s-%s.webp", app.Name, app.Iname)
 	path := filepath.Join(webpDir, filename)
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		path = filepath.Join(webpDir, "pushed", iname+".webp")
+		// Try pushed subdirectory with iname as fallback
+		path = filepath.Join(webpDir, "pushed", app.Iname+".webp")
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			s.sendDefaultImage(w, r, device)
 			return

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -564,7 +564,12 @@ func (s *Server) handleRenderConfigPreview(w http.ResponseWriter, r *http.Reques
 		}
 		if app.Path != nil && strings.HasPrefix(*app.Path, "pushed:") {
 			installationID := strings.TrimPrefix(*app.Path, "pushed:")
-			path := filepath.Join(webpDir, "pushed", installationID+".webp")
+			path, err := securejoin.SecureJoin(filepath.Join(webpDir, "pushed"), installationID+".webp")
+			if err != nil {
+				slog.Error("Failed to resolve pushed image path", "error", err)
+				s.sendDefaultImage(w, r, device)
+				return
+			}
 			if _, err := os.Stat(path); err == nil {
 				http.ServeFile(w, r, path)
 				return

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -674,12 +674,7 @@ func (s *Server) handlePushPreview(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Image not found", http.StatusNotFound)
 			return
 		}
-		// Push preview image to device (ephemeral)
-		if err := s.savePushedImage(device.ID, app.Iname, imgBytes); err != nil {
-			http.Error(w, "Failed to push preview", http.StatusInternalServerError)
-			return
-		}
-		// Notify device via Websocket (Broadcaster)
+		// Notify device via Websocket (Broadcaster) - no need to re-save, image already exists
 		s.Broadcaster.Notify(device.ID, imgBytes)
 		w.WriteHeader(http.StatusOK)
 		return

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -621,7 +621,12 @@ func (s *Server) handleRenderConfigPreview(w http.ResponseWriter, r *http.Reques
 	// For pushed apps, look up by installationID (stored in path as "pushed:{installationID}")
 	if app.Pushed && app.Path != nil && strings.HasPrefix(*app.Path, "pushed:") {
 		installationID := strings.TrimPrefix(*app.Path, "pushed:")
-		path := filepath.Join(webpDir, "pushed", installationID+".webp")
+		path, err := securejoin.SecureJoin(filepath.Join(webpDir, "pushed"), installationID+".webp")
+		if err != nil {
+			slog.Error("Failed to resolve pushed image path", "error", err)
+			s.sendDefaultImage(w, r, device)
+			return
+		}
 		if _, err := os.Stat(path); err == nil {
 			http.ServeFile(w, r, path)
 			return
@@ -657,7 +662,12 @@ func (s *Server) handlePushPreview(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
-		pushedImagePath := filepath.Join(webpDir, "pushed", installationID+".webp")
+		pushedImagePath, err := securejoin.SecureJoin(filepath.Join(webpDir, "pushed"), installationID+".webp")
+		if err != nil {
+			slog.Error("Failed to resolve pushed image path", "error", err)
+			http.Error(w, "Image not found", http.StatusNotFound)
+			return
+		}
 		imgBytes, err := os.ReadFile(pushedImagePath)
 		if err != nil {
 			slog.Error("Failed to read pushed image for preview", "path", pushedImagePath, "error", err)

--- a/internal/server/rotation.go
+++ b/internal/server/rotation.go
@@ -14,6 +14,7 @@ import (
 	"tronbyt-server/internal/data"
 	"tronbyt-server/web"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"gorm.io/gorm"
 )
 
@@ -340,7 +341,12 @@ func createExpandedAppsList(device *data.Device, apps []*data.App) []*data.App {
 func (s *Server) getAppWebpPath(deviceWebpDir string, app *data.App) string {
 	if app.Pushed && app.Path != nil && strings.HasPrefix(*app.Path, "pushed:") {
 		installID := strings.TrimPrefix(*app.Path, "pushed:")
-		return filepath.Join(deviceWebpDir, "pushed", installID+".webp")
+		path, err := securejoin.SecureJoin(filepath.Join(deviceWebpDir, "pushed"), installID+".webp")
+		if err != nil {
+			slog.Error("Failed to resolve pushed image path", "error", err)
+			return ""
+		}
+		return path
 	}
 	appBasename := fmt.Sprintf("%s-%s", app.Name, app.Iname)
 	return filepath.Join(deviceWebpDir, fmt.Sprintf("%s.webp", appBasename))

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1,12 +1,14 @@
 {{ define "configapp" }}
 {{ template "base" . }}
 {{ end }}
-{{ define "title" }}{{ t .Localizer "Configuring" }} {{ .App.Name }}{{ end }}
+{{ define "title" }}{{ t .Localizer "Configuring" }} {{ if eq .App.Name "pushed" }}{{ installationID .App }}{{ else }}{{ .App.Name }}{{ end }}{{ end }}
 {{ define "header" }}
 <link rel="stylesheet" href="/static/css/configapp-simple.css">
 <link rel="stylesheet" href="/static/css/updateapp-simple.css">
 <script src="/static/js/location.js"></script>
-<h1>{{ t .Localizer "Configuring" }} {{ .App.Iname }} ({{ .App.Name }})</h1>
+<h1>
+{{ t .Localizer "Configuring" }} {{ if eq .App.Name "pushed" }}{{ installationID .App }}{{ else }}{{ .App.Iname }} ({{ .App.Name }}){{ end }}
+</h1>
 {{ end }}
 {{ define "content" }}
 <!-- Navigation and Toggle Buttons -->

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="/static/css/updateapp-simple.css">
 <script src="/static/js/location.js"></script>
 <h1>
-{{ t .Localizer "Configuring" }} {{ if eq .App.Name "pushed" }}{{ installationID .App }}{{ else }}{{ .App.Iname }} ({{ .App.Name }}){{ end }}
+{{ t .Localizer "Configuring" }} {{ if eq .App.Name "pushed" }}{{ installationID .App }}(pushed){{ else }}{{ .App.Iname }} ({{ .App.Name }}){{ end }}
 </h1>
 {{ end }}
 {{ define "content" }}
@@ -97,7 +97,7 @@
                        id="name"
                        name="name"
                        class="form-control"
-                       value="{{ .App.Name }}"
+                       value="{{ if eq .App.Name "pushed" }}{{ installationID .App }}{{ else }}{{ .App.Name }}{{ end }}"
                        readonly>
             </td>
         </tr>

--- a/web/templates/partials/app_card.html
+++ b/web/templates/partials/app_card.html
@@ -31,7 +31,7 @@
     <!-- Middle: App Info and Action Buttons -->
     <div class="app-info">
         <div class="app-header">
-            <h3>{{ .App.Name }}-{{ .App.Iname }}</h3>
+            <h3>{{ if eq .App.Name "pushed" }}{{ installationID .App }}{{ else }}{{ .App.Name }}-{{ .App.Iname }}{{ end }}</h3>
             <div class="app-status">
                 {{ if isPinned .Device .App.Iname }}
                 <span class="status-badge pinned"><i class="fa-solid fa-thumbtack" aria-hidden="true"></i> {{ t .Localizer "PINNED" }}</span>

--- a/web/templates/partials/app_card.html
+++ b/web/templates/partials/app_card.html
@@ -31,7 +31,9 @@
     <!-- Middle: App Info and Action Buttons -->
     <div class="app-info">
         <div class="app-header">
-            <h3>{{ if eq .App.Name "pushed" }}{{ installationID .App }}{{ else }}{{ .App.Name }}-{{ .App.Iname }}{{ end }}</h3>
+            <h3>
+            {{ if eq .App.Name "pushed" }}{{ installationID .App }}(pushed){{ else }}{{ .App.Name }}-{{ .App.Iname }}{{ end }}
+            </h3>
             <div class="app-status">
                 {{ if isPinned .Device .App.Iname }}
                 <span class="status-badge pinned"><i class="fa-solid fa-thumbtack" aria-hidden="true"></i> {{ t .Localizer "PINNED" }}</span>


### PR DESCRIPTION
pushed apps with installationID were not displaying correctly.  This uses the installationID as the name of the app and also allows shows the preview of the app correctly.