### PR TITLE
Add "Refresh options" for dynamically-fetched schema dropdowns

### DIFF
--- a/cmd/server/serve/cache.go
+++ b/cmd/server/serve/cache.go
@@ -6,12 +6,14 @@ import (
 	"log/slog"
 	"time"
 
+	"tronbyt-server/internal/pixletcache"
+
 	"github.com/tronbyt/pixlet/runtime"
 )
 
-func initCache(redisURL string) (runtime.Cache, error) {
+func initCache(redisURL string) (*pixletcache.BypassCache, error) {
 	// Initialize Pixlet Cache
-	var cache runtime.Cache
+	var inner runtime.Cache
 	var err error
 
 	if redisURL != "" {
@@ -20,13 +22,17 @@ func initCache(redisURL string) (runtime.Cache, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 
-		if cache, err = runtime.NewRedisCache(ctx, redisURL); err != nil {
+		if inner, err = runtime.NewRedisCache(ctx, redisURL); err != nil {
 			return nil, fmt.Errorf("failed to connect to Redis: %w", err)
 		}
 	} else {
 		slog.Info("Initializing Pixlet in-memory cache")
-		cache = runtime.NewInMemoryCache()
+		inner = runtime.NewInMemoryCache()
 	}
+
+	// Wrap so the server can force a one-shot refetch of an app's cached HTTP
+	// responses (used by the schema "Refresh options" endpoint).
+	cache := pixletcache.New(inner)
 
 	runtime.InitHTTP(cache)
 	runtime.InitCache(cache)

--- a/cmd/server/serve/cmd.go
+++ b/cmd/server/serve/cmd.go
@@ -64,6 +64,7 @@ func run(cmd *cobra.Command, args []string) error {
 	defer cache.Close()
 
 	srv := server.NewServer(db, cfg)
+	srv.SchemaCache = cache
 
 	// Firmware Update (production only)
 	if cfg.Production {

--- a/internal/pixletcache/cache.go
+++ b/internal/pixletcache/cache.go
@@ -20,7 +20,7 @@ import (
 type BypassCache struct {
 	inner runtime.Cache
 
-	mu       sync.Mutex
+	mu       sync.RWMutex
 	prefixes map[string]int // active bypass prefix -> refcount
 }
 
@@ -79,10 +79,12 @@ func (c *BypassCache) remove(prefix string) {
 }
 
 func (c *BypassCache) bypassed(key string) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	for prefix := range c.prefixes {
-		if strings.HasPrefix(key, prefix) {
+		// Guard against an empty prefix, which would match every key and
+		// inadvertently bypass the entire cache.
+		if prefix != "" && strings.HasPrefix(key, prefix) {
 			return true
 		}
 	}

--- a/internal/pixletcache/cache.go
+++ b/internal/pixletcache/cache.go
@@ -1,0 +1,90 @@
+// Package pixletcache wraps a pixlet runtime.Cache to add on-demand cache
+// invalidation. Pixlet's HTTP cache honors the per-request TTL configured by an
+// app's http.get(ttl_seconds=...) call, which means dynamic schema data (e.g.
+// dropdown options fetched from GitHub inside get_schema) only refreshes after
+// that TTL expires. BypassCache lets the server force a one-shot refetch so a
+// user can pull the latest options without waiting out the app's TTL.
+package pixletcache
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/tronbyt/pixlet/runtime"
+)
+
+// BypassCache wraps a pixlet runtime.Cache and can force cache reads for keys
+// matching a prefix to miss, causing the caller to refetch and overwrite the
+// stale entry. All other behavior is delegated to the wrapped cache.
+type BypassCache struct {
+	inner runtime.Cache
+
+	mu       sync.Mutex
+	prefixes map[string]int // active bypass prefix -> refcount
+}
+
+// New wraps the given cache.
+func New(inner runtime.Cache) *BypassCache {
+	return &BypassCache{
+		inner:    inner,
+		prefixes: make(map[string]int),
+	}
+}
+
+// Get returns a miss for keys currently being bypassed; otherwise it delegates
+// to the wrapped cache.
+func (c *BypassCache) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	if c.bypassed(key) {
+		return nil, false, nil
+	}
+	return c.inner.Get(ctx, key)
+}
+
+// Set delegates to the wrapped cache.
+func (c *BypassCache) Set(ctx context.Context, key string, value []byte, ttl int64) error {
+	return c.inner.Set(ctx, key, value, ttl)
+}
+
+// Close delegates to the wrapped cache.
+func (c *BypassCache) Close() {
+	c.inner.Close()
+}
+
+// WithBypass runs fn while forcing cache reads for keys with the given prefix to
+// miss, so any http.get issued during fn refetches from origin and overwrites
+// the cached entry (resetting its TTL). Reads are restored once fn returns.
+// Concurrent calls with the same prefix are reference-counted so they don't
+// clear each other prematurely.
+func (c *BypassCache) WithBypass(prefix string, fn func() error) error {
+	c.add(prefix)
+	defer c.remove(prefix)
+	return fn()
+}
+
+func (c *BypassCache) add(prefix string) {
+	c.mu.Lock()
+	c.prefixes[prefix]++
+	c.mu.Unlock()
+}
+
+func (c *BypassCache) remove(prefix string) {
+	c.mu.Lock()
+	if c.prefixes[prefix] <= 1 {
+		delete(c.prefixes, prefix)
+	} else {
+		c.prefixes[prefix]--
+	}
+	c.mu.Unlock()
+}
+
+func (c *BypassCache) bypassed(key string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for prefix := range c.prefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pixletcache/cache_test.go
+++ b/internal/pixletcache/cache_test.go
@@ -1,0 +1,105 @@
+package pixletcache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCache is a minimal in-memory runtime.Cache for testing.
+type fakeCache struct {
+	data map[string][]byte
+}
+
+func newFakeCache() *fakeCache { return &fakeCache{data: map[string][]byte{}} }
+
+func (f *fakeCache) Get(_ context.Context, key string) ([]byte, bool, error) {
+	v, ok := f.data[key]
+	return v, ok, nil
+}
+
+func (f *fakeCache) Set(_ context.Context, key string, value []byte, _ int64) error {
+	f.data[key] = value
+	return nil
+}
+
+func (f *fakeCache) Close() {}
+
+func TestBypassCacheDelegatesWhenNotBypassed(t *testing.T) {
+	inner := newFakeCache()
+	c := New(inner)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "httpcache:soccermens.star:abc", []byte("cached"), 60))
+
+	v, found, err := c.Get(ctx, "httpcache:soccermens.star:abc")
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, []byte("cached"), v)
+}
+
+func TestBypassForcesMissForMatchingPrefixOnly(t *testing.T) {
+	inner := newFakeCache()
+	c := New(inner)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "httpcache:soccermens.star:abc", []byte("soccer"), 60))
+	require.NoError(t, c.Set(ctx, "httpcache:other.star:xyz", []byte("other"), 60))
+
+	err := c.WithBypass("httpcache:soccermens.star:", func() error {
+		// Matching key is forced to miss so the caller refetches.
+		_, found, _ := c.Get(ctx, "httpcache:soccermens.star:abc")
+		assert.False(t, found, "matching key should miss while bypassed")
+
+		// A different app's entries are unaffected.
+		_, found, _ = c.Get(ctx, "httpcache:other.star:xyz")
+		assert.True(t, found, "non-matching key should still hit")
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Once the bypass window closes, reads hit the cache again.
+	_, found, _ := c.Get(ctx, "httpcache:soccermens.star:abc")
+	assert.True(t, found, "key should hit again after bypass ends")
+}
+
+func TestBypassRefcountKeepsActiveUntilAllReleased(t *testing.T) {
+	inner := newFakeCache()
+	c := New(inner)
+	ctx := context.Background()
+	require.NoError(t, c.Set(ctx, "httpcache:app:1", []byte("v"), 60))
+
+	const prefix = "httpcache:app:"
+	c.add(prefix)
+	c.add(prefix)
+
+	_, found, _ := c.Get(ctx, "httpcache:app:1")
+	assert.False(t, found, "bypass active with two holders")
+
+	c.remove(prefix)
+	_, found, _ = c.Get(ctx, "httpcache:app:1")
+	assert.False(t, found, "bypass still active after one release")
+
+	c.remove(prefix)
+	_, found, _ = c.Get(ctx, "httpcache:app:1")
+	assert.True(t, found, "bypass cleared after all releases")
+}
+
+func TestBypassRestoredWhenFnPanics(t *testing.T) {
+	inner := newFakeCache()
+	c := New(inner)
+	ctx := context.Background()
+	require.NoError(t, c.Set(ctx, "httpcache:app:1", []byte("v"), 60))
+
+	assert.Panics(t, func() {
+		_ = c.WithBypass("httpcache:app:", func() error {
+			panic("boom")
+		})
+	})
+
+	// defer in WithBypass must have released the bypass even on panic.
+	_, found, _ := c.Get(ctx, "httpcache:app:1")
+	assert.True(t, found, "bypass should be released after panic")
+}

--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -321,6 +321,11 @@ func (s *Server) handleConfigAppGet(w http.ResponseWriter, r *http.Request) {
 	device := GetDevice(r)
 	app := GetApp(r)
 
+	// The schema (including dynamically-fetched dropdown options) is rendered
+	// into the page once, server-side. Prevent the browser from serving a stale
+	// cached page so a reload always re-runs get_schema.
+	w.Header().Set("Cache-Control", "no-cache")
+
 	// Get Schema
 	var schemaBytes []byte
 	if app.Path != nil && *app.Path != "" {
@@ -361,6 +366,63 @@ func (s *Server) handleConfigAppGet(w http.ResponseWriter, r *http.Request) {
 		ShowFullAnimationOptions: s.getShowFullAnimationChoices(),
 		AppMetadata:              appMetadata,
 	})
+}
+
+// handleAppSchemaGet returns the app's schema JSON (same shape as the schema
+// embedded in the config page). With ?refresh=true it forces the app's cached
+// HTTP responses to be refetched so dynamic dropdown options reflect the latest
+// upstream data without waiting out the app's http.get TTL.
+func (s *Server) handleAppSchemaGet(w http.ResponseWriter, r *http.Request) {
+	device := GetDevice(r)
+	app := GetApp(r)
+
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Content-Type", "application/json")
+
+	schemaBytes := []byte("{}")
+	if app.Path != nil && *app.Path != "" {
+		appPath, err := securejoin.SecureJoin(s.DataDir, *app.Path)
+		if err != nil {
+			slog.Error("Failed to resolve app path", "path", *app.Path, "error", err)
+			http.Error(w, "Invalid app path", http.StatusBadRequest)
+			return
+		}
+
+		if !strings.HasSuffix(strings.ToLower(appPath), ".webp") {
+			getSchema := func() error {
+				b, err := renderer.GetSchema(r.Context(), appPath, 64, 32, device.Type.Supports2x())
+				if err != nil {
+					return err
+				}
+				if len(b) > 0 {
+					schemaBytes = b
+				}
+				return nil
+			}
+
+			// On refresh, bypass the cached http.get responses for this app so
+			// get_schema refetches dropdown data from origin. The cache key
+			// prefix mirrors pixlet's: "httpcache:<app id>:" where the app id is
+			// the base name of the applet path (see runtime/httpcache.go).
+			if r.URL.Query().Get("refresh") == "true" && s.SchemaCache != nil {
+				prefix := fmt.Sprintf("httpcache:%s:", filepath.Base(appPath))
+				err = s.SchemaCache.WithBypass(prefix, getSchema)
+			} else {
+				err = getSchema()
+			}
+			if err != nil {
+				// Return an error so the client keeps the currently-rendered
+				// options instead of replacing them with an empty form.
+				slog.Error("Failed to get app schema", "error", err)
+				http.Error(w, "Failed to load schema", http.StatusBadGateway)
+				return
+			}
+		}
+	}
+
+	if _, err := w.Write(schemaBytes); err != nil {
+		slog.Error("Failed to write schema response", "error", err)
+	}
 }
 
 func (s *Server) handleConfigAppPost(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,8 +53,19 @@ type Server struct {
 	systemAppsCache      []apps.AppMetadata
 	systemAppsCacheMutex sync.RWMutex
 
+	// SchemaCache, when set, allows forcing a one-shot refetch of an app's
+	// cached HTTP responses so dynamic schema data (e.g. dropdown options
+	// fetched in get_schema) can be refreshed before the app's TTL expires.
+	SchemaCache SchemaCacheBypasser
+
 	UpdateAvailable  bool
 	LatestReleaseURL string
+}
+
+// SchemaCacheBypasser forces cache reads for keys with the given prefix to miss
+// for the duration of fn, so http.get calls made during fn refetch from origin.
+type SchemaCacheBypasser interface {
+	WithBypass(prefix string, fn func() error) error
 }
 
 // Map template names to their file paths relative to web/templates.
@@ -292,6 +303,7 @@ func (s *Server) routes() {
 
 	s.Router.HandleFunc("POST /devices/{id}/{iname}/delete", s.RequireLogin(s.RequireDevice(s.RequireApp(s.handleDeleteApp))))
 	s.Router.HandleFunc("GET /devices/{id}/{iname}/config", s.RequireLogin(s.RequireDevice(s.RequireApp(s.handleConfigAppGet))))
+	s.Router.HandleFunc("GET /devices/{id}/{iname}/schema", s.RequireLogin(s.RequireDevice(s.RequireApp(s.handleAppSchemaGet))))
 	s.Router.HandleFunc("POST /devices/{id}/{iname}/config", s.RequireLogin(s.RequireDevice(s.RequireApp(s.handleConfigAppPost))))
 	s.Router.HandleFunc("POST /devices/{id}/{iname}/schema_handler/{handler}", s.RequireLogin(s.RequireDevice(s.RequireApp(s.handleSchemaHandler))))
 

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -1,4 +1,13 @@
 {
+  "Refresh options": {
+    "other": "Optionen aktualisieren"
+  },
+  "Reload dropdown options from their source. Use this if an app's options are fetched online and you've updated them.": {
+    "other": "Dropdown-Optionen aus ihrer Quelle neu laden. Verwenden Sie dies, wenn die Optionen einer App online abgerufen werden und Sie sie aktualisiert haben."
+  },
+  "Failed to refresh options. Please try again.": {
+    "other": "Optionen konnten nicht aktualisiert werden. Bitte versuchen Sie es erneut."
+  },
   "OIDC Support": {
     "other": "OIDC-Unterstützung"
   },

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -1,4 +1,13 @@
 {
+  "Refresh options": {
+    "other": "Refresh options"
+  },
+  "Reload dropdown options from their source. Use this if an app's options are fetched online and you've updated them.": {
+    "other": "Reload dropdown options from their source. Use this if an app's options are fetched online and you've updated them."
+  },
+  "Failed to refresh options. Please try again.": {
+    "other": "Failed to refresh options. Please try again."
+  },
   "OIDC Support": {
     "other": "OIDC Support"
   },

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -77,7 +77,16 @@
 {{ end }}
 <form method="post" id="dynamicForm">
     <!-- Schema Config Section -->
-    <h2>{{ t .Localizer "App Configuration" }}</h2>
+    <div style="display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:10px">
+        <h2>{{ t .Localizer "App Configuration" }}</h2>
+        <button type="button"
+                class="w3-button w3-blue w3-round"
+                id="refreshSchemaButton"
+                title="{{ t .Localizer "Reload dropdown options from their source. Use this if an app's options are fetched online and you've updated them." }}">
+            <i class="fa-solid fa-arrows-rotate" aria-hidden="true"></i>
+            <span class="button-label">{{ t .Localizer "Refresh options" }}</span>
+        </button>
+    </div>
     <table id="schemaConfigContainer"
            class="form-table"
            style="border-spacing: 0 15px">
@@ -712,7 +721,8 @@
 </div>
 <script>
   // Make the schema and config objects available to JavaScript
-  const schema = {{ .Schema }};
+  // (mutable so the "Refresh options" button can swap in a freshly-fetched schema)
+  let schema = {{ .Schema }};
   const config = {{ .AppConfig | json }} || {};
   const deleteOnCancel = {{ .DeleteOnCancel }};
 
@@ -1658,6 +1668,17 @@
       });
   }
 
+  // Re-render the schema config table from the current `schema` and `config`.
+  // Used after the "Refresh options" button swaps in a freshly-fetched schema.
+  function rebuildSchemaForm() {
+    const formTable = document.getElementById("schemaConfigContainer");
+    if (!formTable) return;
+    formTable.innerHTML = "";
+    const formFields = createFormFields(schema, config);
+    formFields.forEach(row => formTable.appendChild(row));
+    createGeneratedFormFields(schema, config);
+  }
+
   document.addEventListener("DOMContentLoaded", function () {
     const previewImage = document.getElementById('previewImage');
     if (previewImage) {
@@ -1685,6 +1706,32 @@
     initializeToggleButtons();
     initializeRecurrenceOptions();
     updateConfigAndPreview();
+
+    // "Refresh options" — refetch the schema (bypassing the app's http.get
+    // cache) and rebuild the form without losing the current selections.
+    const refreshSchemaButton = document.getElementById("refreshSchemaButton");
+    if (refreshSchemaButton) {
+      const refreshLabel = refreshSchemaButton.querySelector(".button-label");
+      refreshSchemaButton.addEventListener("click", async function () {
+        const originalLabel = refreshLabel ? refreshLabel.textContent : "";
+        refreshSchemaButton.disabled = true;
+        if (refreshLabel) refreshLabel.textContent = "{{ t .Localizer "Refreshing..." }}";
+        try {
+          const url = "/devices/{{ .Device.ID }}/{{ .App.Iname }}/schema?refresh=true";
+          const response = await fetch(url, { headers: { "Accept": "application/json" } });
+          if (!response.ok) throw new Error("Failed to refresh schema");
+          schema = await response.json();
+          rebuildSchemaForm();
+          updateConfigAndPreview();
+        } catch (error) {
+          console.error("Error refreshing options:", error);
+          alert("{{ t .Localizer "Failed to refresh options. Please try again." }}");
+        } finally {
+          refreshSchemaButton.disabled = false;
+          if (refreshLabel) refreshLabel.textContent = originalLabel;
+        }
+      });
+    }
 
     form.addEventListener("submit", function (event) {
       event.preventDefault();

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -77,7 +77,11 @@
 {{ end }}
 <form method="post" id="dynamicForm">
     <!-- Schema Config Section -->
-    <div style="display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:10px">
+    <div style="display:flex;
+                align-items:center;
+                justify-content:space-between;
+                flex-wrap:wrap;
+                gap:10px">
         <h2>{{ t .Localizer "App Configuration" }}</h2>
         <button type="button"
                 class="w3-button w3-blue w3-round"


### PR DESCRIPTION
# Friends and Server Gurus
this is an edge case solution to when a schema item is dynamic & the user doesn't exit their browser / tab - the schema is not refreshed based upon the TTL of the http.get inside the .star file.   this is probably not something a ton of people encounter - so you can take it or leave it & i will be happy either way.

I had Claude Code do 99% of the work - I made a couple of test passes and it and everything seems OK - but I also know you have a ton of other tests / checks / methods than I could ever.   

let me know if you need something tweaked - or I'm totally off my rocker.



## Problem

App config schemas are rendered **server-side once** at page load and embedded into the config page. For apps whose dropdown options are fetched online inside `get_schema()` (e.g. the men's soccer app's "League / Tournament" list, pulled from GitHub via `http.get`), the options never refresh while the config page stays open. Even on a reload, pixlet's HTTP cache honors the app's `ttl_seconds` (12h for `soccermens`), so updated options can lag well behind the source — with no way to force a refresh short of waiting out the TTL.

## What this adds

**1. "Refresh options" button on the app config page**
- Re-fetches the schema via a new `GET /devices/{id}/{iname}/schema` endpoint and rebuilds the form **in place**, preserving the current selections — no logout or full reload needed.
- With `?refresh=true` it **bypasses the app's cached `http.get` responses**, so dropdown data is refetched from origin immediately and then re-cached (TTL clock reset). Normal page loads stay fast.
- On failure (e.g. origin returns a non-200) the endpoint returns an error and the page keeps the currently-rendered options instead of blanking the form.

**2. `Cache-Control: no-cache` on the config page GET**
- So a plain browser reload always re-runs `get_schema()` rather than serving a stale cached page.

## How the cache bypass works (no pixlet changes)

Pixlet's HTTP cache keys are scoped as `httpcache:<app id>:<hash>`, where `<app id>` is `filepath.Base(appPath)`. A small wrapper around pixlet's public `runtime.Cache` interface — `internal/pixletcache.BypassCache` — delegates everything to the real backend (in-memory or Redis) except that `WithBypass(prefix, fn)` forces cache **reads** under that prefix to miss for the duration of one schema load. Pixlet then sees a normal cache miss and refetches. It's reference-counted and panic-safe.

This is pure composition over pixlet's existing public API (`runtime.InitHTTP` / `runtime.InitCache`) — **no fork or patch of pixlet**, and `go.mod`/`go.sum` are unchanged. The one assumption is pixlet's cache-key prefix format; if that ever changed, the bypass would simply fall back to normal TTL behavior (no breakage), and this is noted in a comment at the call site. Works with both the in-memory and Redis cache backends.

## Tests

- New `internal/pixletcache/cache_test.go` covers delegation, prefix-scoped bypass (other apps' entries unaffected), refcounting, and panic-safety.
- `go build ./...`, `go vet ./...`, and existing `internal/server` tests pass.
- Added the three new UI strings to `web/i18n/en.json` and `web/i18n/de.json`.

## Files

- `internal/pixletcache/{cache,cache_test}.go` (new)
- `cmd/server/serve/{cache,cmd}.go` — wrap the cache and hand it to the server
- `internal/server/{server,handlers_app}.go` — new endpoint/route + `no-cache` header
- `web/templates/manager/configapp.html` — button + in-place rebuild
- `web/i18n/{en,de}.json` — new strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)