### PR TITLE
feat: add PKCE support to OIDC login flow

### DIFF
--- a/internal/server/oidc.go
+++ b/internal/server/oidc.go
@@ -26,6 +26,7 @@ type OIDCProvider struct {
 	clientID     string
 	clientSecret string
 	issuerURL    string
+	supportsPKCE bool
 }
 
 func (s *Server) setupOIDCProvider(ctx context.Context) (*OIDCProvider, error) {
@@ -48,7 +49,22 @@ func (s *Server) setupOIDCProvider(ctx context.Context) (*OIDCProvider, error) {
 		clientID:     s.Config.OIDCClientID,
 		clientSecret: s.Config.OIDCClientSecret,
 		issuerURL:    s.Config.OIDCIssuerURL,
+		supportsPKCE: providerSupportsPKCE(provider),
 	}, nil
+}
+
+// providerSupportsPKCE reports whether the OIDC provider advertises S256 PKCE
+// support in its discovery metadata. When the field is absent, providers are
+// assumed not to support PKCE per RFC 8414.
+func providerSupportsPKCE(provider *oidc.Provider) bool {
+	var metadata struct {
+		CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported"`
+	}
+	if err := provider.Claims(&metadata); err != nil {
+		slog.Warn("Failed to read OIDC provider metadata for PKCE detection", "error", err)
+		return false
+	}
+	return slices.Contains(metadata.CodeChallengeMethodsSupported, "S256")
 }
 
 // oauth2Config returns the OAuth2 configuration with a dynamic redirect URI.
@@ -119,6 +135,16 @@ func (s *Server) startOIDCAuth(w http.ResponseWriter, r *http.Request, isLinking
 		delete(session.Values, "oidc_link")
 	}
 
+	// Generate a PKCE verifier when the provider supports S256. The verifier is
+	// kept in the session and matched against the code challenge on exchange.
+	codeVerifier := ""
+	if prov.supportsPKCE {
+		codeVerifier = oauth2.GenerateVerifier()
+		session.Values["oidc_code_verifier"] = codeVerifier
+	} else {
+		delete(session.Values, "oidc_code_verifier")
+	}
+
 	if err := s.saveSession(w, r, session); err != nil {
 		slog.Error("Failed to save session", "error", err)
 		http.Error(w, "Internal error", http.StatusInternalServerError)
@@ -126,11 +152,18 @@ func (s *Server) startOIDCAuth(w http.ResponseWriter, r *http.Request, isLinking
 	}
 	slog.Debug("OIDC state and nonce saved to session", "state_length", len(state), "nonce_length", len(nonce))
 
-	// Build auth URL with nonce
+	// Build auth URL with nonce and, when supported, the PKCE code challenge.
 	oauth2Cfg := prov.oauth2Config(s.GetBaseURL(r))
-	authURL := oauth2Cfg.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("nonce", nonce))
+	opts := []oauth2.AuthCodeOption{
+		oauth2.AccessTypeOffline,
+		oauth2.SetAuthURLParam("nonce", nonce),
+	}
+	if codeVerifier != "" {
+		opts = append(opts, oauth2.S256ChallengeOption(codeVerifier))
+	}
+	authURL := oauth2Cfg.AuthCodeURL(state, opts...)
 
-	slog.Debug("Redirecting to OIDC provider", "url", authURL, "linking", isLinking)
+	slog.Debug("Redirecting to OIDC provider", "url", authURL, "linking", isLinking, "pkce", codeVerifier != "")
 	http.Redirect(w, r, authURL, http.StatusSeeOther)
 }
 
@@ -191,9 +224,13 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 		expectedNonce = ""
 	}
 
-	// Clear state/nonce from session
+	// Retrieve the PKCE verifier (if one was stored during the auth request).
+	codeVerifier, _ := session.Values["oidc_code_verifier"].(string)
+
+	// Clear state/nonce/verifier from session
 	delete(session.Values, "oidc_state")
 	delete(session.Values, "oidc_nonce")
+	delete(session.Values, "oidc_code_verifier")
 
 	// Get code
 	code := r.URL.Query().Get("code")
@@ -216,7 +253,11 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	oauth2Cfg := prov.oauth2Config(s.GetBaseURL(r))
-	token, err := oauth2Cfg.Exchange(ctx, code)
+	var exchangeOpts []oauth2.AuthCodeOption
+	if codeVerifier != "" {
+		exchangeOpts = append(exchangeOpts, oauth2.VerifierOption(codeVerifier))
+	}
+	token, err := oauth2Cfg.Exchange(ctx, code, exchangeOpts...)
 	if err != nil {
 		slog.Error("Failed to exchange code for tokens", "error", err)
 		s.renderTemplate(w, r, "login", TemplateData{

--- a/internal/server/oidc_test.go
+++ b/internal/server/oidc_test.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/stretchr/testify/require"
+)
+
+func startOIDCAuthWithMetadata(t *testing.T, codeChallengeMethods []string) *httptest.ResponseRecorder {
+	t.Helper()
+	s := newTestServer(t)
+
+	metadata := map[string]any{
+		"issuer":                 "will-be-overridden",
+		"authorization_endpoint": "will-be-overridden",
+		"token_endpoint":         "will-be-overridden",
+		"jwks_uri":               "will-be-overridden",
+	}
+	if codeChallengeMethods != nil {
+		metadata["code_challenge_methods_supported"] = codeChallengeMethods
+	}
+
+	srv := newDiscoveryServer(t, metadata)
+	metadata["issuer"] = srv.URL
+	metadata["authorization_endpoint"] = srv.URL + "/auth"
+	metadata["token_endpoint"] = srv.URL + "/token"
+	metadata["jwks_uri"] = srv.URL + "/keys"
+
+	s.Config.OIDCEnabled = true
+	s.Config.OIDCIssuerURL = srv.URL
+	s.Config.OIDCClientID = "client-id"
+	s.Config.OIDCClientSecret = "client-secret"
+
+	prov, err := s.setupOIDCProvider(context.Background())
+	require.NoError(t, err)
+	s.OIDCProvider = prov
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/oidc/login", nil)
+	rr := httptest.NewRecorder()
+	s.startOIDCAuth(rr, req, false)
+
+	require.Equal(t, http.StatusSeeOther, rr.Code)
+	return rr
+}
+
+func newDiscoveryServer(t *testing.T, metadata map[string]any) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(metadata); err != nil {
+			t.Errorf("failed to encode discovery document: %v", err)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestProviderSupportsPKCE(t *testing.T) {
+	tests := []struct {
+		name     string
+		methods  []string
+		expected bool
+	}{
+		{name: "advertises S256", methods: []string{"S256"}, expected: true},
+		{name: "advertises S256 among others", methods: []string{"plain", "S256"}, expected: true},
+		{name: "advertises plain only", methods: []string{"plain"}, expected: false},
+		{name: "advertises no methods", methods: nil, expected: false},
+		{name: "advertises empty methods", methods: []string{}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := map[string]any{
+				"issuer": "will-be-overridden",
+			}
+			if tt.methods != nil {
+				metadata["code_challenge_methods_supported"] = tt.methods
+			}
+
+			srv := newDiscoveryServer(t, metadata)
+			metadata["issuer"] = srv.URL
+
+			provider, err := oidc.NewProvider(context.Background(), srv.URL)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, providerSupportsPKCE(provider))
+		})
+	}
+}
+
+func TestStartOIDCAuthIncludesPKCEWhenSupported(t *testing.T) {
+	rr := startOIDCAuthWithMetadata(t, []string{"S256"})
+
+	location := rr.Result().Header.Get("Location")
+	require.NotEmpty(t, location)
+	require.Contains(t, location, "code_challenge_method=S256")
+	require.Contains(t, location, "code_challenge=")
+}
+
+func TestStartOIDCAuthOmitsPKCEWhenUnsupported(t *testing.T) {
+	rr := startOIDCAuthWithMetadata(t, nil)
+
+	location := rr.Result().Header.Get("Location")
+	require.NotEmpty(t, location)
+	require.NotContains(t, location, "code_challenge")
+	require.NotContains(t, location, "code_challenge_method")
+}


### PR DESCRIPTION
Enable S256 PKCE automatically when the IdP advertises code_challenge_methods_supported in its discovery metadata. The verifier is held in the session and supplied on token exchange; providers that do not advertise PKCE fall back to the existing confidential-client flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added automatic PKCE support for OIDC providers that advertise S256 support.
  * Authorization flows now securely generate, use, and clear PKCE verifiers when applicable.
  * Providers without S256 support continue using the existing authentication flow.
* **Reliability**
  * OIDC discovery issues are handled gracefully, with PKCE disabled when metadata cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->