### PR TITLE
fix(web): polish login screen template

### DIFF
--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -6,11 +6,24 @@
 <h1>{{ t .Localizer "Log In" }}</h1>
 {{ end }}
 {{ define "content" }}
+{{ if .Flashes }}
+<div class="w3-panel w3-red">
+    {{ range .Flashes }}
+    <p>{{ . }}</p>
+    {{ end }}
+</div>
+{{ end }}
 <form method="post">
     <label for="username">{{ t .Localizer "Username" }}</label>
-    <input name="username" id="username" required>
+    <input class="w3-input w3-border" name="username" id="username" required>
+    <br>
     <label for="password">{{ t .Localizer "Password" }}</label>
-    <input type="password" name="password" id="password" required>
+    <input class="w3-input w3-border"
+           type="password"
+           name="password"
+           id="password"
+           required>
+    <br>
     <div>
         <input type="checkbox" name="remember" id="remember">
         <label for="remember">{{ t .Localizer "Remember Me" }}</label>
@@ -31,12 +44,12 @@
     {{ end }}
 </div>
 <script>
-    function loginWebAuthn() {
+    (function () {
         if (!window.PublicKeyCredential || !navigator.credentials) {
             const el = document.getElementById('webauthn-login-container');
             if (el) el.style.display = 'none';
         }
-    });
+    })();
 
     function bufferDecode(value) {
         return Uint8Array.from(atob(value.replace(/-/g, "+").replace(/_/g, "/")), c => c.charCodeAt(0));


### PR DESCRIPTION
## Summary

Fixes three issues with the login screen template to bring it in line with the register and edit pages after the recent UI overhaul (PR #794).

## Changes

1. **Flash message rendering** — The backend (`auth.go:145,159`) sends "Invalid username or password" flash messages on failed login, but the template had no `{{ if .Flashes }}` block to display them. Login errors were silent. Added the same flash rendering block used in `register.html`.

2. **Form input styling** — Added `w3-input w3-border` CSS classes and `<br>` spacing to the username and password fields, matching the register and edit templates.

3. **WebAuthn detection fix** — The first `loginWebAuthn()` function had a stray `});` (syntax error) and was a named function that shadowed the real async `loginWebAuthn()` below it. Converted it to an IIFE so it runs on page load and hides the passkey button on browsers that don't support WebAuthn.

## Testing

- `djlint web/templates --profile=golang --check` passes (0 files would be updated)
- Template-only change, no Go code modified

Fixes #800

This contribution was developed with AI assistance.