### PR TITLE
feat: expire anonymous ephemeral pushes older than 24 hours

### DIFF
--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -557,24 +557,30 @@ func (s *Server) savePushedImage(deviceID, installID, coalesceID string, data []
 	}
 
 	// Clean up anonymous ephemeral files older than 24 hours.
-	// The filename embeds a nanosecond timestamp: __{nanos}.webp
-	cutoff := time.Now().UnixNano() - 24*int64(time.Hour)
-	if entries, readErr := os.ReadDir(dir); readErr == nil {
-		for _, entry := range entries {
-			name := entry.Name()
-			if !entry.IsDir() && strings.HasPrefix(name, "__") && strings.HasSuffix(name, ".webp") {
-				// Anonymous pushes: __{nanos}.webp (no underscore between __ and .webp suffix)
-				inner := name[2 : len(name)-5]
-				if strings.Contains(inner, "_") {
-					continue // coalesced push, not anonymous
-				}
-				if ts, parseErr := strconv.ParseInt(inner, 10, 64); parseErr == nil && ts < cutoff {
-					if err := os.Remove(filepath.Join(dir, name)); err != nil {
-						slog.Warn("Failed to remove expired ephemeral image", "name", name, "error", err)
+	// Only runs when saving an anonymous push (coalesced and installID-based
+	// pushes are already bounded). Runs in a background goroutine to avoid
+	// blocking the HTTP response.
+	if installID == "" && coalesceID == "" {
+		go func() {
+			cutoff := time.Now().UnixNano() - 24*int64(time.Hour)
+			if entries, readErr := os.ReadDir(dir); readErr == nil {
+				for _, entry := range entries {
+					name := entry.Name()
+					if !entry.IsDir() && strings.HasPrefix(name, "__") && strings.HasSuffix(name, ".webp") {
+						// Anonymous pushes: __{nanos}.webp (no underscore between __ and .webp suffix)
+						inner := name[2 : len(name)-5]
+						if strings.Contains(inner, "_") {
+							continue // coalesced push, not anonymous
+						}
+						if ts, parseErr := strconv.ParseInt(inner, 10, 64); parseErr == nil && ts < cutoff {
+							if err := os.Remove(filepath.Join(dir, name)); err != nil && !os.IsNotExist(err) {
+								slog.Warn("Failed to remove expired ephemeral image", "name", name, "error", err)
+							}
+						}
 					}
 				}
 			}
-		}
+		}()
 	}
 
 	return nil

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -551,7 +552,32 @@ func (s *Server) savePushedImage(deviceID, installID, coalesceID string, data []
 		return err
 	}
 
-	return os.WriteFile(path, data, 0644)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return err
+	}
+
+	// Clean up anonymous ephemeral files older than 24 hours.
+	// The filename embeds a nanosecond timestamp: __{nanos}.webp
+	cutoff := time.Now().UnixNano() - 24*int64(time.Hour)
+	if entries, readErr := os.ReadDir(dir); readErr == nil {
+		for _, entry := range entries {
+			name := entry.Name()
+			if !entry.IsDir() && strings.HasPrefix(name, "__") && strings.HasSuffix(name, ".webp") {
+				// Anonymous pushes: __{nanos}.webp (no underscore between __ and .webp suffix)
+				inner := name[2 : len(name)-5]
+				if strings.Contains(inner, "_") {
+					continue // coalesced push, not anonymous
+				}
+				if ts, parseErr := strconv.ParseInt(inner, 10, 64); parseErr == nil && ts < cutoff {
+					if err := os.Remove(filepath.Join(dir, name)); err != nil {
+						slog.Warn("Failed to remove expired ephemeral image", "name", name, "error", err)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (s *Server) ensurePushedApp(ctx context.Context, deviceID, installID string) error {

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -1038,6 +1038,43 @@ func TestSavePushedImage_CoalesceID_SuffixCollision(t *testing.T) {
 	}
 }
 
+func TestSavePushedImage_AnonymousExpiry(t *testing.T) {
+	s := newTestServerAPI(t)
+	deviceID := "testdevice-expiry"
+	pushedDir := filepath.Join(s.DataDir, "webp", deviceID, "pushed")
+
+	// Create an anonymous file with timestamp from 48 hours ago
+	oldNanos := time.Now().UnixNano() - 48*int64(time.Hour)
+	oldName := fmt.Sprintf("__%d.webp", oldNanos)
+	if err := os.MkdirAll(pushedDir, 0755); err != nil {
+		t.Fatalf("failed to create pushed dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pushedDir, oldName), []byte("old"), 0644); err != nil {
+		t.Fatalf("failed to write old file: %v", err)
+	}
+
+	// Save a new push — should trigger cleanup of the 48-hour-old file
+	if err := s.savePushedImage(deviceID, "", "", []byte("new")); err != nil {
+		t.Fatalf("Failed to save anonymous push: %v", err)
+	}
+
+	entries, err := os.ReadDir(pushedDir)
+	if err != nil {
+		t.Fatalf("Failed to read pushed dir: %v", err)
+	}
+
+	// Only the new file should remain; the 48-hour-old file should be cleaned up
+	ephemeralCount := 0
+	for _, entry := range entries {
+		if isAnonymousEphemeral(entry.Name()) {
+			ephemeralCount++
+		}
+	}
+	if ephemeralCount != 1 {
+		t.Errorf("Expected 1 anonymous ephemeral file (48h old cleaned up), got %d: %v", ephemeralCount, entryNames(pushedDir))
+	}
+}
+
 func TestSavePushedImage_CoalesceID_Invalid(t *testing.T) {
 	s := newTestServerAPI(t)
 

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -1053,26 +1053,25 @@ func TestSavePushedImage_AnonymousExpiry(t *testing.T) {
 		t.Fatalf("failed to write old file: %v", err)
 	}
 
-	// Save a new push — should trigger cleanup of the 48-hour-old file
+	// Save a new anonymous push — triggers async cleanup of the 48-hour-old file
 	if err := s.savePushedImage(deviceID, "", "", []byte("new")); err != nil {
 		t.Fatalf("Failed to save anonymous push: %v", err)
 	}
 
-	entries, err := os.ReadDir(pushedDir)
-	if err != nil {
-		t.Fatalf("Failed to read pushed dir: %v", err)
-	}
-
-	// Only the new file should remain; the 48-hour-old file should be cleaned up
-	ephemeralCount := 0
-	for _, entry := range entries {
-		if isAnonymousEphemeral(entry.Name()) {
-			ephemeralCount++
+	// Cleanup runs in a background goroutine; wait for it.
+	assert.Eventually(t, func() bool {
+		entries, err := os.ReadDir(pushedDir)
+		if err != nil {
+			return false
 		}
-	}
-	if ephemeralCount != 1 {
-		t.Errorf("Expected 1 anonymous ephemeral file (48h old cleaned up), got %d: %v", ephemeralCount, entryNames(pushedDir))
-	}
+		count := 0
+		for _, entry := range entries {
+			if isAnonymousEphemeral(entry.Name()) {
+				count++
+			}
+		}
+		return count == 1
+	}, 2*time.Second, 10*time.Millisecond, "Expected 1 anonymous ephemeral file after async cleanup")
 }
 
 func TestSavePushedImage_CoalesceID_Invalid(t *testing.T) {


### PR DESCRIPTION
## Summary

Cleans up anonymous ephemeral pushes (`__{timestamp}.webp`) older than 24 hours to prevent unbounded disk usage when a device goes offline and pushes continue accumulating.

## How it works

`savePushedImage` now runs a cleanup pass after every save: it scans the pushed directory for anonymous `__*.webp` files (identified by having no underscore between the `__` prefix and `.webp` suffix), parses the nanosecond timestamp from the filename, and deletes any older than 24 hours. App-identified pushes (`__{timestamp}_{coalesceID}.webp`) and installID-based pushes (`{installID}.webp`) are not affected.

The timestamp is already embedded in the filename, so expiry is a cheap parse-and-compare — no stat calls needed.