### PR TITLE
Fix schema.Location: persist device location, respect blank, add Clear button

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -690,6 +690,19 @@ func (dt DeviceType) MergedFilename(swapColors bool) string {
 	}
 }
 
+// HasLocation reports whether the device has a usable saved location, as
+// opposed to the zero-value DeviceLocation struct that exists before the user
+// picks one. Needed because Go templates treat any struct value as truthy, so
+// `{{ if .Device.Location }}` is always true even when the location is blank.
+func (d *Device) HasLocation() bool {
+	if d == nil {
+		return false
+	}
+	l := d.Location
+	return l.Timezone != "" || l.Description != "" || l.Locality != "" ||
+		l.PlaceID != "" || l.Lat != 0 || l.Lng != 0
+}
+
 func (d *Device) GetTimezone() string {
 	if d.Timezone != nil && *d.Timezone != "" {
 		return *d.Timezone

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1041,15 +1041,21 @@
     hiddenInput.value = initialLocationJsonString;
     container.appendChild(hiddenInput);
 
-    // Seed the config object with the resolved location (saved value, device
-    // location fallback, or field default). collectSettings() serializes the
-    // `config` object on save -- NOT the hidden inputs -- so without this seed
-    // the device-location fallback shown in the UI silently fails to persist,
-    // and the app falls back to its own hardcoded default location at render
-    // time. The onChange callback below only fires when the user re-picks from
-    // the search box, which is exactly the step users skip. (LocationBased
-    // fields seed config via fetchOptionsForLocation's dispatched change event.)
-    if (config[field.id] == null || config[field.id] === "") {
+    // Seed the config object with the resolved location (device location
+    // fallback or field default). collectSettings() serializes the `config`
+    // object on save -- NOT the hidden inputs -- so without this seed the
+    // device-location fallback shown in the UI silently fails to persist, and
+    // the app falls back to its own hardcoded default location at render time.
+    // The onChange callback below only fires when the user re-picks from the
+    // search box, which is exactly the step users skip. (LocationBased fields
+    // seed config via fetchOptionsForLocation's dispatched change event.)
+    //
+    // Only auto-fill when FIRST adding the app instance. delete_on_cancel=true
+    // marks the initial config of a just-added app; on later edits it is false.
+    // Gating on it means a location the user intentionally left blank stays
+    // blank on edit instead of silently inheriting the (possibly since-changed)
+    // device location. Blank is only auto-filled at creation, never on edit.
+    if (deleteOnCancel && (config[field.id] == null || config[field.id] === "")) {
       try {
         const seedLoc = JSON.parse(initialLocationJsonString);
         // Only seed a location that actually has content. A blank device

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -717,7 +717,7 @@
   const deleteOnCancel = {{ .DeleteOnCancel }};
 
   // Device Location
-  const deviceLocation = {{ if .Device.Location }}{{ json .Device.Location }}{{ else }}null{{ end }};
+  const deviceLocation = {{ if .Device.HasLocation }}{{ json .Device.Location }}{{ else }}null{{ end }};
 
   // Initialize toggle buttons for config and debug content
   function initializeToggleButtons() {
@@ -1052,7 +1052,16 @@
     if (config[field.id] == null || config[field.id] === "") {
       try {
         const seedLoc = JSON.parse(initialLocationJsonString);
-        if (seedLoc && Object.keys(seedLoc).length > 0) {
+        // Only seed a location that actually has content. A blank device
+        // location must NOT be written, or the app receives lat/lng 0,0 and an
+        // empty timezone and errors at render time. (lat/lng of exactly 0 alone
+        // is treated as blank; a real equatorial location still has a timezone,
+        // locality, or place_id set.)
+        const hasContent = seedLoc && (
+          seedLoc.timezone || seedLoc.description || seedLoc.locality ||
+          seedLoc.place_id || seedLoc.lat || seedLoc.lng
+        );
+        if (hasContent) {
           config[field.id] = seedLoc;
         }
       } catch (e) {

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1094,7 +1094,7 @@
     // and break apps that do config.get("location", DEFAULT).
     const clearButton = document.createElement("button");
     clearButton.type = "button";
-    clearButton.className = "w3-button w3-round w3-small";
+    clearButton.className = "w3-button w3-border w3-round w3-small";
     clearButton.style.marginTop = "4px";
     clearButton.textContent = "{{ t .Localizer "Clear location" }}";
     container.appendChild(clearButton);
@@ -1125,6 +1125,9 @@
       updateConfigAndPreview();
     });
 
+    // importConfig() updates config[field.id] and dispatches an "input" event on
+    // the hidden input (matched by data-config-id); sync the button off that too.
+    hiddenInput.addEventListener("input", syncClearButtonState);
     syncClearButtonState();
 
     return container;

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1075,6 +1075,26 @@
       }
     }
 
+    // Clear button: lets the user blank out a location on an existing app.
+    // Emptying the search box alone does nothing (it is just a search field),
+    // so without this there is no way to remove a previously-saved location.
+    // We DELETE the key (rather than store {}) so the saved config omits it and
+    // the app falls back to its own default -- an empty object would be truthy
+    // and break apps that do config.get("location", DEFAULT).
+    const clearButton = document.createElement("button");
+    clearButton.type = "button";
+    clearButton.className = "w3-button w3-round w3-small";
+    clearButton.style.marginTop = "4px";
+    clearButton.textContent = "{{ t .Localizer "Clear location" }}";
+    clearButton.addEventListener("click", function () {
+      delete config[field.id];
+      searchInput.value = "";
+      hiddenInput.value = "{}";
+      resultsList.innerHTML = "";
+      updateConfigAndPreview();
+    });
+    container.appendChild(clearButton);
+
     enableLocationSearch(searchInput, resultsList, hiddenInput, location => {
       // location is a JSON string
       try {

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1041,6 +1041,25 @@
     hiddenInput.value = initialLocationJsonString;
     container.appendChild(hiddenInput);
 
+    // Seed the config object with the resolved location (saved value, device
+    // location fallback, or field default). collectSettings() serializes the
+    // `config` object on save -- NOT the hidden inputs -- so without this seed
+    // the device-location fallback shown in the UI silently fails to persist,
+    // and the app falls back to its own hardcoded default location at render
+    // time. The onChange callback below only fires when the user re-picks from
+    // the search box, which is exactly the step users skip. (LocationBased
+    // fields seed config via fetchOptionsForLocation's dispatched change event.)
+    if (config[field.id] == null || config[field.id] === "") {
+      try {
+        const seedLoc = JSON.parse(initialLocationJsonString);
+        if (seedLoc && Object.keys(seedLoc).length > 0) {
+          config[field.id] = seedLoc;
+        }
+      } catch (e) {
+        // initialLocationJsonString was "{}" or invalid; nothing to seed.
+      }
+    }
+
     enableLocationSearch(searchInput, resultsList, hiddenInput, location => {
       // location is a JSON string
       try {

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1016,6 +1016,24 @@
   function createLocationField(field, config) {
     const { container, searchInput, resultsList } = createLocationSearchElements(field);
 
+    // A location counts as "set" only if it carries real content. A bare {} or
+    // a zeroed struct (lat/lng 0,0, empty timezone) does NOT count -- writing
+    // that breaks apps that do config.get("location", DEFAULT). (lat/lng of
+    // exactly 0 alone is treated as blank; a real equatorial location still has
+    // a timezone, locality, or place_id set.)
+    const locationHasContent = (loc) => {
+      if (!loc) return false;
+      if (typeof loc === "string") {
+        try {
+          loc = JSON.parse(loc);
+        } catch (e) {
+          return loc.trim() !== "" && loc.trim() !== "{}";
+        }
+      }
+      return !!(loc && (loc.timezone || loc.description || loc.locality ||
+                        loc.place_id || loc.lat || loc.lng));
+    };
+
     let initialLocationJsonString = config[field.id] || (deviceLocation !== null ? JSON.stringify(deviceLocation) : undefined) || field.default || "{}";
     if (typeof initialLocationJsonString !== 'string') {
       initialLocationJsonString = JSON.stringify(initialLocationJsonString);
@@ -1058,16 +1076,9 @@
     if (deleteOnCancel && (config[field.id] == null || config[field.id] === "")) {
       try {
         const seedLoc = JSON.parse(initialLocationJsonString);
-        // Only seed a location that actually has content. A blank device
-        // location must NOT be written, or the app receives lat/lng 0,0 and an
-        // empty timezone and errors at render time. (lat/lng of exactly 0 alone
-        // is treated as blank; a real equatorial location still has a timezone,
-        // locality, or place_id set.)
-        const hasContent = seedLoc && (
-          seedLoc.timezone || seedLoc.description || seedLoc.locality ||
-          seedLoc.place_id || seedLoc.lat || seedLoc.lng
-        );
-        if (hasContent) {
+        // Only seed a location that actually has content -- a blank device
+        // location must NOT be written (see locationHasContent above).
+        if (locationHasContent(seedLoc)) {
           config[field.id] = seedLoc;
         }
       } catch (e) {
@@ -1086,14 +1097,22 @@
     clearButton.className = "w3-button w3-round w3-small";
     clearButton.style.marginTop = "4px";
     clearButton.textContent = "{{ t .Localizer "Clear location" }}";
+    container.appendChild(clearButton);
+
+    // Keep the button always visible, but disabled when there is no location to
+    // clear, so its purpose stays discoverable.
+    const syncClearButtonState = () => {
+      clearButton.disabled = !locationHasContent(config[field.id]);
+    };
+
     clearButton.addEventListener("click", function () {
       delete config[field.id];
       searchInput.value = "";
       hiddenInput.value = "{}";
       resultsList.innerHTML = "";
+      syncClearButtonState();
       updateConfigAndPreview();
     });
-    container.appendChild(clearButton);
 
     enableLocationSearch(searchInput, resultsList, hiddenInput, location => {
       // location is a JSON string
@@ -1102,8 +1121,11 @@
       } catch (e) {
           config[field.id] = location;
       }
+      syncClearButtonState();
       updateConfigAndPreview();
     });
+
+    syncClearButtonState();
 
     return container;
   }


### PR DESCRIPTION
## Summary

Fixes `schema.Location` handling in the app config screen. A device's saved
location was shown in the app config UI but never written to the savable
`config` object, so apps fell back to their own hardcoded default at render
time (e.g. **sunrisesunset** showed Manchester, UK's 3:39 AM sunrise instead
of the user's local time). Affects the ~148 apps that use `schema.Location`.

**Root cause:** `collectSettings()` serializes the JS `config` object on save,
not the hidden DOM inputs, but `createLocationField` only wrote the resolved
location into the hidden input and the visible search box — never into
`config`. It was only set when the user manually re-picked from the search
dropdown, the step most users skip.

## Changes

- **Persist the device-location fallback.** Seed `config[field.id]` with the
  resolved location at field creation so it saves without a manual re-pick.
- **Never seed a blank device location.** `{{ if .Device.Location }}` is always
  true (Go templates treat any struct as truthy), so a blank device produced a
  zeroed location (`0,0`, empty tz) that got written and errored at render.
  Added `Device.HasLocation()` and gated the template on it, so `deviceLocation`
  is genuinely `null` when blank. This also stops `createLocationBasedField`
  from fetching options for a `0,0` location.
- **Auto-fill on add only, not on edit.** Gated the seed on `deleteOnCancel`
  (true only for the initial config of a just-added app), so a location left
  blank stays blank on later edits instead of silently inheriting the
  (possibly since-changed) device location.
- **Add a "Clear location" button.** There was no way to remove a saved
  location (emptying the search box is a no-op). It deletes the key — not `{}`,
  which is truthy and would re-break the app — so the app falls back to its own
  default. Always visible; disabled when there is nothing to clear.

## Behavior

| Scenario | Result |
| --- | --- |
| Add app, device **has** location | auto-filled |
| Add app, device **blank** | no location → app default |
| Edit app with a saved location | preserved |
| Edit app with a **blank** location | stays blank |
| Clear location on an existing app | removed → app default |
| Multiple instances, different locations | each preserved |

## Testing

Manually verified the add/edit/blank/clear matrix above on a from-source
build. `createLocationBasedField` is intentionally left unchanged — its saved
value is the chosen option (not the location), and it already seeds `config`
via `fetchOptionsForLocation`'s dispatched change event.

Opening as a draft for review.
