### PR TITLE
feat: add CoalesceID to push API for ephemeral image deduplication

### DIFF
--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -510,20 +510,37 @@ func (s *Server) savePushedImage(deviceID, installID, coalesceID string, data []
 		// Image push with installID: stable filename, always replaces
 		filename = installID + ".webp"
 	} else if coalesceID != "" {
+		// Validate coalesceID to prevent path traversal and suffix collisions.
+		if len(coalesceID) > 64 {
+			return fmt.Errorf("coalesceID exceeds maximum length of 64 characters")
+		}
+		for _, r := range coalesceID {
+			isValid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
+			if !isValid {
+				return fmt.Errorf("coalesceID contains invalid characters (only alphanumeric, underscore, and dash allowed)")
+			}
+		}
+
 		// Coalesced push: delete existing file with same coalesceID, then save.
 		// At most 1 pending push per coalesceID.
-		suffix := "_" + coalesceID + ".webp"
+		// Filename format: __{timestamp}_{coalesceID}.webp
+		// Extract coalesceID by splitting at the first underscore after the "__" prefix.
 		if entries, err := os.ReadDir(dir); err == nil {
 			for _, entry := range entries {
 				name := entry.Name()
-				if strings.HasPrefix(name, "__") && strings.HasSuffix(name, suffix) {
-					if err := os.Remove(filepath.Join(dir, name)); err != nil {
-						slog.Warn("Failed to remove coalesced push", "name", name, "error", err)
+				if strings.HasPrefix(name, "__") && strings.HasSuffix(name, ".webp") {
+					inner := name[2 : len(name)-5] // strip "__" and ".webp"
+					if _, fileCoalesceID, found := strings.Cut(inner, "_"); found {
+						if fileCoalesceID == coalesceID {
+							if err := os.Remove(filepath.Join(dir, name)); err != nil {
+								slog.Warn("Failed to remove coalesced push", "name", name, "error", err)
+							}
+						}
 					}
 				}
 			}
 		}
-		filename = fmt.Sprintf("__%d%s", time.Now().UnixNano(), suffix)
+		filename = fmt.Sprintf("__%d_%s.webp", time.Now().UnixNano(), coalesceID)
 	} else {
 		// Anonymous push: unbounded ephemeral queue
 		filename = fmt.Sprintf("__%d.webp", time.Now().UnixNano())

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -243,6 +243,7 @@ type PushAppData struct {
 	AppID             string         `json:"app_id"`
 	InstallationID    string         `json:"installationID"`
 	InstallationIDAlt string         `json:"installationId"`
+	CoalesceID        string         `json:"coalesceID"`
 	Background        bool           `json:"background"`
 }
 
@@ -380,7 +381,7 @@ func (s *Server) handlePushApp(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !sent || installationID != "" {
-		if err := s.savePushedImage(device.ID, installationID, imgBytes); err != nil {
+		if err := s.savePushedImage(device.ID, installationID, dataReq.CoalesceID, imgBytes); err != nil {
 			http.Error(w, "Failed to save image", http.StatusInternalServerError)
 			return
 		}
@@ -442,6 +443,7 @@ func (s *Server) handleGetInstallation(w http.ResponseWriter, r *http.Request) {
 type PushData struct {
 	InstallationID    string `json:"installationID"`
 	InstallationIDAlt string `json:"installationId"`
+	CoalesceID        string `json:"coalesceID"`
 	Image             string `json:"image"`
 	Background        bool   `json:"background"`
 }
@@ -479,7 +481,7 @@ func (s *Server) handlePushImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !sent || installID != "" {
-		if err := s.savePushedImage(device.ID, installID, imgBytes); err != nil {
+		if err := s.savePushedImage(device.ID, installID, dataReq.CoalesceID, imgBytes); err != nil {
 			http.Error(w, fmt.Sprintf("Failed to save image: %v", err), http.StatusInternalServerError)
 			return
 		}
@@ -492,7 +494,7 @@ func (s *Server) handlePushImage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) savePushedImage(deviceID, installID string, data []byte) error {
+func (s *Server) savePushedImage(deviceID, installID, coalesceID string, data []byte) error {
 	dir, err := s.ensureDeviceImageDir(deviceID)
 	if err != nil {
 		return fmt.Errorf("failed to get device webp directory: %w", err)
@@ -505,8 +507,25 @@ func (s *Server) savePushedImage(deviceID, installID string, data []byte) error 
 
 	var filename string
 	if installID != "" {
+		// Image push with installID: stable filename, always replaces
 		filename = installID + ".webp"
+	} else if coalesceID != "" {
+		// Coalesced push: delete existing file with same coalesceID, then save.
+		// At most 1 pending push per coalesceID.
+		suffix := "_" + coalesceID + ".webp"
+		if entries, err := os.ReadDir(dir); err == nil {
+			for _, entry := range entries {
+				name := entry.Name()
+				if strings.HasPrefix(name, "__") && strings.HasSuffix(name, suffix) {
+					if err := os.Remove(filepath.Join(dir, name)); err != nil {
+						slog.Warn("Failed to remove coalesced push", "name", name, "error", err)
+					}
+				}
+			}
+		}
+		filename = fmt.Sprintf("__%d%s", time.Now().UnixNano(), suffix)
 	} else {
+		// Anonymous push: unbounded ephemeral queue
 		filename = fmt.Sprintf("__%d.webp", time.Now().UnixNano())
 	}
 

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -528,7 +528,7 @@ func (s *Server) savePushedImage(deviceID, installID, coalesceID string, data []
 		if entries, err := os.ReadDir(dir); err == nil {
 			for _, entry := range entries {
 				name := entry.Name()
-				if strings.HasPrefix(name, "__") && strings.HasSuffix(name, ".webp") {
+				if !entry.IsDir() && strings.HasPrefix(name, "__") && strings.HasSuffix(name, ".webp") {
 					inner := name[2 : len(name)-5] // strip "__" and ".webp"
 					if _, fileCoalesceID, found := strings.Cut(inner, "_"); found {
 						if fileCoalesceID == coalesceID {

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -993,6 +993,71 @@ func TestSavePushedImage_CoalesceID(t *testing.T) {
 	}
 }
 
+func TestSavePushedImage_CoalesceID_SuffixCollision(t *testing.T) {
+	s := newTestServerAPI(t)
+	deviceID := "testdevice-collision"
+	pushedDir := filepath.Join(s.DataDir, "webp", deviceID, "pushed")
+
+	// Save with coalesceID "foo"
+	if err := s.savePushedImage(deviceID, "", "foo", []byte("foo")); err != nil {
+		t.Fatalf("Failed to save with coalesceID 'foo': %v", err)
+	}
+	// Save with coalesceID "bar_foo" (must not collide with "foo")
+	if err := s.savePushedImage(deviceID, "", "bar_foo", []byte("bar_foo")); err != nil {
+		t.Fatalf("Failed to save with coalesceID 'bar_foo': %v", err)
+	}
+
+	entries, err := os.ReadDir(pushedDir)
+	if err != nil {
+		t.Fatalf("Failed to read pushed dir: %v", err)
+	}
+
+	// Both files should exist — "bar_foo" must not have deleted "foo"'s file.
+	// Extract coalesceID from filenames properly (split at first _ after __).
+	fooCount := 0
+	barFooCount := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, "__") && strings.HasSuffix(name, ".webp") {
+			inner := name[2 : len(name)-5]
+			if _, fileCoalesceID, found := strings.Cut(inner, "_"); found {
+				switch fileCoalesceID {
+				case "foo":
+					fooCount++
+				case "bar_foo":
+					barFooCount++
+				}
+			}
+		}
+	}
+	if fooCount != 1 {
+		t.Errorf("Expected 1 file for coalesceID 'foo', got %d: %v", fooCount, entryNames(pushedDir))
+	}
+	if barFooCount != 1 {
+		t.Errorf("Expected 1 file for coalesceID 'bar_foo', got %d: %v", barFooCount, entryNames(pushedDir))
+	}
+}
+
+func TestSavePushedImage_CoalesceID_Invalid(t *testing.T) {
+	s := newTestServerAPI(t)
+
+	// Too long
+	longID := strings.Repeat("a", 65)
+	if err := s.savePushedImage("testdevice", "", longID, []byte("x")); err == nil {
+		t.Error("Expected error for coalesceID > 64 chars, got nil")
+	}
+
+	// Invalid characters (slash)
+	if err := s.savePushedImage("testdevice", "", "foo/bar", []byte("x")); err == nil {
+		t.Error("Expected error for coalesceID with slash, got nil")
+	}
+
+	// Invalid characters (dot)
+	if err := s.savePushedImage("testdevice", "", "foo.bar", []byte("x")); err == nil {
+		t.Error("Expected error for coalesceID with dot, got nil")
+	}
+}
+
 func TestSavePushedImage_Anonymous(t *testing.T) {
 	s := newTestServerAPI(t)
 	deviceID := "testdevice2"

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -327,7 +328,7 @@ def main(config):
 		t.Errorf("Expected body 'App pushed.', got '%s'", rr.Body.String())
 	}
 
-	// Verify image exists
+	// Verify image exists (installID-based: testinstall.webp)
 	expectedPath := filepath.Join(s.DataDir, "webp", deviceID, "pushed", "testinstall.webp")
 	if _, err := os.Stat(expectedPath); os.IsNotExist(err) {
 		t.Errorf("Expected pushed image to exist at %s, but it didn't", expectedPath)
@@ -958,4 +959,116 @@ func TestHandleRebootDeviceAPI(t *testing.T) {
 	if rr.Body.String() != "Reboot command sent." {
 		t.Errorf("Expected body 'Reboot command sent.', got '%s'", rr.Body.String())
 	}
+}
+
+func TestSavePushedImage_CoalesceID(t *testing.T) {
+	s := newTestServerAPI(t)
+	deviceID := "testdevice"
+
+	pushedDir := filepath.Join(s.DataDir, "webp", deviceID, "pushed")
+
+	// Save 5 coalesced pushes with the same coalesceID — only 1 should remain
+	for i := range 5 {
+		imgData := fmt.Appendf(nil, "coalesced image %d", i)
+		if err := s.savePushedImage(deviceID, "", "mycoalesce", imgData); err != nil {
+			t.Fatalf("Failed to save coalesced push %d: %v", i, err)
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	entries, err := os.ReadDir(pushedDir)
+	if err != nil {
+		t.Fatalf("Failed to read pushed dir: %v", err)
+	}
+
+	// With coalesceID, at most 1 file with that ID (__{timestamp}_{coalesceID}.webp)
+	coalescedCount := 0
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "__") && strings.HasSuffix(entry.Name(), "_mycoalesce.webp") {
+			coalescedCount++
+		}
+	}
+	if coalescedCount != 1 {
+		t.Errorf("Expected 1 coalesced file, got %d: %v", coalescedCount, entryNames(pushedDir))
+	}
+}
+
+func TestSavePushedImage_Anonymous(t *testing.T) {
+	s := newTestServerAPI(t)
+	deviceID := "testdevice2"
+
+	pushedDir := filepath.Join(s.DataDir, "webp", deviceID, "pushed")
+
+	// Save 5 anonymous pushes (no installID, no coalesceID) — all should remain
+	for i := range 5 {
+		imgData := fmt.Appendf(nil, "anonymous image %d", i)
+		if err := s.savePushedImage(deviceID, "", "", imgData); err != nil {
+			t.Fatalf("Failed to save anonymous push %d: %v", i, err)
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	entries, err := os.ReadDir(pushedDir)
+	if err != nil {
+		t.Fatalf("Failed to read pushed dir: %v", err)
+	}
+
+	// All 5 files should remain (unbounded anonymous queue)
+	// Anonymous: __{timestamp}.webp (only digits between __ and .webp)
+	ephemeralCount := 0
+	for _, entry := range entries {
+		if isAnonymousEphemeral(entry.Name()) {
+			ephemeralCount++
+		}
+	}
+	if ephemeralCount != 5 {
+		t.Errorf("Expected 5 anonymous ephemeral files, got %d: %v", ephemeralCount, entryNames(pushedDir))
+	}
+}
+
+func TestSavePushedImage_InstallID_Replaces(t *testing.T) {
+	s := newTestServerAPI(t)
+	deviceID := "testdevice3"
+
+	pushedDir := filepath.Join(s.DataDir, "webp", deviceID, "pushed")
+
+	// Save 5 images with same installID
+	for i := range 5 {
+		imgData := fmt.Appendf(nil, "image %d", i)
+		if err := s.savePushedImage(deviceID, "myapp", "", imgData); err != nil {
+			t.Fatalf("Failed to save pushed image %d: %v", i, err)
+		}
+	}
+
+	entries, err := os.ReadDir(pushedDir)
+	if err != nil {
+		t.Fatalf("Failed to read pushed dir: %v", err)
+	}
+
+	// With installID, file is always "myapp.webp" → overwrites → 1 file
+	if len(entries) != 1 {
+		t.Errorf("Expected 1 file with installID (always overwrites), got %d: %v", len(entries), entryNames(pushedDir))
+	}
+	if entries[0].Name() != "myapp.webp" {
+		t.Errorf("Expected file 'myapp.webp', got '%s'", entries[0].Name())
+	}
+}
+
+func entryNames(dir string) []string {
+	entries, _ := os.ReadDir(dir)
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// isAnonymousEphemeral returns true for __{timestamp}.webp files
+// (no underscore between the timestamp and .webp).
+func isAnonymousEphemeral(name string) bool {
+	if !strings.HasPrefix(name, "__") || !strings.HasSuffix(name, ".webp") {
+		return false
+	}
+	inner := name[2 : len(name)-5] // strip "__" and ".webp"
+	return !strings.Contains(inner, "_")
 }

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -718,7 +718,7 @@ func (s *Server) handlePushPreview(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Push preview image to device (ephemeral)
-	if err := s.savePushedImage(device.ID, app.Iname, imgBytes); err != nil {
+	if err := s.savePushedImage(device.ID, app.Iname, "", imgBytes); err != nil {
 		http.Error(w, "Failed to push preview", http.StatusInternalServerError)
 		return
 	}

--- a/internal/server/handlers_device_api_test.go
+++ b/internal/server/handlers_device_api_test.go
@@ -27,7 +27,7 @@ func TestHandleNextApp(t *testing.T) {
 		t.Fatalf("Failed to create app: %v", err)
 	}
 
-	if err := s.savePushedImage("testdevice", "testapp", []byte("dummy image")); err != nil {
+	if err := s.savePushedImage("testdevice", "testapp", "", []byte("dummy image")); err != nil {
 		t.Fatalf("Failed to save pushed image: %v", err)
 	}
 
@@ -106,7 +106,7 @@ func TestHandleNextApp_APIKey(t *testing.T) {
 		Path:      &path,
 	}
 	s.DB.Create(&app)
-	if err := s.savePushedImage("testdevice", "testapp", []byte("dummy image")); err != nil {
+	if err := s.savePushedImage("testdevice", "testapp", "", []byte("dummy image")); err != nil {
 		t.Fatalf("Failed to save pushed image: %v", err)
 	}
 

--- a/internal/server/rotation.go
+++ b/internal/server/rotation.go
@@ -20,18 +20,35 @@ import (
 
 func (s *Server) GetNextAppImage(ctx context.Context, device *data.Device, user *data.User) ([]byte, *data.App, error) {
 	// 1. Check Pushed Ephemeral Images (__*)
+	// Serve the oldest and delete only that one. Anonymous pushes accumulate
+	// unbounded; callers should use coalesceID to limit queue depth.
 	pushedDir := filepath.Join(s.DataDir, "webp", device.ID, "pushed")
 	if entries, err := os.ReadDir(pushedDir); err == nil {
+		var ephemeral []os.DirEntry
 		for _, entry := range entries {
 			if strings.HasPrefix(entry.Name(), "__") {
-				fullPath := filepath.Join(pushedDir, entry.Name())
-				data, err := os.ReadFile(fullPath)
-				if err == nil {
-					if err := os.Remove(fullPath); err != nil {
-						slog.Error("Failed to remove ephemeral image", "path", fullPath, "error", err)
-					}
-					return data, nil, nil
+				ephemeral = append(ephemeral, entry)
+			}
+		}
+		if len(ephemeral) > 0 {
+			// Sort ascending by name (lower timestamp = older)
+			sort.Slice(ephemeral, func(i, j int) bool {
+				return ephemeral[i].Name() < ephemeral[j].Name()
+			})
+
+			oldestPath := filepath.Join(pushedDir, ephemeral[0].Name())
+			imgData, err := os.ReadFile(oldestPath)
+			if err == nil {
+				// Delete only the one served; coalesceID handles dedup at write time
+				if err := os.Remove(oldestPath); err != nil {
+					slog.Warn("Failed to remove ephemeral image", "path", oldestPath, "error", err)
 				}
+				return imgData, nil, nil
+			}
+			// If reading failed, clean it up
+			slog.Warn("Failed to read ephemeral image, cleaning up", "path", oldestPath, "error", err)
+			if err := os.Remove(oldestPath); err != nil {
+				slog.Warn("Failed to remove broken ephemeral image", "path", oldestPath, "error", err)
 			}
 		}
 	}

--- a/internal/server/rotation.go
+++ b/internal/server/rotation.go
@@ -26,7 +26,7 @@ func (s *Server) GetNextAppImage(ctx context.Context, device *data.Device, user 
 	if entries, err := os.ReadDir(pushedDir); err == nil {
 		var ephemeral []os.DirEntry
 		for _, entry := range entries {
-			if strings.HasPrefix(entry.Name(), "__") {
+			if strings.HasPrefix(entry.Name(), "__") && strings.HasSuffix(entry.Name(), ".webp") && !entry.IsDir() {
 				ephemeral = append(ephemeral, entry)
 			}
 		}

--- a/internal/server/rotation.go
+++ b/internal/server/rotation.go
@@ -36,19 +36,21 @@ func (s *Server) GetNextAppImage(ctx context.Context, device *data.Device, user 
 				return ephemeral[i].Name() < ephemeral[j].Name()
 			})
 
-			oldestPath := filepath.Join(pushedDir, ephemeral[0].Name())
-			imgData, err := os.ReadFile(oldestPath)
-			if err == nil {
-				// Delete only the one served; coalesceID handles dedup at write time
-				if err := os.Remove(oldestPath); err != nil {
-					slog.Warn("Failed to remove ephemeral image", "path", oldestPath, "error", err)
+			for _, entry := range ephemeral {
+				entryPath := filepath.Join(pushedDir, entry.Name())
+				imgData, err := os.ReadFile(entryPath)
+				if err == nil {
+					// Delete only the one served; coalesceID handles dedup at write time
+					if err := os.Remove(entryPath); err != nil {
+						slog.Warn("Failed to remove ephemeral image", "path", entryPath, "error", err)
+					}
+					return imgData, nil, nil
 				}
-				return imgData, nil, nil
-			}
-			// If reading failed, clean it up
-			slog.Warn("Failed to read ephemeral image, cleaning up", "path", oldestPath, "error", err)
-			if err := os.Remove(oldestPath); err != nil {
-				slog.Warn("Failed to remove broken ephemeral image", "path", oldestPath, "error", err)
+				// If reading failed, clean it up and try the next one
+				slog.Warn("Failed to read ephemeral image, cleaning up", "path", entryPath, "error", err)
+				if err := os.Remove(entryPath); err != nil {
+					slog.Warn("Failed to remove broken ephemeral image", "path", entryPath, "error", err)
+				}
 			}
 		}
 	}

--- a/internal/server/rotation_test.go
+++ b/internal/server/rotation_test.go
@@ -506,6 +506,70 @@ func TestGetNextAppImage_EphemeralCleanup(t *testing.T) {
 	}
 }
 
+func TestGetNextAppImage_EphemeralBrokenFileSkipsToNext(t *testing.T) {
+	s := newTestServer(t)
+	ctx := context.Background()
+
+	user := data.User{Username: "testuser"}
+	if err := gorm.G[data.User](s.DB).Create(ctx, &user); err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	device := data.Device{
+		ID:       "testdevice-broken",
+		Username: user.Username,
+	}
+	if err := gorm.G[data.Device](s.DB).Create(ctx, &device); err != nil {
+		t.Fatalf("failed to create device: %v", err)
+	}
+
+	pushedDir := filepath.Join(s.DataDir, "webp", device.ID, "pushed")
+	if err := os.MkdirAll(pushedDir, 0755); err != nil {
+		t.Fatalf("failed to create pushed dir: %v", err)
+	}
+
+	// Create 3 ephemeral files. Make the oldest one unreadable via chmod.
+	var oldestPath string
+	for i := range 3 {
+		fname := filepath.Join(pushedDir, fmt.Sprintf("__%d.webp", time.Now().UnixNano()+int64(i)))
+		if err := os.WriteFile(fname, fmt.Appendf(nil, "image %d", i), 0644); err != nil {
+			t.Fatalf("failed to write ephemeral file: %v", err)
+		}
+		if i == 0 {
+			oldestPath = fname
+			if err := os.Chmod(fname, 0000); err != nil {
+				t.Fatalf("failed to chmod oldest file: %v", err)
+			}
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+	defer func() {
+		if err := os.Chmod(oldestPath, 0644); err != nil {
+			t.Logf("failed to restore chmod on oldest file: %v", err)
+		}
+	}()
+
+	// GetNextAppImage should skip the broken oldest file and serve the next one
+	imgData, _, err := s.GetNextAppImage(ctx, &device, &user)
+	if err != nil {
+		t.Fatalf("GetNextAppImage failed: %v", err)
+	}
+	if len(imgData) == 0 {
+		t.Error("Expected non-empty image data (second file), got empty")
+	}
+
+	// Both the broken oldest and the served second file should be deleted;
+	// only the third file remains.
+	entries, err := os.ReadDir(pushedDir)
+	if err != nil {
+		t.Fatalf("failed to read pushed dir: %v", err)
+	}
+	ephemeralCount := countPrefix(entries, "__")
+	if ephemeralCount != 1 {
+		t.Errorf("expected 1 remaining ephemeral file, got %d", ephemeralCount)
+	}
+}
+
 func countPrefix(entries []os.DirEntry, prefix string) int {
 	count := 0
 	for _, e := range entries {

--- a/internal/server/rotation_test.go
+++ b/internal/server/rotation_test.go
@@ -2,6 +2,10 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -440,4 +444,74 @@ func TestDetermineNextApp_AutoPin(t *testing.T) {
 	if dbDevice.PinnedApp != nil {
 		t.Error("Auto-unpin not reflected in DB")
 	}
+}
+
+func TestGetNextAppImage_EphemeralCleanup(t *testing.T) {
+	s := newTestServer(t)
+	ctx := context.Background()
+
+	// Create a user
+	user := data.User{Username: "testuser"}
+	if err := gorm.G[data.User](s.DB).Create(ctx, &user); err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	// Create a device without apps (so it always falls through to default after ephemeral)
+	device := data.Device{
+		ID:       "testdevice",
+		Username: user.Username,
+	}
+	if err := gorm.G[data.Device](s.DB).Create(ctx, &device); err != nil {
+		t.Fatalf("failed to create device: %v", err)
+	}
+
+	// Create a bunch of ephemeral __*.webp files
+	pushedDir := filepath.Join(s.DataDir, "webp", device.ID, "pushed")
+	if err := os.MkdirAll(pushedDir, 0755); err != nil {
+		t.Fatalf("failed to create pushed dir: %v", err)
+	}
+
+	for i := range 5 {
+		fname := filepath.Join(pushedDir, fmt.Sprintf("__%d.webp", time.Now().UnixNano()+int64(i)))
+		if err := os.WriteFile(fname, fmt.Appendf(nil, "image %d", i), 0644); err != nil {
+			t.Fatalf("failed to write ephemeral file: %v", err)
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	// Verify 5 files exist
+	entries, err := os.ReadDir(pushedDir)
+	if err != nil {
+		t.Fatalf("failed to read pushed dir: %v", err)
+	}
+	ephemeralCount := countPrefix(entries, "__")
+	if ephemeralCount != 5 {
+		t.Fatalf("expected 5 ephemeral files before test, got %d", ephemeralCount)
+	}
+
+	// Call GetNextAppImage — serves oldest, deletes only that one
+	_, _, err = s.GetNextAppImage(ctx, &device, &user)
+	if err != nil {
+		t.Fatalf("GetNextAppImage failed: %v", err)
+	}
+
+	// Verify one file was consumed
+	entries, err = os.ReadDir(pushedDir)
+	if err != nil {
+		t.Fatalf("failed to read pushed dir: %v", err)
+	}
+	ephemeralCount = countPrefix(entries, "__")
+	if ephemeralCount != 4 {
+		t.Errorf("expected 4 ephemeral files after one poll (deletes oldest only), got %d", ephemeralCount)
+	}
+}
+
+func countPrefix(entries []os.DirEntry, prefix string) int {
+	count := 0
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), prefix) {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/server/rotation_test.go
+++ b/internal/server/rotation_test.go
@@ -528,26 +528,21 @@ func TestGetNextAppImage_EphemeralBrokenFileSkipsToNext(t *testing.T) {
 		t.Fatalf("failed to create pushed dir: %v", err)
 	}
 
-	// Create 3 ephemeral files. Make the oldest one unreadable via chmod.
-	var oldestPath string
+	// Create 3 ephemeral files. Make the oldest one a directory so
+	// os.ReadFile fails (works even when tests run as root).
 	for i := range 3 {
 		fname := filepath.Join(pushedDir, fmt.Sprintf("__%d.webp", time.Now().UnixNano()+int64(i)))
-		if err := os.WriteFile(fname, fmt.Appendf(nil, "image %d", i), 0644); err != nil {
-			t.Fatalf("failed to write ephemeral file: %v", err)
-		}
 		if i == 0 {
-			oldestPath = fname
-			if err := os.Chmod(fname, 0000); err != nil {
-				t.Fatalf("failed to chmod oldest file: %v", err)
+			if err := os.Mkdir(fname, 0755); err != nil {
+				t.Fatalf("failed to create broken directory: %v", err)
+			}
+		} else {
+			if err := os.WriteFile(fname, fmt.Appendf(nil, "image %d", i), 0644); err != nil {
+				t.Fatalf("failed to write ephemeral file: %v", err)
 			}
 		}
 		time.Sleep(1 * time.Millisecond)
 	}
-	defer func() {
-		if err := os.Chmod(oldestPath, 0644); err != nil {
-			t.Logf("failed to restore chmod on oldest file: %v", err)
-		}
-	}()
 
 	// GetNextAppImage should skip the broken oldest file and serve the next one
 	imgData, _, err := s.GetNextAppImage(ctx, &device, &user)
@@ -573,7 +568,7 @@ func TestGetNextAppImage_EphemeralBrokenFileSkipsToNext(t *testing.T) {
 func countPrefix(entries []os.DirEntry, prefix string) int {
 	count := 0
 	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), prefix) {
+		if strings.HasPrefix(e.Name(), prefix) && !e.IsDir() {
 			count++
 		}
 	}


### PR DESCRIPTION
## Summary

Adds an optional `coalesceID` field to `PushData` and `PushAppData` API request structs. When provided, a new push deletes any existing ephemeral file with the same coalesceID before saving — ensuring at most 1 pending push per coalesceID.

## Problem

Anonymous pushed images (`__*.webp`) accumulated unbounded because `GetNextAppImage` only deleted one file per device poll. If the push rate exceeded the device poll rate, hundreds of stale files piled up and the device got stuck showing only pushed images.

## Design

**File naming:**
| Case | Filename | Behavior |
|---|---|---|
| Image push with installID | `{installID}.webp` | Always replaces |
| Push with coalesceID | `__{timestamp}_{coalesceID}.webp` | Replaces previous with same coalesceID |
| Anonymous push | `__{timestamp}.webp` | Unbounded queue (backward compatible) |

**GetNextAppImage:** serves the oldest `__*.webp` and deletes only that one, with explicit chronological ordering.

**Backward compatible:** existing clients using installID or anonymous pushes see no change. The `coalesceID` field is optional.