### PR TITLE
Fix/ws wait for displaying ack

### DIFF
--- a/aigenmd/WEBSOCKET_PROTOCOL.md
+++ b/aigenmd/WEBSOCKET_PROTOCOL.md
@@ -102,8 +102,9 @@ The device sends JSON messages to the server to acknowledge the state of images.
 
 The server uses a sophisticated acknowledgment system to manage the flow of images.
 
-*   After sending an image, the server waits for an `Image Displaying` message from the device.
-*   **Timeout for Old Firmware**: If the server doesn't receive an acknowledgment within a certain timeout period, it assumes the device is running older firmware that doesn't send acknowledgments. It then falls back to a simple time-based delay (`dwell_time`) between sending images.
+*   After sending an image, the server waits for an `Image Displaying` message from the device before sending the next image.
+*   **v1+ Firmware (protocol_version ≥ 1)**: The server waits indefinitely for `displaying` so long-running animations are not interrupted by a fixed timeout. Pushed preview images can still interrupt the wait.
+*   **Legacy Firmware**: Devices without `protocol_version` do not send `displaying` ACKs. The server falls back to a dwell-time delay before sending the next image.
 *   **Push Notifications**: The waiting process can be interrupted by server-side events, such as:
     *   An ephemeral app being pushed to the device.
     *   A change in the device's settings (e.g., brightness).

--- a/aigenmd/WEBSOCKET_PROTOCOL.md
+++ b/aigenmd/WEBSOCKET_PROTOCOL.md
@@ -103,7 +103,7 @@ The device sends JSON messages to the server to acknowledge the state of images.
 The server uses a sophisticated acknowledgment system to manage the flow of images.
 
 *   After sending an image, the server waits for an `Image Displaying` message from the device before sending the next image.
-*   **v1+ Firmware (protocol_version ≥ 1)**: The server waits indefinitely for `displaying` so long-running animations are not interrupted by a fixed timeout. Pushed preview images can still interrupt the wait.
+*   **v1+ Firmware (protocol_version ≥ 1)**: The server waits for `displaying` before sending the next image. If no ACK arrives within 10 minutes (safety cap for dropped images or firmware bugs), the server logs a warning and advances rotation. Pushed preview images can interrupt the wait immediately.
 *   **Legacy Firmware**: Devices without `protocol_version` do not send `displaying` ACKs. The server falls back to a dwell-time delay before sending the next image.
 *   **Push Notifications**: The waiting process can be interrupted by server-side events, such as:
     *   An ephemeral app being pushed to the device.

--- a/internal/server/websockets.go
+++ b/internal/server/websockets.go
@@ -14,6 +14,13 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	// maxDisplayingAckTimeoutSeconds is a safety cap for v1+ firmware when displaying
+	// ACK never arrives (dropped image, firmware bug). Long enough for very long WebP
+	// animations but prevents indefinite rotation stall.
+	maxDisplayingAckTimeoutSeconds = 600
+)
+
 type WSMessage struct {
 	Queued     *int        `json:"queued"`
 	Displaying *int        `json:"displaying"`
@@ -280,12 +287,15 @@ func (s *Server) wsWriteLoop(ctx context.Context, conn *websocket.Conn, initialD
 			sendImmediate = false
 		}
 
-		// 3. Wait for displaying ACK, legacy dwell timeout, or interrupt.
-		// v1+ firmware sends displaying only when the image is on screen (including long
-		// animations), so we wait indefinitely rather than advancing on a fixed timeout.
+		// 3. Wait for displaying ACK, safety/legacy timeout, or interrupt.
+		// v1+ firmware sends displaying when the image is on screen (including long
+		// animations). We wait for that ACK, with a long safety timeout if it never arrives.
 		var timer *time.Timer
 		var timerC <-chan time.Time
-		if device.Info.ProtocolVersion == nil {
+		if device.Info.ProtocolVersion != nil {
+			timer = time.NewTimer(time.Duration(maxDisplayingAckTimeoutSeconds) * time.Second)
+			timerC = timer.C
+		} else {
 			timer = time.NewTimer(time.Duration(dwell) * time.Second)
 			timerC = timer.C
 		}
@@ -370,7 +380,18 @@ func (s *Server) wsWriteLoop(ctx context.Context, conn *websocket.Conn, initialD
 					}
 				}
 			case <-timerC:
-				// Legacy firmware: no displaying ACK, fall back to dwell time.
+				if device.Info.ProtocolVersion != nil {
+					appIname := ""
+					if app != nil {
+						appIname = app.Iname
+					}
+					slog.Warn(
+						"Timed out waiting for displaying ACK, advancing rotation",
+						"device", device.ID,
+						"app", appIname,
+						"timeout_secs", maxDisplayingAckTimeoutSeconds,
+					)
+				}
 				waiting = false
 			case <-stopCh:
 				if timer != nil {

--- a/internal/server/websockets.go
+++ b/internal/server/websockets.go
@@ -14,12 +14,6 @@ import (
 	"gorm.io/gorm"
 )
 
-const (
-	// minAckTimeoutSeconds is the minimum time to wait for device ACK.
-	// This accounts for the previous app's dwell time, network latency, and processing overhead.
-	minAckTimeoutSeconds = 30
-)
-
 type WSMessage struct {
 	Queued     *int        `json:"queued"`
 	Displaying *int        `json:"displaying"`
@@ -286,18 +280,15 @@ func (s *Server) wsWriteLoop(ctx context.Context, conn *websocket.Conn, initialD
 			sendImmediate = false
 		}
 
-		// 3. Wait for ACK or Timeout or Interrupt
-		var timeoutSec int
-		if device.Info.ProtocolVersion != nil {
-			// Device may delay ACK until previous app completes its dwell time.
-			// Wait at least minAckTimeoutSeconds OR 2x the dwell time, whichever is greater.
-			timeoutSec = max(dwell*2, minAckTimeoutSeconds)
-		} else {
-			// Old firmware: wait exactly dwell time
-			timeoutSec = dwell
+		// 3. Wait for displaying ACK, legacy dwell timeout, or interrupt.
+		// v1+ firmware sends displaying only when the image is on screen (including long
+		// animations), so we wait indefinitely rather than advancing on a fixed timeout.
+		var timer *time.Timer
+		var timerC <-chan time.Time
+		if device.Info.ProtocolVersion == nil {
+			timer = time.NewTimer(time.Duration(dwell) * time.Second)
+			timerC = timer.C
 		}
-
-		timer := time.NewTimer(time.Duration(timeoutSec) * time.Second)
 
 		interrupted := false
 		waiting := true
@@ -325,7 +316,6 @@ func (s *Server) wsWriteLoop(ctx context.Context, conn *websocket.Conn, initialD
 						slog.Debug("Received ACK for default or pushed image (no app context)", "device", device.ID)
 					}
 				}
-				// If just Queued, we keep waiting for Displaying.
 			case val := <-broadcastCh:
 				// Update available (Reload device first)
 				reloaded, err := gorm.G[data.Device](s.DB).Preload("Apps", nil).Where("id = ?", initialDevice.ID).First(ctx)
@@ -379,15 +369,24 @@ func (s *Server) wsWriteLoop(ctx context.Context, conn *websocket.Conn, initialD
 						lastSentBrightness = newBrightness
 					}
 				}
-			case <-timer.C:
-				// Timeout
+			case <-timerC:
+				// Legacy firmware: no displaying ACK, fall back to dwell time.
 				waiting = false
 			case <-stopCh:
-				timer.Stop()
+				if timer != nil {
+					timer.Stop()
+				}
 				return
 			}
 		}
-		timer.Stop()
+		if timer != nil {
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		}
 
 		if interrupted {
 			continue


### PR DESCRIPTION
fixes #883 

Now we trust a device to send us the "displaying" message and we wait for it up to 10 minutes before advancing the app rotation and rendering/sending a new app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Devices with newer firmware now confirm when content is displayed before rotation continues.
  * Preview updates can interrupt the display acknowledgment wait and appear promptly.

* **Bug Fixes**
  * Added a safety timeout so content rotation continues if a newer device does not respond.
  * Older firmware retains dwell-time behavior for improved compatibility.
  * Timeout events now provide clearer device and app details for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->