### PR TITLE
fix: restore passkey list styling on account settings

### DIFF
--- a/web/static/css/base.css
+++ b/web/static/css/base.css
@@ -268,3 +268,41 @@ input[type="range"] {
   font-weight: 500;
   color: var(--muted-text);
 }
+
+/* Authenticator (passkey) icons */
+.authenticator-icon-container {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.authenticator-icon {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+}
+
+.auth-icon-light {
+  display: block;
+}
+
+.auth-icon-dark {
+  display: none;
+}
+
+[data-theme="dark"] .auth-icon-light {
+  display: none;
+}
+
+[data-theme="dark"] .auth-icon-dark {
+  display: block;
+}
+
+.authenticator-entry {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}

--- a/web/templates/settings/account.html
+++ b/web/templates/settings/account.html
@@ -73,7 +73,7 @@
             <ul class="settings-list">
                 {{ range .User.Credentials }}
                 <li class="settings-list-item">
-                    <div class="settings-list-copy">
+                    <div class="authenticator-entry">
                         {{ $iconLight := webauthn_icon .Authenticator false }}
                         {{ $iconDark := webauthn_icon .Authenticator true }}
                         {{ if and $iconLight $iconDark (ne $iconLight $iconDark) }}


### PR DESCRIPTION
The settings UI overhaul removed the authenticator icon CSS, so passkey entries rendered both light and dark icons at natural size, and the icon stacked above the name. Restore the icon sizing and theme switching, and lay the icon out inline with the passkey name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved passkey and authenticator entry presentation with consistent icon sizing, spacing, and alignment.
  * Added light and dark theme support for authenticator icons, automatically displaying the appropriate variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->