### PR TITLE
add the warnings and nudges to add device location if not set.

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -747,6 +747,19 @@ func (d *Device) HasLocation() bool {
 		l.PlaceID != "" || l.Lat != 0 || l.Lng != 0
 }
 
+// HasTimezone reports whether the device has a usable timezone, either via the
+// explicit Timezone override or the location's timezone. When false, schedule
+// evaluation falls back to the server's local timezone.
+func (d *Device) HasTimezone() bool {
+	if d == nil {
+		return false
+	}
+	if d.Timezone != nil && *d.Timezone != "" {
+		return true
+	}
+	return d.Location.Timezone != ""
+}
+
 func (d *Device) GetTimezone() string {
 	if d.Timezone != nil && *d.Timezone != "" {
 		return *d.Timezone

--- a/internal/data/models_test.go
+++ b/internal/data/models_test.go
@@ -60,6 +60,33 @@ func TestDeviceGetDimModeIsActiveUsesManualOverride(t *testing.T) {
 	assert.True(t, device.GetDimModeIsActive())
 }
 
+func TestDeviceHasTimezone(t *testing.T) {
+	tz := "America/New_York"
+
+	assert.False(t, (*Device)(nil).HasTimezone())
+
+	assert.False(t, (&Device{}).HasTimezone())
+
+	device := &Device{
+		Location: DeviceLocation{Timezone: tz},
+	}
+	assert.True(t, device.HasTimezone())
+
+	device = &Device{
+		Location: DeviceLocation{Description: "Somewhere"},
+	}
+	assert.False(t, device.HasTimezone())
+
+	device = &Device{
+		Timezone: &tz,
+	}
+	assert.True(t, device.HasTimezone())
+
+	empty := ""
+	device = &Device{Timezone: &empty}
+	assert.False(t, device.HasTimezone())
+}
+
 func TestDeviceSupportsHTTPFirmwareCommands(t *testing.T) {
 	httpDevice := Device{
 		Type: DeviceTidbytGen1,

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -1091,6 +1091,18 @@
   "Schedule": {
     "other": "Zeitplan"
   },
+  "No location is set for this device, so schedule times use the server's timezone.": {
+    "other": "F\u00fcr dieses Ger\u00e4t ist kein Standort festgelegt, daher verwenden die Zeitplanzeiten die Zeitzone des Servers."
+  },
+  "Add a location": {
+    "other": "F\u00fcge einen Standort hinzu"
+  },
+  "so schedule times match your local time.": {
+    "other": "damit die Zeitplanzeiten deiner lokalen Zeit entsprechen."
+  },
+  "No location is set for this device, so schedule times use the server's timezone. Add a location so schedule times match your local time.": {
+    "other": "F\u00fcr dieses Ger\u00e4t ist kein Standort festgelegt, daher verwenden die Zeitplanzeiten die Zeitzone des Servers. F\u00fcge einen Standort hinzu, damit die Zeitplanzeiten deiner lokalen Zeit entsprechen."
+  },
   "Start Time": {
     "other": "Startzeit"
   },

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -1094,6 +1094,18 @@
   "Schedule": {
     "other": "Schedule"
   },
+  "No location is set for this device, so schedule times use the server's timezone.": {
+    "other": "No location is set for this device, so schedule times use the server's timezone."
+  },
+  "Add a location": {
+    "other": "Add a location"
+  },
+  "so schedule times match your local time.": {
+    "other": "so schedule times match your local time."
+  },
+  "No location is set for this device, so schedule times use the server's timezone. Add a location so schedule times match your local time.": {
+    "other": "No location is set for this device, so schedule times use the server's timezone. Add a location so schedule times match your local time."
+  },
   "Start Time": {
     "other": "Start Time"
   },

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -247,6 +247,14 @@
     <!-- Schedule Section -->
     <div class="schedule-section">
         <h2>{{ t .Localizer "Schedule" }}</h2>
+        {{ if and .Device (not .Device.HasTimezone) }}
+        <p class="settings-help settings-note-danger">
+            <i class="fa-solid fa-triangle-exclamation"></i>
+            {{ t .Localizer "No location is set for this device, so schedule times use the server's timezone." }}
+            <a href="/devices/{{ .Device.ID }}/update#section-regional">{{ t .Localizer "Add a location" }}</a>
+            {{ t .Localizer "so schedule times match your local time." }}
+        </p>
+        {{ end }}
         <table class="form-table">
             <!-- Start Time -->
             <tr>

--- a/web/templates/manager/create.html
+++ b/web/templates/manager/create.html
@@ -257,6 +257,25 @@
                 deviceIdInput.value = slugify(nameInput.value);
             }
         }
+
+        // Warn before saving without a location so schedule times aren't
+        // silently interpreted in the server's timezone.
+        var noLocationMessage = "{{ t .Localizer "No location is set for this device, so schedule times use the server's timezone. Add a location so schedule times match your local time." }}";
+        document.getElementById('create-device-form').addEventListener('submit', function(event) {
+            var locationRaw = document.getElementById('location').value;
+            var hasTimezone = false;
+            if (locationRaw) {
+                try {
+                    var locationData = JSON.parse(locationRaw);
+                    hasTimezone = !!(locationData && locationData.timezone);
+                } catch (e) {
+                    hasTimezone = false;
+                }
+            }
+            if (!hasTimezone && !confirm(noLocationMessage)) {
+                event.preventDefault();
+            }
+        });
     });
 </script>
 {{ end }}

--- a/web/templates/manager/update.html
+++ b/web/templates/manager/update.html
@@ -542,6 +542,12 @@
                                name="location"
                                id="location"
                                value='{{ if .Device.Location }}{{ json .Device.Location }}{{ else }}{{ "{}" }}{{ end }}'>
+                        {{ if not .Device.HasTimezone }}
+                        <p class="settings-help settings-note-danger">
+                            <i class="fa-solid fa-triangle-exclamation"></i>
+                            {{ t .Localizer "No location is set for this device, so schedule times use the server's timezone. Add a location so schedule times match your local time." }}
+                        </p>
+                        {{ end }}
                     </div>
                 </div>
                 <div class="settings-field-row">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timezone status guidance to device scheduling settings.
  * Display warnings when schedules use the server timezone because no device timezone is configured.
  * Prompt users to add a location and explain how it affects local schedule times.
  * Added a confirmation step when creating a device without timezone information.
  * Added English and German translations for the new messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->