### PR TITLE
fix: push_app with an existing installationID now re-renders with the updated config instead of creating dupe installation

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -978,6 +978,18 @@ func (d *Device) GetApp(iname string) *App {
 	return nil
 }
 
+// GetPushedApp looks up a pushed app by the user-supplied installationID, which is
+// stored in Path as "pushed:<installationID>" rather than in Iname.
+func (d *Device) GetPushedApp(installationID string) *App {
+	target := "pushed:" + installationID
+	for i := range d.Apps {
+		if d.Apps[i].Pushed && d.Apps[i].Path != nil && *d.Apps[i].Path == target {
+			return d.Apps[i]
+		}
+	}
+	return nil
+}
+
 // BrightnessUIScale returns the current brightness level (0-5) for the UI.
 func (d Device) BrightnessUIScale() int {
 	var customScale map[int]int

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -310,7 +310,12 @@ func (s *Server) handlePushApp(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Image not found", http.StatusNotFound)
 			return
 		}
-		if imgBytes, err := os.ReadFile(pushedImagePath); err == nil {
+		imgBytes, err := os.ReadFile(pushedImagePath)
+		if err != nil {
+			// No cached image — fall through to the render path so the caller can
+			// recover by providing an appID and config.
+			slog.Warn("Cached pushed image missing, falling through to render", "path", pushedImagePath)
+		} else {
 			if !dataReq.Background {
 				s.Broadcaster.Notify(device.ID, imgBytes)
 			}

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -283,14 +283,45 @@ func (s *Server) handlePushApp(w http.ResponseWriter, r *http.Request) {
 		installationID = dataReq.InstallationIDAlt
 	}
 
-	// Look up existing app if installationID is provided to get Path, DisplayTime and filters
+	// Look up existing pushed app first (by path), then fall back to iname lookup.
 	var existingApp *data.App
 	var appPath string
 	if installationID != "" {
-		existingApp = device.GetApp(installationID)
-		if existingApp != nil && existingApp.Path != nil && *existingApp.Path != "" {
-			// Infer app path from existing installation
+		existingApp = device.GetPushedApp(installationID)
+		if existingApp == nil {
+			existingApp = device.GetApp(installationID)
+		}
+		// Only derive appPath from non-pushed installations; "pushed:<id>" is not a real app path.
+		if existingApp != nil && existingApp.Path != nil && *existingApp.Path != "" &&
+			!strings.HasPrefix(*existingApp.Path, "pushed:") {
 			appPath, _ = securejoin.SecureJoin(s.DataDir, *existingApp.Path)
+		}
+	}
+
+	// For pushed apps with a cached image and no new config/app being sent, skip
+	// re-rendering and re-push the existing image directly.
+	if existingApp != nil && existingApp.Pushed &&
+		existingApp.Path != nil && strings.HasPrefix(*existingApp.Path, "pushed:") &&
+		len(dataReq.Config) == 0 && dataReq.AppID == "" {
+		cachedID := strings.TrimPrefix(*existingApp.Path, "pushed:")
+		pushedImagePath, err := securejoin.SecureJoin(filepath.Join(s.DataDir, "webp", device.ID, "pushed"), cachedID+".webp")
+		if err != nil {
+			slog.Error("Failed to resolve pushed image path", "error", err)
+			http.Error(w, "Image not found", http.StatusNotFound)
+			return
+		}
+		if imgBytes, err := os.ReadFile(pushedImagePath); err == nil {
+			if !dataReq.Background {
+				s.Broadcaster.Notify(device.ID, imgBytes)
+			}
+			if err := s.ensurePushedApp(r.Context(), device.ID, cachedID); err != nil {
+				slog.Error("Error adding pushed app", "error", err)
+			}
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write([]byte("App pushed.")); err != nil {
+				slog.Error("Failed to write response", "error", err)
+			}
+			return
 		}
 	}
 
@@ -323,33 +354,6 @@ func (s *Server) handlePushApp(w http.ResponseWriter, r *http.Request) {
 		if appPath == "" {
 			http.Error(w, "App not found", http.StatusNotFound)
 			return
-		}
-	}
-
-	// For pushed apps (existing app with "pushed:" path), skip rendering and push existing image
-	if existingApp != nil && existingApp.Pushed {
-		if existingApp.Path != nil && strings.HasPrefix(*existingApp.Path, "pushed:") {
-			installationID := strings.TrimPrefix(*existingApp.Path, "pushed:")
-			pushedImagePath, err := securejoin.SecureJoin(filepath.Join(s.DataDir, "webp", device.ID, "pushed"), installationID+".webp")
-			if err != nil {
-				slog.Error("Failed to resolve pushed image path", "error", err)
-				http.Error(w, "Image not found", http.StatusNotFound)
-				return
-			}
-			if imgBytes, err := os.ReadFile(pushedImagePath); err == nil {
-				// Notify device via Websocket (unless background)
-				if !dataReq.Background {
-					s.Broadcaster.Notify(device.ID, imgBytes)
-				}
-				if err := s.ensurePushedApp(r.Context(), device.ID, installationID); err != nil {
-					slog.Error("Error adding pushed app", "error", err)
-				}
-				w.WriteHeader(http.StatusOK)
-				if _, err := w.Write([]byte("App pushed.")); err != nil {
-					slog.Error("Failed to write response", "error", err)
-				}
-				return
-			}
 		}
 	}
 

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -440,6 +440,94 @@ def main(config):
 	assert.NoError(t, err, "re-render should have created the missing cached image")
 }
 
+// seedPushedInstallation creates a pushed app DB record and writes sentinel bytes as
+// the cached webp so tests can detect whether the file was replaced or left intact.
+func seedPushedInstallation(t *testing.T, s *Server, deviceID, installID string) []byte {
+	t.Helper()
+	ctx := context.Background()
+	installPath := "pushed:" + installID
+	app := data.App{
+		DeviceID:    deviceID,
+		Iname:       "200",
+		Name:        "pushed",
+		UInterval:   10,
+		DisplayTime: 0,
+		Enabled:     true,
+		Pushed:      true,
+		Path:        &installPath,
+	}
+	require.NoError(t, gorm.G[data.App](s.DB).Create(ctx, &app))
+
+	pushedDir := filepath.Join(s.DataDir, "webp", deviceID, "pushed")
+	require.NoError(t, os.MkdirAll(pushedDir, 0755))
+	sentinel := []byte("sentinel-cached-image")
+	require.NoError(t, os.WriteFile(filepath.Join(pushedDir, installID+".webp"), sentinel, 0644))
+	return sentinel
+}
+
+func setupColorApp(t *testing.T, s *Server) string {
+	t.Helper()
+	appID := "colorapp"
+	appDir := filepath.Join(s.DataDir, "system-apps", "apps", appID)
+	require.NoError(t, os.MkdirAll(appDir, 0755))
+	star := `
+load("render.star", "render")
+def main(config):
+    color = config.get("color", "#ffffff")
+    return render.Root(child=render.Box(width=64, height=32, color=color))
+`
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, appID+".star"), []byte(star), 0644))
+	s.RefreshSystemAppsCache()
+	return appID
+}
+
+// TestHandlePushAppConfigReplacesCache verifies that providing a config always
+// triggers a fresh render, replacing the cached image rather than serving it.
+func TestHandlePushAppConfigReplacesCache(t *testing.T) {
+	s := newTestServerAPI(t)
+	apiKey := "device_api_key"
+	deviceID := "testdevice"
+	appID := setupColorApp(t, s)
+	installID := "cached-install"
+	sentinel := seedPushedInstallation(t, s, deviceID, installID)
+
+	body, _ := json.Marshal(PushAppData{
+		InstallationID: installID,
+		AppID:          appID,
+		Config:         map[string]any{"color": "#ff0000"},
+	})
+	req := newAPIRequest("POST", fmt.Sprintf("/v0/devices/%s/push_app", deviceID), apiKey, body)
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	result, err := os.ReadFile(filepath.Join(s.DataDir, "webp", deviceID, "pushed", installID+".webp"))
+	require.NoError(t, err)
+	assert.NotEqual(t, sentinel, result,
+		"providing config must trigger a fresh render, not serve the cached image")
+}
+
+// TestHandlePushAppNoCacheConfigServesCache verifies that omitting config and app_id
+// serves the existing cached image without re-rendering.
+func TestHandlePushAppNoCacheConfigServesCache(t *testing.T) {
+	s := newTestServerAPI(t)
+	apiKey := "device_api_key"
+	deviceID := "testdevice"
+	installID := "cached-install"
+	sentinel := seedPushedInstallation(t, s, deviceID, installID)
+
+	body, _ := json.Marshal(PushAppData{InstallationID: installID})
+	req := newAPIRequest("POST", fmt.Sprintf("/v0/devices/%s/push_app", deviceID), apiKey, body)
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	result, err := os.ReadFile(filepath.Join(s.DataDir, "webp", deviceID, "pushed", installID+".webp"))
+	require.NoError(t, err)
+	assert.Equal(t, sentinel, result,
+		"omitting config and app_id must serve the cached image without re-rendering")
+}
+
 func TestHandleListInstallations(t *testing.T) {
 	s := newTestServerAPI(t)
 	apiKey := "test_api_key"

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -528,6 +528,73 @@ func TestHandlePushAppNoCacheConfigServesCache(t *testing.T) {
 		"omitting config and app_id must serve the cached image without re-rendering")
 }
 
+func TestHandlePushAppAppIDOnly(t *testing.T) {
+	s := newTestServerAPI(t)
+	apiKey := "device_api_key"
+	deviceID := "testdevice"
+	appID := setupColorApp(t, s)
+
+	body, _ := json.Marshal(PushAppData{
+		AppID:  appID,
+		Config: map[string]any{"color": "#ff0000"},
+	})
+	req := newAPIRequest("POST", fmt.Sprintf("/v0/devices/%s/push_app", deviceID), apiKey, body)
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	count, err := gorm.G[data.App](s.DB).Where("device_id = ? AND pushed = ?", deviceID, true).Count(context.Background(), "*")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "push with no installationID must not create an installation record")
+}
+
+func TestHandlePushAppNoAppIDNoInstallationID(t *testing.T) {
+	s := newTestServerAPI(t)
+	apiKey := "device_api_key"
+	deviceID := "testdevice"
+
+	body, _ := json.Marshal(PushAppData{})
+	req := newAPIRequest("POST", fmt.Sprintf("/v0/devices/%s/push_app", deviceID), apiKey, body)
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestHandlePushAppBackground(t *testing.T) {
+	s := newTestServerAPI(t)
+	apiKey := "device_api_key"
+	deviceID := "testdevice"
+	appID := setupColorApp(t, s)
+	installID := "bg-install"
+
+	ch := s.Broadcaster.Subscribe(deviceID)
+	defer s.Broadcaster.Unsubscribe(deviceID, ch)
+
+	body, _ := json.Marshal(PushAppData{
+		AppID:          appID,
+		InstallationID: installID,
+		Config:         map[string]any{"color": "#ff0000"},
+		Background:     true,
+	})
+	req := newAPIRequest("POST", fmt.Sprintf("/v0/devices/%s/push_app", deviceID), apiKey, body)
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	// Image must be saved.
+	imagePath := filepath.Join(s.DataDir, "webp", deviceID, "pushed", installID+".webp")
+	_, err := os.Stat(imagePath)
+	assert.NoError(t, err, "background push must save the rendered image")
+
+	// Broadcaster must not have been notified.
+	select {
+	case <-ch:
+		t.Error("background push must not notify the device broadcaster")
+	default:
+	}
+}
+
 func TestHandleListInstallations(t *testing.T) {
 	s := newTestServerAPI(t)
 	apiKey := "test_api_key"

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -335,6 +335,58 @@ def main(config):
 	}
 }
 
+func TestHandlePushAppUpdatesExistingInstallation(t *testing.T) {
+	s := newTestServerAPI(t)
+	apiKey := "device_api_key"
+	deviceID := "testdevice"
+	appID := "colorapp"
+
+	appDir := filepath.Join(s.DataDir, "system-apps", "apps", appID)
+	require.NoError(t, os.MkdirAll(appDir, 0755))
+
+	starContent := `
+load("render.star", "render")
+def main(config):
+    color = config.get("color", "#ffffff")
+    return render.Root(child=render.Box(width=64, height=32, color=color))
+`
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, appID+".star"), []byte(starContent), 0644))
+	s.RefreshSystemAppsCache()
+
+	const installID = "100"
+	imagePath := filepath.Join(s.DataDir, "webp", deviceID, "pushed", installID+".webp")
+
+	doPush := func(color string) {
+		body, _ := json.Marshal(PushAppData{
+			AppID:          appID,
+			Config:         map[string]any{"color": color},
+			InstallationID: installID,
+		})
+		req := newAPIRequest("POST", fmt.Sprintf("/v0/devices/%s/push_app", deviceID), apiKey, body)
+		rr := httptest.NewRecorder()
+		s.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	}
+
+	doPush("#ff0000")
+	imgRed, err := os.ReadFile(imagePath)
+	require.NoError(t, err)
+
+	doPush("#0000ff")
+	imgBlue, err := os.ReadFile(imagePath)
+	require.NoError(t, err)
+
+	// Re-pushing with a different color config must produce a different image.
+	assert.NotEqual(t, imgRed, imgBlue,
+		"re-pushing to an existing installationID with new config should update the saved image")
+
+	// Exactly one pushed installation should exist.
+	count, err := gorm.G[data.App](s.DB).Where("device_id = ? AND pushed = ?", deviceID, true).Count(context.Background(), "*")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count,
+		"pushing to an existing installationID should not create a second installation")
+}
+
 func TestHandleListInstallations(t *testing.T) {
 	s := newTestServerAPI(t)
 	apiKey := "test_api_key"

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -387,6 +387,59 @@ def main(config):
 		"pushing to an existing installationID should not create a second installation")
 }
 
+// TestHandlePushAppMissingCachedImage verifies that when the cached webp is missing,
+// the handler falls through to the render path rather than erroring. A push that
+// provides an appID and config should succeed and produce a new image.
+func TestHandlePushAppMissingCachedImage(t *testing.T) {
+	s := newTestServerAPI(t)
+	ctx := context.Background()
+	apiKey := "device_api_key"
+	deviceID := "testdevice"
+	appID := "colorapp"
+	installID := "orphaned"
+	installPath := "pushed:" + installID
+
+	appDir := filepath.Join(s.DataDir, "system-apps", "apps", appID)
+	require.NoError(t, os.MkdirAll(appDir, 0755))
+	starContent := `
+load("render.star", "render")
+def main(config):
+    color = config.get("color", "#ffffff")
+    return render.Root(child=render.Box(width=64, height=32, color=color))
+`
+	require.NoError(t, os.WriteFile(filepath.Join(appDir, appID+".star"), []byte(starContent), 0644))
+	s.RefreshSystemAppsCache()
+
+	// Seed a pushed app record without creating the corresponding webp file.
+	pushedApp := data.App{
+		DeviceID:    deviceID,
+		Iname:       "100",
+		Name:        "pushed",
+		UInterval:   10,
+		DisplayTime: 0,
+		Enabled:     true,
+		Pushed:      true,
+		Path:        &installPath,
+	}
+	require.NoError(t, gorm.G[data.App](s.DB).Create(ctx, &pushedApp))
+
+	// Providing appID + config should fall through to a fresh render and succeed.
+	body, _ := json.Marshal(PushAppData{
+		InstallationID: installID,
+		AppID:          appID,
+		Config:         map[string]any{"color": "#ff0000"},
+	})
+	req := newAPIRequest("POST", fmt.Sprintf("/v0/devices/%s/push_app", deviceID), apiKey, body)
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+
+	imagePath := filepath.Join(s.DataDir, "webp", deviceID, "pushed", installID+".webp")
+	_, err := os.Stat(imagePath)
+	assert.NoError(t, err, "re-render should have created the missing cached image")
+}
+
 func TestHandleListInstallations(t *testing.T) {
 	s := newTestServerAPI(t)
 	apiKey := "test_api_key"


### PR DESCRIPTION
## Problem

Based on my read of the [`/v0/devices/{id}/push_app`](https://github.com/tronbyt/server/blob/main/API.md#push-app) docs, I should be able to trigger a render of an installed app in regular rotation by sending a new `config` to the same `installationID`. This was silently broken in two different ways; if `installationID` had been installed manually a duplicate installation would be created, or if the `installationID` matched an app installed via push it was never re-rendered at all.

## Solution

The fix looks up existing pushed installations by path first (`pushed:<installationID>`), and only falls back to `iname` for non-pushed apps. The re-send shortcut is also gated on the absence of a new `config` or `appID` — if either is present, the app is always re-rendered and the saved image updated.

Based on my read of the existing docs, this brings the server behavior up to date with the docs for this endpoint.