### PR TITLE
feat: show a setup QR when a device has no apps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/nicksnyder/go-i18n/v2 v2.6.1
 	github.com/prometheus/client_golang v1.24.1
 	github.com/quic-go/quic-go v0.61.0
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -110,7 +111,6 @@ require (
 	github.com/redis/go-redis/v9 v9.20.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
-	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c // indirect

--- a/internal/server/handlers_device_api.go
+++ b/internal/server/handlers_device_api.go
@@ -103,7 +103,7 @@ func (s *Server) handleNextApp(w http.ResponseWriter, r *http.Request) {
 		slog.Error("Failed to update device info transaction", "device", device.ID, "error", err)
 	}
 
-	imgData, app, err := s.GetNextAppImage(r.Context(), device, user)
+	imgData, app, err := s.GetNextAppImage(r.Context(), device, user, s.GetBaseURL(r))
 	if err != nil {
 		// Send default image if error (or not found)
 		slog.Error("Failed to get next app image", "device", device.ID, "error", err)

--- a/internal/server/rotation.go
+++ b/internal/server/rotation.go
@@ -18,7 +18,12 @@ import (
 	"gorm.io/gorm"
 )
 
-func (s *Server) GetNextAppImage(ctx context.Context, device *data.Device, user *data.User) ([]byte, *data.App, error) {
+// GetNextAppImage picks what a device should display next.
+//
+// baseURL is this server's address as seen by the requesting device; it is
+// used to draw a setup screen when the device has no apps, and may be empty
+// when no request context is available (the placeholder is used instead).
+func (s *Server) GetNextAppImage(ctx context.Context, device *data.Device, user *data.User, baseURL string) ([]byte, *data.App, error) {
 	// 1. Check Pushed Ephemeral Images (__*)
 	// Serve the oldest and delete only that one. Anonymous pushes accumulate
 	// unbounded; callers should use coalesceID to limit queue depth.
@@ -66,6 +71,20 @@ func (s *Server) GetNextAppImage(ctx context.Context, device *data.Device, user 
 
 	// 2. Apps Check
 	if len(device.Apps) == 0 {
+		// Nothing installed yet: show where to install something rather than
+		// a placeholder that gives no way to act on it.
+		if baseURL != "" {
+			width, height := 64, 32
+			if device.Type.Supports2x() {
+				width, height = 128, 64
+			}
+			if img, err := renderSetupImage(ctx, width, height, baseURL); err == nil {
+				return img, nil, nil
+			} else {
+				slog.Warn("Could not render setup image, falling back to default",
+					"device", device.ID, "error", err)
+			}
+		}
 		slog.Debug("No apps on device, returning default image", "device", device.ID)
 		return getDefaultImage()
 	}

--- a/internal/server/rotation_test.go
+++ b/internal/server/rotation_test.go
@@ -490,7 +490,7 @@ func TestGetNextAppImage_EphemeralCleanup(t *testing.T) {
 	}
 
 	// Call GetNextAppImage — serves oldest, deletes only that one
-	_, _, err = s.GetNextAppImage(ctx, &device, &user)
+	_, _, err = s.GetNextAppImage(ctx, &device, &user, "")
 	if err != nil {
 		t.Fatalf("GetNextAppImage failed: %v", err)
 	}
@@ -545,7 +545,7 @@ func TestGetNextAppImage_EphemeralBrokenFileSkipsToNext(t *testing.T) {
 	}
 
 	// GetNextAppImage should skip the broken oldest file and serve the next one
-	imgData, _, err := s.GetNextAppImage(ctx, &device, &user)
+	imgData, _, err := s.GetNextAppImage(ctx, &device, &user, "")
 	if err != nil {
 		t.Fatalf("GetNextAppImage failed: %v", err)
 	}

--- a/internal/server/setup_image.go
+++ b/internal/server/setup_image.go
@@ -1,0 +1,178 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/skip2/go-qrcode"
+	"github.com/tronbyt/pixlet/encode"
+	"github.com/tronbyt/pixlet/render"
+)
+
+// A device with no apps installed used to show a placeholder image, which
+// tells whoever is looking at it nothing about how to fix that. Instead we
+// draw a QR of this server's address next to the address in text: scan it, or
+// type it, and you land on the page where apps get added.
+//
+// The address comes from the request the device itself made, so it is by
+// construction one that reaches this server from the device's network — which
+// is the same network as the phone about to scan it.
+
+var (
+	setupQRLight = color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+	setupQRDark  = color.RGBA{A: 0xff}
+	setupTextFg  = color.RGBA{R: 0xff, G: 0xa5, B: 0x00, A: 0xff}
+)
+
+// renderSetupImage draws the QR and address for a device that has nothing to
+// show yet. Returns an error if baseURL cannot be turned into something worth
+// displaying, so callers can fall back to the placeholder.
+func renderSetupImage(ctx context.Context, width, height int, baseURL string) ([]byte, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Host == "" {
+		return nil, fmt.Errorf("setup image: unusable base URL %q", baseURL)
+	}
+
+	children := []render.Widget{}
+	textWidth := width
+
+	// The QR is optional: on a short panel a long address may not fit at even
+	// one module per pixel, and half a QR is worse than none.
+	const gap = 2
+	if qrImage, side, ok := setupQRImage(baseURL, height); ok {
+		encoded, err := encodePNG(qrImage)
+		if err != nil {
+			return nil, err
+		}
+		// HoldFrames must be at least 1: frameImg divides by it, and a
+		// zero value panics rather than defaulting.
+		qr := &render.Image{Src: encoded, Width: side, Height: side, HoldFrames: 1}
+		// Image decodes Src only when initialized; painting an uninitialized
+		// one panics rather than erroring.
+		if err := qr.InitFromImage(encoded); err != nil {
+			return nil, err
+		}
+		children = append(children, qr)
+		textWidth = width - side - gap
+	}
+
+	// The address without its scheme: it is what someone types, and every
+	// character costs pixels on a 64-wide panel.
+	address := &render.WrappedText{
+		Content: strings.TrimSuffix(parsed.Host, ":80"),
+		Font:    setupFont(width),
+		Color:   setupTextFg,
+		Align:   "center",
+		Width:   textWidth,
+		// An address has no spaces to wrap on, so it has to break mid-token
+		// or it renders as one clipped line.
+		WordBreak: true,
+	}
+	// nil thread is safe because Font is set explicitly; the thread is only
+	// consulted to look up a default font.
+	if err := address.Init(nil); err != nil {
+		return nil, err
+	}
+	children = append(children, &render.Padding{
+		Pad:   render.Insets{Left: gap},
+		Child: address,
+	})
+
+	root := render.Root{
+		Child: &render.Box{
+			Width:  width,
+			Height: height,
+			Child: &render.Row{
+				MainAlign:  "start",
+				CrossAlign: "center",
+				Children:   children,
+			},
+		},
+	}
+
+	screens := encode.ScreensFromRoots([]render.Root{root}, width, height)
+	return screens.EncodeWebP(ctx, 15*time.Second)
+}
+
+// setupFont picks the smallest legible face for the panel. tom-thumb is the
+// narrowest pixlet ships, which is what makes an address fit beside a QR on a
+// 64x32.
+func setupFont(width int) string {
+	if width >= 128 {
+		return "6x13"
+	}
+	return "tom-thumb"
+}
+
+// setupQRImage renders content as a QR sized to fit maxSide pixels square,
+// reporting false when it cannot be drawn legibly.
+//
+// The quiet zone is the widest that still fits. The spec asks for four
+// modules; a 64x32 panel cannot always afford that, and a code drawn without
+// any margin at all is one a phone will not read — so this steps down rather
+// than either overflowing or silently dropping the margin.
+func setupQRImage(content string, maxSide int) (image.Image, int, bool) {
+	code, err := qrcode.New(content, qrcode.Low)
+	if err != nil {
+		return nil, 0, false
+	}
+	code.DisableBorder = true
+
+	modules := code.Bitmap()
+	if len(modules) == 0 {
+		return nil, 0, false
+	}
+
+	// Bigger modules matter more than a wider margin: a code drawn at one
+	// pixel per module on a 64-tall panel is at the limit of what a phone
+	// camera resolves, so maximise scale first and spend whatever height is
+	// left on the quiet zone. The spec asks for four modules of margin; a
+	// small panel cannot always afford that, and dropping it entirely makes a
+	// code most readers refuse, so this takes the widest that still fits.
+	quiet, scale := 0, 0
+	for candidate := 4; candidate >= 1; candidate-- {
+		fit := maxSide / (len(modules) + 2*candidate)
+		if fit > scale {
+			quiet, scale = candidate, fit
+		}
+	}
+	if scale < 1 {
+		return nil, 0, false
+	}
+
+	total := len(modules) + 2*quiet
+	side := total * scale
+	img := image.NewRGBA(image.Rect(0, 0, side, side))
+	// Standard dark-on-light: an inverted code is far less reliably scanned,
+	// so the code's background is what gets lit on the panel.
+	draw.Draw(img, img.Bounds(), &image.Uniform{C: setupQRLight}, image.Point{}, draw.Src)
+	for y, row := range modules {
+		for x, dark := range row {
+			if !dark {
+				continue
+			}
+			module := image.Rect(
+				(x+quiet)*scale, (y+quiet)*scale,
+				(x+quiet+1)*scale, (y+quiet+1)*scale,
+			)
+			draw.Draw(img, module, &image.Uniform{C: setupQRDark}, image.Point{}, draw.Src)
+		}
+	}
+	return img, side, true
+}
+
+func encodePNG(img image.Image) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/server/setup_image_test.go
+++ b/internal/server/setup_image_test.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"image/color"
+	"strings"
+	"testing"
+
+	"tronbyt-server/internal/data"
+	"tronbyt-server/web"
+
+	"github.com/skip2/go-qrcode"
+	"gorm.io/gorm"
+)
+
+// The drawn code must be the encoder's code — a QR that is merely
+// QR-shaped scans as nothing.
+func TestSetupQRImageMatchesTheEncoder(t *testing.T) {
+	const content = "http://192.168.1.155:8000"
+
+	img, side, ok := setupQRImage(content, 32)
+	if !ok {
+		t.Fatal("expected a QR to fit a 32px panel")
+	}
+
+	expected, err := qrcode.New(content, qrcode.Low)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected.DisableBorder = true
+	modules := expected.Bitmap()
+
+	quiet := (side/scaleOf(side, len(modules)) - len(modules)) / 2
+	scale := scaleOf(side, len(modules))
+	for y, row := range modules {
+		for x, dark := range row {
+			px := img.At((x+quiet)*scale, (y+quiet)*scale)
+			if isDark(px) != dark {
+				t.Fatalf("module (%d,%d): drawn dark=%v, encoder says %v",
+					x, y, isDark(px), dark)
+			}
+		}
+	}
+}
+
+// Standard dark-on-light polarity: inverted codes are read far less
+// reliably, so the margin has to be the lit colour, not the panel's black.
+func TestSetupQRImageHasALightQuietZone(t *testing.T) {
+	img, side, ok := setupQRImage("http://192.168.1.155:8000", 32)
+	if !ok {
+		t.Fatal("expected a QR to fit")
+	}
+	for _, p := range [][2]int{{0, 0}, {side - 1, 0}, {0, side - 1}, {side - 1, side - 1}} {
+		if isDark(img.At(p[0], p[1])) {
+			t.Errorf("corner %v is dark; the quiet zone must be light", p)
+		}
+	}
+}
+
+// A code that cannot be drawn at even one pixel per module is worse than no
+// code at all, so it is declined rather than clipped.
+func TestSetupQRImageDeclinesWhatCannotFit(t *testing.T) {
+	if _, _, ok := setupQRImage("http://192.168.1.155:8000", 8); ok {
+		t.Error("expected a QR to be declined on an 8px panel")
+	}
+}
+
+func TestRenderSetupImageDrawsBothPanelSizes(t *testing.T) {
+	for _, c := range []struct{ w, h int }{{64, 32}, {128, 64}} {
+		data, err := renderSetupImage(context.Background(), c.w, c.h, "http://192.168.1.155:8000")
+		if err != nil {
+			t.Fatalf("%dx%d: %v", c.w, c.h, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("%dx%d: empty image", c.w, c.h)
+		}
+		if !bytes.HasPrefix(data, []byte("RIFF")) {
+			t.Errorf("%dx%d: not a WebP", c.w, c.h)
+		}
+	}
+}
+
+func TestRenderSetupImageRejectsAnAddressItCannotUse(t *testing.T) {
+	if _, err := renderSetupImage(context.Background(), 64, 32, "::not a url"); err == nil {
+		t.Error("expected an error for an unusable address")
+	}
+}
+
+// The point of the change: a device with nothing installed is told where to
+// go, instead of being shown a placeholder it cannot act on.
+func TestGetNextAppImageShowsSetupWhenThereAreNoApps(t *testing.T) {
+	s := newTestServer(t)
+	ctx := context.Background()
+
+	user := data.User{Username: "testuser"}
+	if err := gorm.G[data.User](s.DB).Create(ctx, &user); err != nil {
+		t.Fatal(err)
+	}
+	device := data.Device{ID: "dev1", Username: user.Username, Name: "Dev", Brightness: 50}
+	if err := gorm.G[data.Device](s.DB).Create(ctx, &device); err != nil {
+		t.Fatal(err)
+	}
+
+	placeholder, err := web.Assets.ReadFile("static/images/default.webp")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	withURL, _, err := s.GetNextAppImage(ctx, &device, &user, "http://192.168.1.155:8000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(withURL, placeholder) {
+		t.Error("expected the setup screen, got the placeholder")
+	}
+
+	// Without an address there is nothing to point at, so the old behaviour
+	// stands rather than drawing a code that leads nowhere.
+	withoutURL, _, err := s.GetNextAppImage(ctx, &device, &user, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(withoutURL, placeholder) {
+		t.Error("expected the placeholder when no address is known")
+	}
+}
+
+func TestSetupFontFitsThePanel(t *testing.T) {
+	if f := setupFont(64); !strings.Contains(f, "tom-thumb") {
+		t.Errorf("64px panel should use the narrowest face, got %q", f)
+	}
+	if f := setupFont(128); f == "tom-thumb" {
+		t.Error("128px panel has room for a larger face")
+	}
+}
+
+// helpers
+
+func scaleOf(side, modules int) int {
+	for quiet := 4; quiet >= 1; quiet-- {
+		total := modules + 2*quiet
+		if total*(side/total) == side {
+			return side / total
+		}
+	}
+	return 1
+}
+
+func isDark(c color.Color) bool {
+	r, g, b, _ := c.RGBA()
+	return r < 0x8000 && g < 0x8000 && b < 0x8000
+}

--- a/internal/server/websockets.go
+++ b/internal/server/websockets.go
@@ -199,10 +199,12 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	s.wsWriteLoop(r.Context(), conn, device, &user, ackCh, ch, stopCh)
+	s.wsWriteLoop(r.Context(), conn, device, &user, ackCh, ch, stopCh, s.GetBaseURL(r))
 }
 
-func (s *Server) wsWriteLoop(ctx context.Context, conn *websocket.Conn, initialDevice *data.Device, user *data.User, ackCh <-chan WSMessage, broadcastCh <-chan any, stopCh <-chan struct{}) {
+// baseURL is this server's address as the device connected to it, captured
+// when the socket opened — the write loop outlives the request that made it.
+func (s *Server) wsWriteLoop(ctx context.Context, conn *websocket.Conn, initialDevice *data.Device, user *data.User, ackCh <-chan WSMessage, broadcastCh <-chan any, stopCh <-chan struct{}, baseURL string) {
 	var pendingImage []byte
 	device := *initialDevice
 	lastSentBrightness := -1
@@ -227,7 +229,7 @@ func (s *Server) wsWriteLoop(ctx context.Context, conn *websocket.Conn, initialD
 			imgData = pendingImage
 			pendingImage = nil
 		} else {
-			imgData, app, err = s.GetNextAppImage(ctx, &device, user)
+			imgData, app, err = s.GetNextAppImage(ctx, &device, user, baseURL)
 			if err != nil {
 				slog.Error("Failed to get next app", "error", err)
 


### PR DESCRIPTION
A device with nothing installed shows the placeholder image. This draws the server's address instead: a QR on the left, the same address in text beside it. 

### What it looks like

**64×32**

![Setup screen on a 64x32 panel](https://raw.githubusercontent.com/nsluke/tronbyt-server/pr896-assets/setup-64x32.png)

**128×64** — the code scales to 2× and the address gets a larger face

![Setup screen on a 128x64 panel](https://raw.githubusercontent.com/nsluke/tronbyt-server/pr896-assets/setup-128x64.png)

**A longer address** still fits; the text wraps rather than clipping

![Setup screen with a longer address](https://raw.githubusercontent.com/nsluke/tronbyt-server/pr896-assets/setup-64x32-longer-address.png)

### Where the address comes from

From the request the device itself made, via the existing `Server.GetBaseURL(r)` (which already handles `X-Forwarded-Proto/Host/Port`). That address is by construction reachable from the device's network — the same network as the phone about to scan it.

When no address is available, `GetNextAppImage` falls back to the placeholder exactly as before. That's why the two existing call sites in `rotation_test.go` only needed `""` appended and none of their expectations changed.

### Scope

Only the **no-apps** case changes. `getDefaultImage()` is reached for five reasons — no apps, every app disabled or scheduled out, and two read failures. A setup code would be wrong or misleading in the other four, so they keep the placeholder.

```
 go.mod                                 |   2 +-   (go-qrcode: indirect -> direct)
 internal/server/handlers_device_api.go |   2 +-
 internal/server/rotation.go            |  21 +++-
 internal/server/rotation_test.go       |   4 +-
 internal/server/setup_image.go         | 178 +++++++++++++++++
 internal/server/setup_image_test.go    | 153 ++++++++++++++
 internal/server/websockets.go          |   8 +-
```

No new dependency: `skip2/go-qrcode`, pixlet's `render`/`encode` and the webp encoders were already in the module graph. `go-qrcode` just moves from indirect to direct.

### Two sizing decisions, both learned on a real 64x32 panel

**Module size beats margin.** A code drawn at one pixel per module on a 64-tall panel is at the limit of what a phone camera resolves, so the renderer maximises scale first and spends what height is left on the quiet zone. The spec asks for four modules of margin; a small panel can't always afford four, and a code with no margin is one most readers refuse — so it takes the widest that fits, and declines to draw a code at all when even one pixel per module won't fit (text-only, rather than something clipped).

My first attempt maximised the *margin* instead, which left the 128x64 panel showing a 33px code in a 64px space. Worth knowing if this gets refactored.

**Dark-on-light.** Inverted codes scan far less reliably, so the code's background is what gets lit, not the modules.

### Tests

- drawn modules compared against `go-qrcode`'s own bitmap — a QR that is merely QR-*shaped* scans as nothing
- quiet zone asserted light (polarity)
- an impossible panel asserted to decline rather than clip
- `GetNextAppImage` asserted to return the setup screen with an address and the placeholder without one

`go test ./...` passes, `golangci-lint run` reports 0 issues, `go mod verify` clean.

### One gap worth flagging

I verified the module data matches the encoder, but I wasn't able to run a real decoder against these particular renders in this environment. The same polarity and quiet-zone approach does decode from a physical panel in my own setup, but someone pointing a phone at a 64x32 before merge would be worth it.

### Open questions for maintainers

- Wording: right now it's address-only, no label. Happy to add something like "ADD APPS" if that reads better?  I left it off deliberately since the same screen could be reached by a device whose apps are all scheduled out if the scope were ever widened.
- Should WS devices get this too? They do here (the address is captured when the socket opens, since the write loop outlives the request), but say the word if you'd rather it were HTTP-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Devices without installed apps now display a setup image with a QR code and server address.
  * Setup images are optimized for different device panel sizes and remain readable through responsive text layout.
* **Bug Fixes**
  * Devices gracefully fall back to the default setup image when the server address is unavailable or image generation fails.
  * QR codes are omitted when they cannot fit within the available display area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
