### PR TITLE
feat: auto-reload TLS certificates on file change

### DIFF
--- a/cmd/server/serve/http.go
+++ b/cmd/server/serve/http.go
@@ -63,15 +63,16 @@ func serve(cfg *config.Settings, srv *server.Server) error {
 	// TLS Config (Shared)
 	var tlsConfig *tls.Config
 	if cfg.SSLCertFile != "" && cfg.SSLKeyFile != "" {
-		cert, err := tls.LoadX509KeyPair(cfg.SSLCertFile, cfg.SSLKeyFile)
+		cw, err := newCertWatcher(cfg.SSLCertFile, cfg.SSLKeyFile)
 		if err != nil {
 			return fmt.Errorf("failed to load TLS certificates: %w", err)
 		}
 		tlsConfig = &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			NextProtos:   []string{"h2", "http/1.1"},
+			GetCertificate: cw.getCertificate,
+			NextProtos:     []string{"h2", "http/1.1"},
 		}
 		slog.Info("TLS certificates loaded", "cert", cfg.SSLCertFile, "key", cfg.SSLKeyFile)
+		cw.watch()
 	}
 
 	// HTTP/3 (QUIC) Support

--- a/cmd/server/serve/http.go
+++ b/cmd/server/serve/http.go
@@ -67,6 +67,11 @@ func serve(cfg *config.Settings, srv *server.Server) error {
 		if err != nil {
 			return fmt.Errorf("failed to load TLS certificates: %w", err)
 		}
+		defer func() {
+			if err := cw.Close(); err != nil {
+				slog.Debug("Error closing TLS cert watcher", "error", err)
+			}
+		}()
 		tlsConfig = &tls.Config{
 			GetCertificate: cw.getCertificate,
 			NextProtos:     []string{"h2", "http/1.1"},

--- a/cmd/server/serve/tls_reload.go
+++ b/cmd/server/serve/tls_reload.go
@@ -17,18 +17,31 @@ type certWatcher struct {
 	cert     *tls.Certificate
 	certFile string
 	keyFile  string
+	watcher  *fsnotify.Watcher
 }
 
 // newCertWatcher creates a certWatcher and performs the initial certificate load.
 func newCertWatcher(certFile, keyFile string) (*certWatcher, error) {
 	cw := &certWatcher{
-		certFile: certFile,
-		keyFile:  keyFile,
+		certFile: filepath.Clean(certFile),
+		keyFile:  filepath.Clean(keyFile),
 	}
 	if err := cw.reload(); err != nil {
 		return nil, err
 	}
 	return cw, nil
+}
+
+// Close stops the file watcher and releases resources.
+func (cw *certWatcher) Close() error {
+	cw.mu.Lock()
+	defer cw.mu.Unlock()
+	if cw.watcher != nil {
+		err := cw.watcher.Close()
+		cw.watcher = nil
+		return err
+	}
+	return nil
 }
 
 // reload loads the certificate from disk and swaps it under the write lock.
@@ -90,6 +103,11 @@ func (cw *certWatcher) watch() {
 		}
 	}
 
+	// Store the watcher so Close() can shut it down.
+	cw.mu.Lock()
+	cw.watcher = watcher
+	cw.mu.Unlock()
+
 	slog.Info("Watching TLS certificate files for changes",
 		"cert", cw.certFile, "key", cw.keyFile)
 
@@ -97,16 +115,17 @@ func (cw *certWatcher) watch() {
 }
 
 // watchLoop runs the fsnotify event loop and triggers debounced reloads.
+// All work (including reloads) runs on this single goroutine: a select-based
+// timer ensures that only one reload can be in flight at a time, and rapid
+// successive events are coalesced into a single reload after a quiet period.
 func (cw *certWatcher) watchLoop(watcher *fsnotify.Watcher) {
 	const debounceDelay = 1 * time.Second
 	var timer *time.Timer
+	var delayChan <-chan time.Time
 
 	defer func() {
 		if timer != nil {
 			timer.Stop()
-		}
-		if err := watcher.Close(); err != nil {
-			slog.Debug("Error closing TLS file watcher", "error", err)
 		}
 	}()
 
@@ -146,11 +165,14 @@ func (cw *certWatcher) watchLoop(watcher *fsnotify.Watcher) {
 			if timer != nil {
 				timer.Stop()
 			}
-			timer = time.AfterFunc(debounceDelay, func() {
-				if err := cw.reload(); err != nil {
-					slog.Error("Failed to reload TLS certificate", "error", err)
-				}
-			})
+			timer = time.NewTimer(debounceDelay)
+			delayChan = timer.C
+
+		case <-delayChan:
+			delayChan = nil
+			if err := cw.reload(); err != nil {
+				slog.Error("Failed to reload TLS certificate", "error", err)
+			}
 
 		case err, ok := <-watcher.Errors:
 			if !ok {

--- a/cmd/server/serve/tls_reload.go
+++ b/cmd/server/serve/tls_reload.go
@@ -98,33 +98,23 @@ func (cw *certWatcher) watch() {
 
 // watchLoop runs the fsnotify event loop and triggers debounced reloads.
 func (cw *certWatcher) watchLoop(watcher *fsnotify.Watcher) {
+	const debounceDelay = 1 * time.Second
+	var timer *time.Timer
+
 	defer func() {
+		if timer != nil {
+			timer.Stop()
+		}
 		if err := watcher.Close(); err != nil {
 			slog.Debug("Error closing TLS file watcher", "error", err)
 		}
 	}()
-
-	const debounceDelay = 1 * time.Second
-	var timer *time.Timer
 
 	for {
 		select {
 		case event, ok := <-watcher.Events:
 			if !ok {
 				return
-			}
-
-			// When a watched file is removed or renamed (atomic save),
-			// re-add the watch after a brief delay so the new inode is
-			// picked up.
-			if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
-				if event.Name == cw.certFile || event.Name == cw.keyFile {
-					time.Sleep(50 * time.Millisecond)
-					if err := watcher.Add(event.Name); err != nil {
-						slog.Debug("Could not re-add TLS file watch (file may not exist yet)",
-							"error", err, "file", event.Name)
-					}
-				}
 			}
 
 			// Determine if the event is for one of our files. For parent
@@ -138,6 +128,17 @@ func (cw *certWatcher) watchLoop(watcher *fsnotify.Watcher) {
 			// Only react to writes and creates (not chmod, etc.).
 			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
 				continue
+			}
+
+			// If a file was recreated (e.g., via atomic save), re-add the
+			// watch to ensure we continue monitoring it. The parent
+			// directory watch catches Create events when a new inode
+			// replaces the old one.
+			if event.Op&fsnotify.Create != 0 {
+				if err := watcher.Add(event.Name); err != nil {
+					slog.Debug("Failed to re-add TLS file watch",
+						"error", err, "file", event.Name)
+				}
 			}
 
 			// Debounce: reset the timer on each relevant event; reload

--- a/cmd/server/serve/tls_reload.go
+++ b/cmd/server/serve/tls_reload.go
@@ -13,20 +13,28 @@ import (
 // certWatcher manages hot-reloading of TLS certificates by watching the
 // certificate and key files for changes using fsnotify.
 type certWatcher struct {
-	mu       sync.RWMutex
-	cert     *tls.Certificate
-	certFile string
-	keyFile  string
-	watcher  *fsnotify.Watcher
+	mu            sync.RWMutex
+	cert          *tls.Certificate
+	certFile      string
+	keyFile       string
+	watcher       *fsnotify.Watcher
+	debounceDelay time.Duration
 }
 
 // newCertWatcher creates a certWatcher and performs the initial certificate load.
 func newCertWatcher(certFile, keyFile string) (*certWatcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
 	cw := &certWatcher{
-		certFile: filepath.Clean(certFile),
-		keyFile:  filepath.Clean(keyFile),
+		certFile:      filepath.Clean(certFile),
+		keyFile:       filepath.Clean(keyFile),
+		watcher:       watcher,
+		debounceDelay: 1 * time.Second,
 	}
 	if err := cw.reload(); err != nil {
+		_ = watcher.Close()
 		return nil, err
 	}
 	return cw, nil
@@ -71,19 +79,10 @@ func (cw *certWatcher) getCertificate(*tls.ClientHelloInfo) (*tls.Certificate, e
 // while both files are still being written (e.g., certbot renewals or atomic
 // editor saves).
 func (cw *certWatcher) watch() {
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		slog.Error("Failed to create TLS cert file watcher", "error", err)
-		return
-	}
-
 	// Watch the specific files for direct writes.
 	for _, f := range []string{cw.certFile, cw.keyFile} {
-		if err := watcher.Add(f); err != nil {
+		if err := cw.watcher.Add(f); err != nil {
 			slog.Error("Failed to watch TLS file", "error", err, "file", f)
-			if closeErr := watcher.Close(); closeErr != nil {
-				slog.Debug("Error closing TLS file watcher", "error", closeErr)
-			}
 			return
 		}
 	}
@@ -97,21 +96,16 @@ func (cw *certWatcher) watch() {
 		parentDirs[filepath.Dir(f)] = struct{}{}
 	}
 	for dir := range parentDirs {
-		if err := watcher.Add(dir); err != nil {
+		if err := cw.watcher.Add(dir); err != nil {
 			slog.Warn("Failed to watch parent directory for TLS cert changes",
 				"error", err, "dir", dir)
 		}
 	}
 
-	// Store the watcher so Close() can shut it down.
-	cw.mu.Lock()
-	cw.watcher = watcher
-	cw.mu.Unlock()
-
 	slog.Info("Watching TLS certificate files for changes",
 		"cert", cw.certFile, "key", cw.keyFile)
 
-	go cw.watchLoop(watcher)
+	go cw.watchLoop(cw.watcher)
 }
 
 // watchLoop runs the fsnotify event loop and triggers debounced reloads.
@@ -119,7 +113,6 @@ func (cw *certWatcher) watch() {
 // timer ensures that only one reload can be in flight at a time, and rapid
 // successive events are coalesced into a single reload after a quiet period.
 func (cw *certWatcher) watchLoop(watcher *fsnotify.Watcher) {
-	const debounceDelay = 1 * time.Second
 	var timer *time.Timer
 	var delayChan <-chan time.Time
 
@@ -136,16 +129,18 @@ func (cw *certWatcher) watchLoop(watcher *fsnotify.Watcher) {
 				return
 			}
 
-			// Determine if the event is for one of our files. For parent
-			// directory events we check if the named file is ours.
-			relevant := event.Name == cw.certFile || event.Name == cw.keyFile
+			// Clean the event name to ensure consistent path comparison
+			// regardless of how the OS reports the path (e.g., relative
+			// segments like "./").
+			cleanName := filepath.Clean(event.Name)
+			relevant := cleanName == cw.certFile || cleanName == cw.keyFile
 
 			if !relevant {
 				continue
 			}
 
-			// Only react to writes and creates (not chmod, etc.).
-			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+			// React to writes, creates, and renames (not chmod, etc.).
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
 				continue
 			}
 
@@ -154,9 +149,9 @@ func (cw *certWatcher) watchLoop(watcher *fsnotify.Watcher) {
 			// directory watch catches Create events when a new inode
 			// replaces the old one.
 			if event.Op&fsnotify.Create != 0 {
-				if err := watcher.Add(event.Name); err != nil {
+				if err := watcher.Add(cleanName); err != nil {
 					slog.Debug("Failed to re-add TLS file watch",
-						"error", err, "file", event.Name)
+						"error", err, "file", cleanName)
 				}
 			}
 
@@ -165,7 +160,7 @@ func (cw *certWatcher) watchLoop(watcher *fsnotify.Watcher) {
 			if timer != nil {
 				timer.Stop()
 			}
-			timer = time.NewTimer(debounceDelay)
+			timer = time.NewTimer(cw.debounceDelay)
 			delayChan = timer.C
 
 		case <-delayChan:

--- a/cmd/server/serve/tls_reload.go
+++ b/cmd/server/serve/tls_reload.go
@@ -1,0 +1,161 @@
+package serve
+
+import (
+	"crypto/tls"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// certWatcher manages hot-reloading of TLS certificates by watching the
+// certificate and key files for changes using fsnotify.
+type certWatcher struct {
+	mu       sync.RWMutex
+	cert     *tls.Certificate
+	certFile string
+	keyFile  string
+}
+
+// newCertWatcher creates a certWatcher and performs the initial certificate load.
+func newCertWatcher(certFile, keyFile string) (*certWatcher, error) {
+	cw := &certWatcher{
+		certFile: certFile,
+		keyFile:  keyFile,
+	}
+	if err := cw.reload(); err != nil {
+		return nil, err
+	}
+	return cw, nil
+}
+
+// reload loads the certificate from disk and swaps it under the write lock.
+func (cw *certWatcher) reload() error {
+	cert, err := tls.LoadX509KeyPair(cw.certFile, cw.keyFile)
+	if err != nil {
+		return err
+	}
+	cw.mu.Lock()
+	cw.cert = &cert
+	cw.mu.Unlock()
+	slog.Info("TLS certificate reloaded", "cert", cw.certFile, "key", cw.keyFile)
+	return nil
+}
+
+// getCertificate matches the tls.Config.GetCertificate signature.
+// It is called for every TLS handshake, so new connections always get the
+// latest certificate.
+func (cw *certWatcher) getCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cw.mu.RLock()
+	defer cw.mu.RUnlock()
+	return cw.cert, nil
+}
+
+// watch starts a background goroutine that watches the certificate and key
+// files for changes using fsnotify. Changes are debounced to avoid reloading
+// while both files are still being written (e.g., certbot renewals or atomic
+// editor saves).
+func (cw *certWatcher) watch() {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		slog.Error("Failed to create TLS cert file watcher", "error", err)
+		return
+	}
+
+	// Watch the specific files for direct writes.
+	for _, f := range []string{cw.certFile, cw.keyFile} {
+		if err := watcher.Add(f); err != nil {
+			slog.Error("Failed to watch TLS file", "error", err, "file", f)
+			if closeErr := watcher.Close(); closeErr != nil {
+				slog.Debug("Error closing TLS file watcher", "error", closeErr)
+			}
+			return
+		}
+	}
+
+	// Also watch parent directories to catch atomic saves (editors that
+	// write a temp file and rename it over the target, like vim or sed -i).
+	// When the old inode is replaced, the original file watch becomes stale;
+	// by watching the directory we can detect the new file creation.
+	parentDirs := make(map[string]struct{})
+	for _, f := range []string{cw.certFile, cw.keyFile} {
+		parentDirs[filepath.Dir(f)] = struct{}{}
+	}
+	for dir := range parentDirs {
+		if err := watcher.Add(dir); err != nil {
+			slog.Warn("Failed to watch parent directory for TLS cert changes",
+				"error", err, "dir", dir)
+		}
+	}
+
+	slog.Info("Watching TLS certificate files for changes",
+		"cert", cw.certFile, "key", cw.keyFile)
+
+	go cw.watchLoop(watcher)
+}
+
+// watchLoop runs the fsnotify event loop and triggers debounced reloads.
+func (cw *certWatcher) watchLoop(watcher *fsnotify.Watcher) {
+	defer func() {
+		if err := watcher.Close(); err != nil {
+			slog.Debug("Error closing TLS file watcher", "error", err)
+		}
+	}()
+
+	const debounceDelay = 1 * time.Second
+	var timer *time.Timer
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+
+			// When a watched file is removed or renamed (atomic save),
+			// re-add the watch after a brief delay so the new inode is
+			// picked up.
+			if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+				if event.Name == cw.certFile || event.Name == cw.keyFile {
+					time.Sleep(50 * time.Millisecond)
+					if err := watcher.Add(event.Name); err != nil {
+						slog.Debug("Could not re-add TLS file watch (file may not exist yet)",
+							"error", err, "file", event.Name)
+					}
+				}
+			}
+
+			// Determine if the event is for one of our files. For parent
+			// directory events we check if the named file is ours.
+			relevant := event.Name == cw.certFile || event.Name == cw.keyFile
+
+			if !relevant {
+				continue
+			}
+
+			// Only react to writes and creates (not chmod, etc.).
+			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+				continue
+			}
+
+			// Debounce: reset the timer on each relevant event; reload
+			// only after a quiet period.
+			if timer != nil {
+				timer.Stop()
+			}
+			timer = time.AfterFunc(debounceDelay, func() {
+				if err := cw.reload(); err != nil {
+					slog.Error("Failed to reload TLS certificate", "error", err)
+				}
+			})
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			slog.Error("TLS cert file watcher error", "error", err)
+		}
+	}
+}

--- a/cmd/server/serve/tls_reload_test.go
+++ b/cmd/server/serve/tls_reload_test.go
@@ -1,0 +1,213 @@
+package serve
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestCert creates a self-signed certificate and key and writes them
+// to PEM files in the given directory. Returns the cert file path and key file
+// path.
+func generateTestCert(t *testing.T, dir, prefix string) (string, string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	serial := big.NewInt(time.Now().UnixNano())
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: prefix + ".example.com",
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certFile := filepath.Join(dir, prefix+".pem")
+	keyFile := filepath.Join(dir, prefix+"-key.pem")
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0600))
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0600))
+
+	return certFile, keyFile
+}
+
+// certSerial returns the serial number of the first certificate in the chain
+// served by a certWatcher, or nil on error.
+func certSerial(cw *certWatcher) *big.Int {
+	cert, err := cw.getCertificate(nil)
+	if err != nil || cert == nil {
+		return nil
+	}
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil
+	}
+	return x509Cert.SerialNumber
+}
+
+// TestCertWatcherInitialLoad verifies that a new certWatcher loads the
+// certificate successfully and serves it via getCertificate.
+func TestCertWatcherInitialLoad(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateTestCert(t, dir, "initial")
+
+	cw, err := newCertWatcher(certFile, keyFile)
+	require.NoError(t, err)
+	require.NotNil(t, cw)
+
+	// getCertificate should return a non-nil cert.
+	cert, err := cw.getCertificate(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, cert)
+
+	// The certificate should have at least one certificate in the chain.
+	assert.NotEmpty(t, cert.Certificate)
+	assert.NotNil(t, certSerial(cw))
+}
+
+// TestCertWatcherReload verifies that after writing a new certificate to disk,
+// the watcher reloads and serves the updated certificate.
+func TestCertWatcherReload(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateTestCert(t, dir, "initial")
+
+	cw, err := newCertWatcher(certFile, keyFile)
+	require.NoError(t, err)
+
+	// Get the original cert's serial number.
+	origSerial := certSerial(cw)
+	require.NotNil(t, origSerial)
+
+	// Start watching.
+	cw.watch()
+
+	// Give the watcher time to set up.
+	time.Sleep(100 * time.Millisecond)
+
+	// Write a new certificate pair to the same paths.
+	generateTestCert(t, dir, "initial") // same prefix overwrites the files
+
+	// Wait for debounce + reload (debounce is 1s, give some extra time).
+	time.Sleep(1500 * time.Millisecond)
+
+	// Get the new certificate.
+	newSerial := certSerial(cw)
+	require.NotNil(t, newSerial)
+
+	assert.NotEqual(t, origSerial.String(), newSerial.String(),
+		"certificate should have been reloaded with different serial")
+}
+
+// TestCertWatcherReloadFailureKeepsOldCert verifies that if reloading fails
+// (e.g., only one file is updated), the old certificate is preserved.
+func TestCertWatcherReloadFailureKeepsOldCert(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateTestCert(t, dir, "initial")
+
+	cw, err := newCertWatcher(certFile, keyFile)
+	require.NoError(t, err)
+
+	origSerial := certSerial(cw)
+	require.NotNil(t, origSerial)
+
+	// Corrupt the key file (write invalid PEM).
+	require.NoError(t, os.WriteFile(keyFile, []byte("not a valid key"), 0600))
+
+	// Manual reload attempt should fail.
+	err = cw.reload()
+	assert.Error(t, err, "reload should fail with invalid key material")
+
+	// The old cert should still be served.
+	newSerial := certSerial(cw)
+	require.NotNil(t, newSerial)
+	assert.Equal(t, origSerial.String(), newSerial.String(),
+		"old certificate should still be served after failed reload")
+}
+
+// TestCertWatcherAtomicSave simulates an atomic save where files are renamed
+// over the target paths.
+func TestCertWatcherAtomicSave(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateTestCert(t, dir, "initial")
+
+	cw, err := newCertWatcher(certFile, keyFile)
+	require.NoError(t, err)
+
+	origSerial := certSerial(cw)
+	require.NotNil(t, origSerial)
+
+	cw.watch()
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate atomic save: create temp files, then rename over originals.
+	tmpDir := t.TempDir()
+	newCertFile, newKeyFile := generateTestCert(t, tmpDir, "atomic")
+	newCertData, err := os.ReadFile(newCertFile)
+	require.NoError(t, err)
+	newKeyData, err := os.ReadFile(newKeyFile)
+	require.NoError(t, err)
+
+	// Rename replaces the files (common pattern in editors and certbot).
+	require.NoError(t, os.Rename(newCertFile, certFile))
+	require.NoError(t, os.Rename(newKeyFile, keyFile))
+
+	// After rename, the destination files contain the new data. But since
+	// we're renaming from a different temp dir, the files moved correctly.
+	// Verify they have content:
+	certData, err := os.ReadFile(certFile)
+	require.NoError(t, err)
+	require.Equal(t, newCertData, certData)
+	keyData, err := os.ReadFile(keyFile)
+	require.NoError(t, err)
+	require.Equal(t, newKeyData, keyData)
+
+	// Wait for debounce.
+	time.Sleep(1500 * time.Millisecond)
+
+	newSerial := certSerial(cw)
+	require.NotNil(t, newSerial)
+
+	assert.NotEqual(t, origSerial.String(), newSerial.String(),
+		"certificate should have been reloaded after atomic save")
+}
+
+// TestCertWatcherNilClientHello verifies getCertificate handles nil
+// ClientHelloInfo (the common runtime case when TLS calls without SNI).
+func TestCertWatcherNilClientHello(t *testing.T) {
+	dir := t.TempDir()
+	certFile, keyFile := generateTestCert(t, dir, "nil-hello")
+
+	cw, err := newCertWatcher(certFile, keyFile)
+	require.NoError(t, err)
+
+	cert, err := cw.getCertificate(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, cert)
+}

--- a/cmd/server/serve/tls_reload_test.go
+++ b/cmd/server/serve/tls_reload_test.go
@@ -116,14 +116,11 @@ func TestCertWatcherReload(t *testing.T) {
 	// Write a new certificate pair to the same paths.
 	generateTestCert(t, dir, "initial") // same prefix overwrites the files
 
-	// Wait for debounce + reload (debounce is 10ms, give some extra time).
-	time.Sleep(50 * time.Millisecond)
-
-	// Get the new certificate.
-	newSerial := certSerial(cw)
-	require.NotNil(t, newSerial)
-
-	assert.NotEqual(t, origSerial.String(), newSerial.String(),
+	// Wait for debounce + reload and verify the certificate is updated.
+	assert.Eventually(t, func() bool {
+		newSerial := certSerial(cw)
+		return newSerial != nil && origSerial.String() != newSerial.String()
+	}, 500*time.Millisecond, 10*time.Millisecond,
 		"certificate should have been reloaded with different serial")
 }
 
@@ -192,13 +189,11 @@ func TestCertWatcherAtomicSave(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, newKeyData, keyData)
 
-	// Wait for debounce (debounce is 10ms, give some extra time).
-	time.Sleep(50 * time.Millisecond)
-
-	newSerial := certSerial(cw)
-	require.NotNil(t, newSerial)
-
-	assert.NotEqual(t, origSerial.String(), newSerial.String(),
+	// Wait for debounce + reload and verify the certificate is updated.
+	assert.Eventually(t, func() bool {
+		newSerial := certSerial(cw)
+		return newSerial != nil && origSerial.String() != newSerial.String()
+	}, 500*time.Millisecond, 10*time.Millisecond,
 		"certificate should have been reloaded after atomic save")
 }
 

--- a/cmd/server/serve/tls_reload_test.go
+++ b/cmd/server/serve/tls_reload_test.go
@@ -100,6 +100,7 @@ func TestCertWatcherReload(t *testing.T) {
 
 	cw, err := newCertWatcher(certFile, keyFile)
 	require.NoError(t, err)
+	cw.debounceDelay = 10 * time.Millisecond
 	defer func() { _ = cw.Close() }()
 
 	// Get the original cert's serial number.
@@ -110,13 +111,13 @@ func TestCertWatcherReload(t *testing.T) {
 	cw.watch()
 
 	// Give the watcher time to set up.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// Write a new certificate pair to the same paths.
 	generateTestCert(t, dir, "initial") // same prefix overwrites the files
 
-	// Wait for debounce + reload (debounce is 1s, give some extra time).
-	time.Sleep(1500 * time.Millisecond)
+	// Wait for debounce + reload (debounce is 10ms, give some extra time).
+	time.Sleep(50 * time.Millisecond)
 
 	// Get the new certificate.
 	newSerial := certSerial(cw)
@@ -160,13 +161,14 @@ func TestCertWatcherAtomicSave(t *testing.T) {
 
 	cw, err := newCertWatcher(certFile, keyFile)
 	require.NoError(t, err)
+	cw.debounceDelay = 10 * time.Millisecond
 	defer func() { _ = cw.Close() }()
 
 	origSerial := certSerial(cw)
 	require.NotNil(t, origSerial)
 
 	cw.watch()
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// Simulate atomic save: create temp files, then rename over originals.
 	tmpDir := t.TempDir()
@@ -190,8 +192,8 @@ func TestCertWatcherAtomicSave(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, newKeyData, keyData)
 
-	// Wait for debounce.
-	time.Sleep(1500 * time.Millisecond)
+	// Wait for debounce (debounce is 10ms, give some extra time).
+	time.Sleep(50 * time.Millisecond)
 
 	newSerial := certSerial(cw)
 	require.NotNil(t, newSerial)

--- a/cmd/server/serve/tls_reload_test.go
+++ b/cmd/server/serve/tls_reload_test.go
@@ -100,6 +100,7 @@ func TestCertWatcherReload(t *testing.T) {
 
 	cw, err := newCertWatcher(certFile, keyFile)
 	require.NoError(t, err)
+	defer func() { _ = cw.Close() }()
 
 	// Get the original cert's serial number.
 	origSerial := certSerial(cw)
@@ -159,6 +160,7 @@ func TestCertWatcherAtomicSave(t *testing.T) {
 
 	cw, err := newCertWatcher(certFile, keyFile)
 	require.NoError(t, err)
+	defer func() { _ = cw.Close() }()
 
 	origSerial := certSerial(cw)
 	require.NotNil(t, origSerial)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/cyphar/filepath-securejoin v0.6.1
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-git/go-git/v6 v6.0.0-alpha.3
 	github.com/go-webauthn/webauthn v0.17.2
 	github.com/google/uuid v1.6.0
@@ -62,7 +63,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/ericpauley/go-quantize v0.0.0-20200331213906-ae555eb2afa4 // indirect
 	github.com/fatih/color v1.18.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gen2brain/webp v0.5.5 // indirect


### PR DESCRIPTION
Watch certificate and key files with fsnotify so TLS certs are reloaded automatically when they change on disk (e.g., certbot renewals). Uses a debounced watcher (1s quiet period) to handle partial writes and atomic editor saves.

The tls.Config now uses GetCertificate (per-handshake callback) instead of a static Certificates slice, so both TCP+TLS and HTTP/3 (QUIC) connections pick up the new cert without a server restart.