### PR TITLE
fix custom recurrance ui bugs

### DIFF
--- a/internal/server/funcmap.go
+++ b/internal/server/funcmap.go
@@ -7,7 +7,6 @@ import (
 	"html/template"
 	"log/slog"
 	"reflect"
-	"slices"
 	"strings"
 	"time"
 
@@ -224,21 +223,30 @@ func tmplSlice(args ...string) []string {
 }
 
 func tmplContains(slice any, item string) bool {
-	switch s := slice.(type) {
-	case []string:
-		return slices.Contains(s, item)
-	case []any:
-		for _, v := range s {
-			if str, ok := v.(string); ok && str == item {
-				return true
-			}
-		}
-		return false
-	case nil:
-		return false
-	default:
+	if slice == nil {
 		return false
 	}
+
+	rv := reflect.ValueOf(slice)
+	for rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return false
+		}
+		rv = rv.Elem()
+	}
+
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return false
+	}
+
+	for i := 0; i < rv.Len(); i++ {
+		v := rv.Index(i).Interface()
+		if str, ok := v.(string); ok && str == item {
+			return true
+		}
+	}
+
+	return false
 }
 
 func tmplInstallationID(app data.App) string {

--- a/internal/server/funcmap.go
+++ b/internal/server/funcmap.go
@@ -223,8 +223,22 @@ func tmplSlice(args ...string) []string {
 	return args
 }
 
-func tmplContains(slice []string, item string) bool {
-	return slices.Contains(slice, item)
+func tmplContains(slice any, item string) bool {
+	switch s := slice.(type) {
+	case []string:
+		return slices.Contains(s, item)
+	case []any:
+		for _, v := range s {
+			if str, ok := v.(string); ok && str == item {
+				return true
+			}
+		}
+		return false
+	case nil:
+		return false
+	default:
+		return false
+	}
 }
 
 func tmplInstallationID(app data.App) string {

--- a/internal/server/funcmap_test.go
+++ b/internal/server/funcmap_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"tronbyt-server/internal/data"
+
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/language"
@@ -54,6 +56,65 @@ func TestHumanizeTime(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Using "TimeAgo" as prefix since it uses humanizeTime internally
 			result := humanizeTime(localizer, tt.input, "TimeAgo")
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTmplContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    any
+		item     string
+		expected bool
+	}{
+		{
+			name:     "String slice contains item",
+			slice:    []string{"a", "b", "c"},
+			item:     "b",
+			expected: true,
+		},
+		{
+			name:     "String slice does not contain item",
+			slice:    []string{"a", "b", "c"},
+			item:     "d",
+			expected: false,
+		},
+		{
+			name:     "Any slice contains item",
+			slice:    []any{"a", 1, true},
+			item:     "a",
+			expected: true,
+		},
+		{
+			name:     "Any slice does not contain item",
+			slice:    []any{"a", 1, true},
+			item:     "b",
+			expected: false,
+		},
+		{
+			name:     "Data StringSlice contains item",
+			slice:    data.StringSlice{"a", "b", "c"},
+			item:     "c",
+			expected: true,
+		},
+		{
+			name:     "Nil slice",
+			slice:    nil,
+			item:     "a",
+			expected: false,
+		},
+		{
+			name:     "Not a slice",
+			slice:    "not a slice",
+			item:     "a",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tmplContains(tt.slice, tt.item)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1515,8 +1515,12 @@
              }
          }
       } else {
-         // Clear recurrence_pattern when custom recurrence is disabled
+         // Clear recurrence fields when custom recurrence is disabled
          settings.recurrence_pattern = null;
+         settings.recurrence_type = 'daily';
+         settings.recurrence_interval = 1;
+         settings.recurrence_start_date = '';
+         settings.recurrence_end_date = '';
       }
       return settings;
   }

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1514,6 +1514,9 @@
                  settings.recurrence_pattern.day_of_week = settings.day_of_week_pattern;
              }
          }
+      } else {
+         // Clear recurrence_pattern when custom recurrence is disabled
+         settings.recurrence_pattern = null;
       }
       return settings;
   }


### PR DESCRIPTION
1. Fixed: Invalid JSON error when unselecting the custom recurrence checkbox and saving
File: web/templates/manager/configapp.html
Problem: When the "Use Custom Recurrence" checkbox was unchecked, the collectSettings() function didn't set recurrence_pattern at all, leaving it as undefined. When this was serialized to JSON, it caused issues.
Fix: Added an else branch to explicitly set recurrence_pattern to null when custom recurrence is disabled:
} else {
   // Clear recurrence_pattern when custom recurrence is disabled
   settings.recurrence_pattern = null;
}
2. Fixed: Custom recurrence options don't show after enabling, saving, and returning to the edit page
File: internal/server/funcmap.go
Problem: The tmplContains template function only accepted []string as input, but when data comes from the RecurrencePattern JSONMap field (which stores map[string]any), the weekdays array is stored as []any (Go's []interface{}). This type mismatch caused the template function to fail silently, potentially causing template rendering errors that broke the page.
Fix: Updated tmplContains to accept any type and handle both []string and []any slices