### PR TITLE
add the warning and link to login via ip instead of localhost

### DIFF
--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -71,6 +71,13 @@ func (s *Server) getSettingsContentData(user *data.User) TemplateData {
 	}
 }
 
+func (s *Server) loginTemplateData(r *http.Request, flashes []string) TemplateData {
+	return TemplateData{
+		OIDCEnabled: s.Config.OIDCEnabled,
+		Flashes:     flashes,
+	}
+}
+
 func (s *Server) handleLoginGet(w http.ResponseWriter, r *http.Request) {
 	slog.Debug("handleLoginGet called")
 
@@ -130,7 +137,7 @@ func (s *Server) handleLoginGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.renderTemplate(w, r, "login", TemplateData{OIDCEnabled: s.Config.OIDCEnabled})
+	s.renderTemplate(w, r, "login", s.loginTemplateData(r, nil))
 }
 
 func (s *Server) handleLoginPost(w http.ResponseWriter, r *http.Request) {
@@ -142,7 +149,7 @@ func (s *Server) handleLoginPost(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.Warn("Login failed: user not found", "username", username)
 		localizer := s.getLocalizer(r)
-		s.renderTemplate(w, r, "login", TemplateData{Flashes: []string{localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "Invalid username or password"})}})
+		s.renderTemplate(w, r, "login", s.loginTemplateData(r, []string{localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "Invalid username or password"})}))
 		return
 	}
 
@@ -156,7 +163,7 @@ func (s *Server) handleLoginPost(w http.ResponseWriter, r *http.Request) {
 	if !valid {
 		slog.Warn("Login failed: invalid password", "username", username)
 		localizer := s.getLocalizer(r)
-		s.renderTemplate(w, r, "login", TemplateData{Flashes: []string{localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "Invalid username or password"})}})
+		s.renderTemplate(w, r, "login", s.loginTemplateData(r, []string{localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "Invalid username or password"})}))
 		return
 	}
 

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -109,6 +109,7 @@ type TemplateData struct {
 	UserCount                 int    // Number of users, for registration logic
 	DeleteOnCancel            bool   // Indicate if app should be deleted on cancel
 	URLWarning                string // Warning about localhost in image URL
+	DetectedAccessURL         string // Suggested URL (LAN IP) to use instead of localhost
 	ReadOnly                  bool   // Indicate if the view should be read-only
 	Partial                   string
 	SettingsSection           string
@@ -158,6 +159,11 @@ func (s *Server) renderTemplate(w http.ResponseWriter, r *http.Request, name str
 	// Set version
 	tmplData.ServerVersion = version.Version
 	tmplData.CommitHash = version.Commit
+
+	// Suggest a LAN URL to replace localhost on login pages
+	if name == "login" && tmplData.DetectedAccessURL == "" {
+		tmplData.DetectedAccessURL = s.detectedAccessURL(r)
+	}
 
 	// Set Update Info
 	tmplData.UpdateAvailable = s.UpdateAvailable
@@ -437,6 +443,69 @@ func (s *Server) isTrustedNetwork(r *http.Request) bool {
 	}
 
 	return ip.IsLoopback() || ip.IsPrivate()
+}
+
+// isLoopbackHost reports whether the request host refers to the local machine.
+func isLoopbackHost(r *http.Request) bool {
+	host := r.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "localhost" || host == "::1" || host == "127.0.0.1"
+}
+
+// requestScheme returns the scheme used for the current request.
+func requestScheme(r *http.Request) string {
+	if r.TLS != nil || (r.URL != nil && r.URL.Scheme == "https") {
+		return "https"
+	}
+	return "http"
+}
+
+// requestPort returns the port used for the current request, falling back to
+// the well-known port for the request scheme.
+func requestPort(r *http.Request) string {
+	if _, port, err := net.SplitHostPort(r.Host); err == nil && port != "" {
+		return port
+	}
+	if requestScheme(r) == "https" {
+		return "443"
+	}
+	return "80"
+}
+
+// detectedIPAddress returns the IP address clients on the LAN can use to reach
+// this server. It finds the IP of the interface used for outbound traffic via
+// the OS routing table (no packets are actually sent).
+func (s *Server) detectedIPAddress() string {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = conn.Close() }()
+	localAddr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || localAddr == nil {
+		return ""
+	}
+	ip := localAddr.IP
+	if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
+		return ""
+	}
+	return ip.String()
+}
+
+// detectedAccessURL returns a URL that LAN clients can use to reach this
+// server instead of localhost, or "" if one cannot be determined.
+func (s *Server) detectedAccessURL(r *http.Request) string {
+	if !isLoopbackHost(r) {
+		return ""
+	}
+	ip := s.detectedIPAddress()
+	if ip == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s://%s:%s", requestScheme(r), ip, requestPort(r))
 }
 
 // saveSession saves the session with dynamic Secure flag based on request scheme.

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -1,6 +1,10 @@
 package server
 
-import "testing"
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
 
 func TestParseTimeInput(t *testing.T) {
 	tests := []struct {
@@ -25,5 +29,61 @@ func TestParseTimeInput(t *testing.T) {
 		if got != tt.expected {
 			t.Errorf("parseTimeInput(%q) = %q, want %q", tt.input, got, tt.expected)
 		}
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"localhost:8000", true},
+		{"localhost", true},
+		{"127.0.0.1:8000", true},
+		{"127.0.0.1", true},
+		{"[::1]:8000", true},
+		{"::1", true},
+		{"192.168.1.42:8000", false},
+		{"mytronbyt.local", false},
+	}
+	for _, tt := range tests {
+		r := &http.Request{Host: tt.host}
+		if got := isLoopbackHost(r); got != tt.want {
+			t.Errorf("isLoopbackHost(%q) = %v, want %v", tt.host, got, tt.want)
+		}
+	}
+}
+
+func TestRequestScheme(t *testing.T) {
+	if got := requestScheme(&http.Request{}); got != "http" {
+		t.Errorf("requestScheme(plain) = %q, want %q", got, "http")
+	}
+	if got := requestScheme(&http.Request{URL: &url.URL{Scheme: "https"}}); got != "https" {
+		t.Errorf("requestScheme(https URL) = %q, want %q", got, "https")
+	}
+}
+
+func TestRequestPort(t *testing.T) {
+	tests := []struct {
+		req  *http.Request
+		want string
+	}{
+		{&http.Request{Host: "localhost:8000"}, "8000"},
+		{&http.Request{Host: "192.168.1.42:8443"}, "8443"},
+		{&http.Request{Host: "localhost"}, "80"},
+		{&http.Request{Host: "localhost", URL: &url.URL{Scheme: "https"}}, "443"},
+	}
+	for _, tt := range tests {
+		if got := requestPort(tt.req); got != tt.want {
+			t.Errorf("requestPort(%q) = %q, want %q", tt.req.Host, got, tt.want)
+		}
+	}
+}
+
+func TestDetectedAccessURLNonLoopback(t *testing.T) {
+	s := &Server{}
+	r := &http.Request{Host: "192.168.1.42:8000"}
+	if got := s.detectedAccessURL(r); got != "" {
+		t.Errorf("detectedAccessURL(non-loopback) = %q, want empty", got)
 	}
 }

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -2113,5 +2113,8 @@
   },
   "recommended": {
     "other": "empfohlen"
+  },
+  "You are accessing this server via localhost. For proper firmware generation you should use:": {
+    "other": "Sie greifen über localhost auf diesen Server zu. Für eine korrekte Firmware-Generierung sollten Sie Folgendes verwenden:"
   }
 }

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -2116,5 +2116,8 @@
   },
   "recommended": {
     "other": "recommended"
+  },
+  "You are accessing this server via localhost. For proper firmware generation you should use:": {
+    "other": "You are accessing this server via localhost. For proper firmware generation you should use:"
   }
 }

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -6,6 +6,13 @@
 <h1>{{ t .Localizer "Log In" }}</h1>
 {{ end }}
 {{ define "content" }}
+{{ if .DetectedAccessURL }}
+<div class="w3-panel w3-yellow w3-border w3-border-amber w3-round w3-padding">
+    <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
+    {{ t .Localizer "You are accessing this server via localhost. For proper firmware generation you should use:" }}
+    <strong><a href="{{ .DetectedAccessURL }}">{{ .DetectedAccessURL }}</a></strong>
+</div>
+{{ end }}
 <form method="post">
     <label for="username">{{ t .Localizer "Username" }}</label>
     <input name="username" id="username" required>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a login-page warning when accessing the server through localhost.
  * Displays a detected network URL to use for reliable firmware generation.
  * Login pages now consistently show OIDC status and relevant sign-in messages.

* **Localization**
  * Added English and German translations for the new access warning.

* **Bug Fixes**
  * Improved login error handling while preserving existing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->