### PR TITLE
fix: preserve active firmware image URL when API keys are enabled

### DIFF
--- a/internal/server/handlers_device.go
+++ b/internal/server/handlers_device.go
@@ -342,7 +342,9 @@ func (s *Server) handleUpdateDeviceGet(w http.ResponseWriter, r *http.Request) {
 	if device.RequireAPIKey {
 		defaultImgURL = s.getImageURLWithKey(r, device.ID, device.APIKey)
 		defaultWsURL = s.getWebsocketURLWithKey(r, device.ID, device.APIKey)
-		firmwareImgURL = s.getImageURLWithKey(r, device.ID, device.APIKey)
+		// Preserve the device's actual active URL (could be WebSocket or HTTP)
+		// and just append the API key to it, instead of replacing with a new HTTP URL
+		firmwareImgURL = appendKeyToURLString(firmwareImgURL, device.APIKey)
 	}
 
 	s.renderTemplate(w, r, "update", TemplateData{


### PR DESCRIPTION
The device update page was replacing the firmware-reported image URL with a generated HTTP `/next` URL whenever `RequireAPIKey` was enabled. That meant devices currently using WebSocket URLs could get pushed back to HTTP after syncing firmware settings or running an OTA update. 

This fix keeps the URL reported by the device and only append the API key to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware image URL handling when API key protection is enabled.
  * Preserved existing firmware image URLs while securely appending the device API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->