### PR TITLE
Add crop, pan, and zoom controls for image uploads on Shuffle Images app

### DIFF
--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1366,13 +1366,17 @@ function createImageUploadField(field, config) {
     );
   }
 
+  let selectionGeneration = 0;
+
   uploadInput.addEventListener("change", event => {
     const file = event.target.files[0];
     if (!file) return;
 
+    const generation = ++selectionGeneration;
     const reader = new FileReader();
 
     reader.onload = e => {
+      if (generation !== selectionGeneration) return;
       initializeImage(e.target.result, false);
     };
 

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1188,39 +1188,6 @@
     return container;
   }
 
-  function createImageUploadField(field, config) {
-    const container = document.createElement("div");
-
-    const uploadLabel = document.createElement("label");
-    uploadLabel.htmlFor = `${field.id}_upload`;
-    uploadLabel.textContent = "{{ t .Localizer "Upload Image" }}";
-    container.appendChild(uploadLabel);
-
-    const uploadInput = document.createElement("input");
-    uploadInput.type = "file";
-    uploadInput.id = `${field.id}_upload`;
-    uploadInput.setAttribute("data-ignore-config", "true");
-    uploadInput.accept = "image/png, image/jpeg, image/gif, image/svg+xml, image/webp";
-    container.appendChild(uploadInput);
-
-    const hiddenInput = document.createElement("input");
-    hiddenInput.type = "hidden";
-    hiddenInput.id = "schema_" + field.id;
-    hiddenInput.dataset.configId = field.id;
-    hiddenInput.name = field.id;
-    hiddenInput.value = config[field.id] || "";
-    container.appendChild(hiddenInput);
-
-    const previewImage = document.createElement("img");
-    previewImage.id = `${field.id}_preview`;
-    previewImage.src = config[field.id] ? `data:image/png;base64,${config[field.id]}` : "";
-    previewImage.alt = "{{ t .Localizer "Preview" }}";
-    previewImage.style.maxWidth = "100%";
-    previewImage.style.height = "auto";
-    previewImage.style.marginTop = "10px";
-    previewImage.style.display = config[field.id] ? "inline" : "none";
-    container.appendChild(previewImage);
-
 function createImageUploadField(field, config) {
   const container = document.createElement("div");
 
@@ -1233,8 +1200,56 @@ function createImageUploadField(field, config) {
   uploadInput.type = "file";
   uploadInput.id = `${field.id}_upload`;
   uploadInput.setAttribute("data-ignore-config", "true");
-  uploadInput.accept = "image/png, image/jpeg, image/gif, image/svg+xml, image/webp";
+  uploadInput.accept = "image/png, image/jpeg, image/gif, image/webp";
   container.appendChild(uploadInput);
+
+  const cropArea = document.createElement("div");
+  cropArea.style.width = "100%";
+  cropArea.style.maxWidth = "640px";
+  cropArea.style.aspectRatio = "2 / 1";
+  cropArea.style.position = "relative";
+  cropArea.style.overflow = "hidden";
+  cropArea.style.background = "#000";
+  cropArea.style.marginTop = "10px";
+  cropArea.style.cursor = "grab";
+  cropArea.style.display = "none";
+  cropArea.setAttribute("data-ignore-config", "true");
+  container.appendChild(cropArea);
+
+  const cropImage = document.createElement("img");
+  cropImage.style.position = "absolute";
+  cropImage.style.left = "0";
+  cropImage.style.top = "0";
+  cropImage.style.transformOrigin = "0 0";
+  cropImage.style.maxWidth = "none";
+  cropImage.style.userSelect = "none";
+  cropImage.style.pointerEvents = "none";
+  cropArea.appendChild(cropImage);
+
+  const cropFrame = document.createElement("div");
+  cropFrame.style.position = "absolute";
+  cropFrame.style.inset = "0";
+  cropFrame.style.border = "2px solid white";
+  cropFrame.style.boxSizing = "border-box";
+  cropFrame.style.pointerEvents = "none";
+  cropArea.appendChild(cropFrame);
+
+  const zoomLabel = document.createElement("label");
+  zoomLabel.textContent = "Zoom";
+  zoomLabel.style.display = "none";
+  zoomLabel.style.marginTop = "8px";
+  container.appendChild(zoomLabel);
+
+  const zoomInput = document.createElement("input");
+  zoomInput.type = "range";
+  zoomInput.min = "0.1";
+  zoomInput.max = "5";
+  zoomInput.step = "0.01";
+  zoomInput.value = "1";
+  zoomInput.style.width = "100%";
+  zoomInput.style.display = "none";
+  zoomInput.setAttribute("data-ignore-config", "true");
+  container.appendChild(zoomInput);
 
   const hiddenInput = document.createElement("input");
   hiddenInput.type = "hidden";
@@ -1244,15 +1259,53 @@ function createImageUploadField(field, config) {
   hiddenInput.value = config[field.id] || "";
   container.appendChild(hiddenInput);
 
-  const previewImage = document.createElement("img");
-  previewImage.id = `${field.id}_preview`;
-  previewImage.src = config[field.id] ? `data:image/png;base64,${config[field.id]}` : "";
-  previewImage.alt = "{{ t .Localizer "Preview" }}";
-  previewImage.style.maxWidth = "100%";
-  previewImage.style.height = "auto";
-  previewImage.style.marginTop = "10px";
-  previewImage.style.display = config[field.id] ? "inline" : "none";
-  container.appendChild(previewImage);
+  let imageScale = 1;
+  let imageX = 0;
+  let imageY = 0;
+  let dragging = false;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let imageStartX = 0;
+  let imageStartY = 0;
+
+  function updateImagePosition() {
+    cropImage.style.transform =
+      `translate(${imageX}px, ${imageY}px) scale(${imageScale})`;
+  }
+
+  function saveCrop() {
+    if (!cropImage.src) return;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = 64;
+    canvas.height = 32;
+
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "black";
+    ctx.fillRect(0, 0, 64, 32);
+
+    const areaWidth = cropArea.clientWidth;
+    const areaHeight = cropArea.clientHeight;
+
+    const outputScaleX = 64 / areaWidth;
+    const outputScaleY = 32 / areaHeight;
+
+    ctx.save();
+    ctx.scale(outputScaleX, outputScaleY);
+
+    ctx.translate(imageX, imageY);
+    ctx.scale(imageScale, imageScale);
+    ctx.drawImage(cropImage, 0, 0);
+
+    ctx.restore();
+
+    const resizedDataUrl = canvas.toDataURL("image/png");
+    const base64Data = resizedDataUrl.split(",")[1];
+
+    hiddenInput.value = base64Data;
+    config[field.id] = base64Data;
+    updateConfigAndPreview();
+  }
 
   uploadInput.addEventListener("change", event => {
     const file = event.target.files[0];
@@ -1261,48 +1314,88 @@ function createImageUploadField(field, config) {
     const reader = new FileReader();
 
     reader.onload = e => {
-      const sourceImage = new Image();
+      cropImage.onload = () => {
+        cropArea.style.display = "block";
+        zoomLabel.style.display = "block";
+        zoomInput.style.display = "block";
 
-      sourceImage.onload = () => {
-        const canvas = document.createElement("canvas");
-        canvas.width = 64;
-        canvas.height = 32;
+        const areaWidth = cropArea.clientWidth;
+        const areaHeight = cropArea.clientHeight;
 
-        const ctx = canvas.getContext("2d");
-
-        // Black background for any unused space
-        ctx.fillStyle = "black";
-        ctx.fillRect(0, 0, 64, 32);
-
-        // Preserve aspect ratio
-        const scale = Math.min(
-          64 / sourceImage.width,
-          32 / sourceImage.height
+        const initialScale = Math.max(
+          areaWidth / cropImage.naturalWidth,
+          areaHeight / cropImage.naturalHeight
         );
 
-        const width = sourceImage.width * scale;
-        const height = sourceImage.height * scale;
+        imageScale = initialScale;
+        zoomInput.min = initialScale;
+        zoomInput.value = initialScale;
+        zoomInput.max = Math.max(initialScale * 5, 5);
 
-        const x = (64 - width) / 2;
-        const y = (32 - height) / 2;
+        imageX =
+          (areaWidth - cropImage.naturalWidth * imageScale) / 2;
+        imageY =
+          (areaHeight - cropImage.naturalHeight * imageScale) / 2;
 
-        ctx.drawImage(sourceImage, x, y, width, height);
-
-        const resizedDataUrl = canvas.toDataURL("image/png");
-        const base64Data = resizedDataUrl.split(",")[1];
-
-        hiddenInput.value = base64Data;
-        previewImage.src = resizedDataUrl;
-        previewImage.style.display = "inline";
-        config[field.id] = base64Data;
-
-        updateConfigAndPreview();
+        updateImagePosition();
+        saveCrop();
       };
 
-      sourceImage.src = e.target.result;
+      cropImage.src = e.target.result;
     };
 
     reader.readAsDataURL(file);
+  });
+
+  zoomInput.addEventListener("input", () => {
+    const oldScale = imageScale;
+    const newScale = parseFloat(zoomInput.value);
+
+    const centerX = cropArea.clientWidth / 2;
+    const centerY = cropArea.clientHeight / 2;
+
+    imageX =
+      centerX - (centerX - imageX) * (newScale / oldScale);
+    imageY =
+      centerY - (centerY - imageY) * (newScale / oldScale);
+
+    imageScale = newScale;
+
+    updateImagePosition();
+    saveCrop();
+  });
+
+  cropArea.addEventListener("pointerdown", event => {
+    dragging = true;
+    dragStartX = event.clientX;
+    dragStartY = event.clientY;
+    imageStartX = imageX;
+    imageStartY = imageY;
+
+    cropArea.style.cursor = "grabbing";
+    cropArea.setPointerCapture(event.pointerId);
+  });
+
+  cropArea.addEventListener("pointermove", event => {
+    if (!dragging) return;
+
+    imageX = imageStartX + (event.clientX - dragStartX);
+    imageY = imageStartY + (event.clientY - dragStartY);
+
+    updateImagePosition();
+  });
+
+  cropArea.addEventListener("pointerup", event => {
+    if (!dragging) return;
+
+    dragging = false;
+    cropArea.style.cursor = "grab";
+
+    try {
+      cropArea.releasePointerCapture(event.pointerId);
+    } catch (e) {}
+
+    saveCrop();
   });
 
   return container;

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1221,31 +1221,92 @@
     previewImage.style.display = config[field.id] ? "inline" : "none";
     container.appendChild(previewImage);
 
-    uploadInput.addEventListener("change", event => {
-      const file = event.target.files[0];
-      if (!file) return;
+function createImageUploadField(field, config) {
+  const container = document.createElement("div");
 
-      const maxSize = 500 * 1024;
-      if (file.size > maxSize) {
-        alert("{{ t .Localizer "File size exceeds 500KB limit. Please upload a smaller image." }}");
-        uploadInput.value = "";
-        return;
-      }
+  const uploadLabel = document.createElement("label");
+  uploadLabel.htmlFor = `${field.id}_upload`;
+  uploadLabel.textContent = "{{ t .Localizer "Upload Image" }}";
+  container.appendChild(uploadLabel);
 
-      const reader = new FileReader();
-      reader.onload = e => {
-        const base64Data = e.target.result.split(",")[1];
+  const uploadInput = document.createElement("input");
+  uploadInput.type = "file";
+  uploadInput.id = `${field.id}_upload`;
+  uploadInput.setAttribute("data-ignore-config", "true");
+  uploadInput.accept = "image/png, image/jpeg, image/gif, image/svg+xml, image/webp";
+  container.appendChild(uploadInput);
+
+  const hiddenInput = document.createElement("input");
+  hiddenInput.type = "hidden";
+  hiddenInput.id = "schema_" + field.id;
+  hiddenInput.dataset.configId = field.id;
+  hiddenInput.name = field.id;
+  hiddenInput.value = config[field.id] || "";
+  container.appendChild(hiddenInput);
+
+  const previewImage = document.createElement("img");
+  previewImage.id = `${field.id}_preview`;
+  previewImage.src = config[field.id] ? `data:image/png;base64,${config[field.id]}` : "";
+  previewImage.alt = "{{ t .Localizer "Preview" }}";
+  previewImage.style.maxWidth = "100%";
+  previewImage.style.height = "auto";
+  previewImage.style.marginTop = "10px";
+  previewImage.style.display = config[field.id] ? "inline" : "none";
+  container.appendChild(previewImage);
+
+  uploadInput.addEventListener("change", event => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+
+    reader.onload = e => {
+      const sourceImage = new Image();
+
+      sourceImage.onload = () => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 64;
+        canvas.height = 32;
+
+        const ctx = canvas.getContext("2d");
+
+        // Black background for any unused space
+        ctx.fillStyle = "black";
+        ctx.fillRect(0, 0, 64, 32);
+
+        // Preserve aspect ratio
+        const scale = Math.min(
+          64 / sourceImage.width,
+          32 / sourceImage.height
+        );
+
+        const width = sourceImage.width * scale;
+        const height = sourceImage.height * scale;
+
+        const x = (64 - width) / 2;
+        const y = (32 - height) / 2;
+
+        ctx.drawImage(sourceImage, x, y, width, height);
+
+        const resizedDataUrl = canvas.toDataURL("image/png");
+        const base64Data = resizedDataUrl.split(",")[1];
+
         hiddenInput.value = base64Data;
-        previewImage.src = e.target.result;
+        previewImage.src = resizedDataUrl;
         previewImage.style.display = "inline";
         config[field.id] = base64Data;
+
         updateConfigAndPreview();
       };
-      reader.readAsDataURL(file);
-    });
 
-    return container;
-  }
+      sourceImage.src = e.target.result;
+    };
+
+    reader.readAsDataURL(file);
+  });
+
+  return container;
+}
 
   function createTypeaheadField(field, config) {
     let inputElement = document.createElement("div");

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1314,19 +1314,111 @@ function createImageUploadField(field, config) {
   }
 
   // Canvas drawImage + toDataURL flattens animated GIF/WebP to a single PNG frame.
-  function shouldPreserveAnimation(value) {
-    const raw = String(value || "");
-    const payload = storedPayload(raw);
-    if (raw.includes("image/gif") || payload.startsWith("R0lGOD")) {
-      return true;
-    }
-    if (raw.includes("image/webp") || payload.startsWith("UklGR")) {
-      try {
-        return atob(payload.slice(0, 256)).includes("ANIM");
-      } catch (e) {
-        return false;
+  function decodeBase64Bytes(payload) {
+    try {
+      const binary = atob(String(payload || "").replace(/\s/g, ""));
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
       }
+      return bytes;
+    } catch (e) {
+      return null;
     }
+  }
+
+  function readU32LE(bytes, offset) {
+    if (offset + 4 > bytes.length) return null;
+    return (
+      bytes[offset] |
+      (bytes[offset + 1] << 8) |
+      (bytes[offset + 2] << 16) |
+      (bytes[offset + 3] << 24)
+    ) >>> 0;
+  }
+
+  function asciiAt(bytes, offset, length) {
+    if (offset + length > bytes.length) return "";
+    return String.fromCharCode(...bytes.subarray(offset, offset + length));
+  }
+
+  function skipGifSubBlocks(bytes, offset) {
+    let i = offset;
+    while (i < bytes.length) {
+      const len = bytes[i];
+      i += 1;
+      if (len === 0) return i;
+      i += len;
+    }
+    return -1;
+  }
+
+  function gifHasMultipleFrames(bytes) {
+    if (bytes.length < 13) return false;
+    const header = asciiAt(bytes, 0, 6);
+    if (header !== "GIF87a" && header !== "GIF89a") return false;
+
+    let i = 13;
+    const packed = bytes[10];
+    if (packed & 0x80) {
+      i += 3 * (1 << ((packed & 0x07) + 1));
+    }
+
+    let frames = 0;
+    while (i < bytes.length) {
+      const marker = bytes[i];
+      if (marker === 0x3B) break;
+      if (marker === 0x2C) {
+        if (i + 10 > bytes.length) return false;
+        const imgPacked = bytes[i + 9];
+        frames += 1;
+        if (frames >= 2) return true;
+        i += 10;
+        if (imgPacked & 0x80) {
+          i += 3 * (1 << ((imgPacked & 0x07) + 1));
+        }
+        if (i >= bytes.length) return false;
+        i += 1;
+        i = skipGifSubBlocks(bytes, i);
+        if (i < 0) return false;
+        continue;
+      }
+      if (marker === 0x21) {
+        if (i + 2 > bytes.length) return false;
+        i = skipGifSubBlocks(bytes, i + 2);
+        if (i < 0) return false;
+        continue;
+      }
+      return false;
+    }
+    return false;
+  }
+
+  function webpHasAnimChunk(bytes) {
+    if (asciiAt(bytes, 0, 4) !== "RIFF" || asciiAt(bytes, 8, 4) !== "WEBP") {
+      return false;
+    }
+    const riffSize = readU32LE(bytes, 4);
+    if (riffSize === null) return false;
+    const end = Math.min(bytes.length, 8 + riffSize);
+    let i = 12;
+    while (i + 8 <= end) {
+      const fourcc = asciiAt(bytes, i, 4);
+      const size = readU32LE(bytes, i + 4);
+      if (size === null) return false;
+      if (fourcc === "ANIM") return true;
+      const payloadEnd = i + 8 + size + (size % 2);
+      if (payloadEnd <= i) return false;
+      i = payloadEnd;
+    }
+    return false;
+  }
+
+  function shouldPreserveAnimation(value) {
+    const bytes = decodeBase64Bytes(storedPayload(value));
+    if (!bytes) return false;
+    if (gifHasMultipleFrames(bytes)) return true;
+    if (webpHasAnimChunk(bytes)) return true;
     return false;
   }
 

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1235,13 +1235,15 @@ function createImageUploadField(field, config) {
   cropArea.appendChild(cropFrame);
 
   const zoomLabel = document.createElement("label");
-  zoomLabel.textContent = "Zoom";
+  zoomLabel.htmlFor = `${field.id}_zoom`;
+  zoomLabel.textContent = "{{ t .Localizer "Zoom" }}";
   zoomLabel.style.display = "none";
   zoomLabel.style.marginTop = "8px";
   container.appendChild(zoomLabel);
 
   const zoomInput = document.createElement("input");
   zoomInput.type = "range";
+  zoomInput.id = `${field.id}_zoom`;
   zoomInput.min = "0.1";
   zoomInput.max = "5";
   zoomInput.step = "0.01";
@@ -1268,7 +1270,29 @@ function createImageUploadField(field, config) {
   let imageStartX = 0;
   let imageStartY = 0;
 
+  function clampImagePosition() {
+    if (!cropImage.naturalWidth || !cropImage.naturalHeight) return;
+
+    const areaWidth = cropArea.clientWidth;
+    const areaHeight = cropArea.clientHeight;
+    const imageWidth = cropImage.naturalWidth * imageScale;
+    const imageHeight = cropImage.naturalHeight * imageScale;
+
+    if (imageWidth <= areaWidth) {
+      imageX = (areaWidth - imageWidth) / 2;
+    } else {
+      imageX = Math.min(0, Math.max(areaWidth - imageWidth, imageX));
+    }
+
+    if (imageHeight <= areaHeight) {
+      imageY = (areaHeight - imageHeight) / 2;
+    } else {
+      imageY = Math.min(0, Math.max(areaHeight - imageHeight, imageY));
+    }
+  }
+
   function updateImagePosition() {
+    clampImagePosition();
     cropImage.style.transform =
       `translate(${imageX}px, ${imageY}px) scale(${imageScale})`;
   }
@@ -1287,16 +1311,11 @@ function createImageUploadField(field, config) {
     const areaWidth = cropArea.clientWidth;
     const areaHeight = cropArea.clientHeight;
 
-    const outputScaleX = 64 / areaWidth;
-    const outputScaleY = 32 / areaHeight;
-
     ctx.save();
-    ctx.scale(outputScaleX, outputScaleY);
-
+    ctx.scale(64 / areaWidth, 32 / areaHeight);
     ctx.translate(imageX, imageY);
     ctx.scale(imageScale, imageScale);
     ctx.drawImage(cropImage, 0, 0);
-
     ctx.restore();
 
     const resizedDataUrl = canvas.toDataURL("image/png");
@@ -1307,6 +1326,46 @@ function createImageUploadField(field, config) {
     updateConfigAndPreview();
   }
 
+  function initializeImage(source, preserveExisting) {
+    cropImage.onload = () => {
+      cropArea.style.display = "block";
+      zoomLabel.style.display = "block";
+      zoomInput.style.display = "block";
+
+      const areaWidth = cropArea.clientWidth;
+      const areaHeight = cropArea.clientHeight;
+
+      imageScale = Math.max(
+        areaWidth / cropImage.naturalWidth,
+        areaHeight / cropImage.naturalHeight
+      );
+
+      zoomInput.min = imageScale;
+      zoomInput.value = imageScale;
+      zoomInput.max = Math.max(imageScale * 5, 5);
+
+      imageX =
+        (areaWidth - cropImage.naturalWidth * imageScale) / 2;
+      imageY =
+        (areaHeight - cropImage.naturalHeight * imageScale) / 2;
+
+      updateImagePosition();
+
+      if (!preserveExisting) {
+        saveCrop();
+      }
+    };
+
+    cropImage.src = source;
+  }
+
+  if (config[field.id]) {
+    initializeImage(
+      `data:image/png;base64,${config[field.id]}`,
+      true
+    );
+  }
+
   uploadInput.addEventListener("change", event => {
     const file = event.target.files[0];
     if (!file) return;
@@ -1314,34 +1373,7 @@ function createImageUploadField(field, config) {
     const reader = new FileReader();
 
     reader.onload = e => {
-      cropImage.onload = () => {
-        cropArea.style.display = "block";
-        zoomLabel.style.display = "block";
-        zoomInput.style.display = "block";
-
-        const areaWidth = cropArea.clientWidth;
-        const areaHeight = cropArea.clientHeight;
-
-        const initialScale = Math.max(
-          areaWidth / cropImage.naturalWidth,
-          areaHeight / cropImage.naturalHeight
-        );
-
-        imageScale = initialScale;
-        zoomInput.min = initialScale;
-        zoomInput.value = initialScale;
-        zoomInput.max = Math.max(initialScale * 5, 5);
-
-        imageX =
-          (areaWidth - cropImage.naturalWidth * imageScale) / 2;
-        imageY =
-          (areaHeight - cropImage.naturalHeight * imageScale) / 2;
-
-        updateImagePosition();
-        saveCrop();
-      };
-
-      cropImage.src = e.target.result;
+      initializeImage(e.target.result, false);
     };
 
     reader.readAsDataURL(file);
@@ -1365,6 +1397,21 @@ function createImageUploadField(field, config) {
     saveCrop();
   });
 
+  function stopDragging(event, save = true) {
+    if (!dragging) return;
+
+    dragging = false;
+    cropArea.style.cursor = "grab";
+
+    if (event && cropArea.hasPointerCapture(event.pointerId)) {
+      cropArea.releasePointerCapture(event.pointerId);
+    }
+
+    if (save) {
+      saveCrop();
+    }
+  }
+
   cropArea.addEventListener("pointerdown", event => {
     dragging = true;
     dragStartX = event.clientX;
@@ -1386,16 +1433,11 @@ function createImageUploadField(field, config) {
   });
 
   cropArea.addEventListener("pointerup", event => {
-    if (!dragging) return;
+    stopDragging(event);
+  });
 
-    dragging = false;
-    cropArea.style.cursor = "grab";
-
-    try {
-      cropArea.releasePointerCapture(event.pointerId);
-    } catch (e) {}
-
-    saveCrop();
+  cropArea.addEventListener("pointercancel", event => {
+    stopDragging(event);
   });
 
   return container;

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1241,13 +1241,16 @@ function createImageUploadField(field, config) {
   zoomLabel.style.marginTop = "8px";
   container.appendChild(zoomLabel);
 
+  // Integer 0–100 mapped onto [minScale, maxScale]. Gecko constraint-validates
+  // range inputs, so a float min with step="0.01" blocks submit with
+  // "Please select a valid value" and two long decimal neighbors.
   const zoomInput = document.createElement("input");
   zoomInput.type = "range";
   zoomInput.id = `${field.id}_zoom`;
-  zoomInput.min = "0.1";
-  zoomInput.max = "5";
-  zoomInput.step = "0.01";
-  zoomInput.value = "1";
+  zoomInput.min = "0";
+  zoomInput.max = "100";
+  zoomInput.step = "1";
+  zoomInput.value = "0";
   zoomInput.style.width = "100%";
   zoomInput.style.display = "none";
   zoomInput.setAttribute("data-ignore-config", "true");
@@ -1261,6 +1264,8 @@ function createImageUploadField(field, config) {
   hiddenInput.value = config[field.id] || "";
   container.appendChild(hiddenInput);
 
+  let minScale = 1;
+  let maxScale = 5;
   let imageScale = 1;
   let imageX = 0;
   let imageY = 0;
@@ -1289,6 +1294,11 @@ function createImageUploadField(field, config) {
     } else {
       imageY = Math.min(0, Math.max(areaHeight - imageHeight, imageY));
     }
+  }
+
+  function scaleFromZoomSlider() {
+    const t = Number(zoomInput.value) / 100;
+    return minScale + t * (maxScale - minScale);
   }
 
   function updateImagePosition() {
@@ -1335,14 +1345,15 @@ function createImageUploadField(field, config) {
       const areaWidth = cropArea.clientWidth;
       const areaHeight = cropArea.clientHeight;
 
-      imageScale = Math.max(
+      const initialScale = Math.max(
         areaWidth / cropImage.naturalWidth,
         areaHeight / cropImage.naturalHeight
       );
 
-      zoomInput.min = imageScale;
-      zoomInput.value = imageScale;
-      zoomInput.max = Math.max(imageScale * 5, 5);
+      minScale = initialScale;
+      maxScale = Math.max(initialScale * 5, 5);
+      imageScale = minScale;
+      zoomInput.value = "0";
 
       imageX =
         (areaWidth - cropImage.naturalWidth * imageScale) / 2;
@@ -1385,7 +1396,7 @@ function createImageUploadField(field, config) {
 
   zoomInput.addEventListener("input", () => {
     const oldScale = imageScale;
-    const newScale = parseFloat(zoomInput.value);
+    const newScale = scaleFromZoomSlider();
 
     const centerX = cropArea.clientWidth / 2;
     const centerY = cropArea.clientHeight / 2;

--- a/web/templates/manager/configapp.html
+++ b/web/templates/manager/configapp.html
@@ -1269,6 +1269,7 @@ function createImageUploadField(field, config) {
   let imageScale = 1;
   let imageX = 0;
   let imageY = 0;
+  let preserveAnimation = false;
   let dragging = false;
   let dragStartX = 0;
   let dragStartY = 0;
@@ -1307,8 +1308,94 @@ function createImageUploadField(field, config) {
       `translate(${imageX}px, ${imageY}px) scale(${imageScale})`;
   }
 
+  function storedPayload(value) {
+    const raw = String(value || "");
+    return raw.startsWith("data:") ? raw.slice(raw.indexOf(",") + 1) : raw;
+  }
+
+  // Canvas drawImage + toDataURL flattens animated GIF/WebP to a single PNG frame.
+  function shouldPreserveAnimation(value) {
+    const raw = String(value || "");
+    const payload = storedPayload(raw);
+    if (raw.includes("image/gif") || payload.startsWith("R0lGOD")) {
+      return true;
+    }
+    if (raw.includes("image/webp") || payload.startsWith("UklGR")) {
+      try {
+        return atob(payload.slice(0, 256)).includes("ANIM");
+      } catch (e) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  function showCropEditor() {
+    cropArea.style.display = "block";
+    zoomLabel.style.display = preserveAnimation ? "none" : "block";
+    zoomInput.style.display = preserveAnimation ? "none" : "block";
+    cropArea.style.cursor = preserveAnimation ? "default" : "grab";
+  }
+
+  function fitImageToCropArea() {
+    const areaWidth = cropArea.clientWidth;
+    const areaHeight = cropArea.clientHeight;
+    if (!areaWidth || !areaHeight || !cropImage.naturalWidth) {
+      return false;
+    }
+
+    const initialScale = Math.max(
+      areaWidth / cropImage.naturalWidth,
+      areaHeight / cropImage.naturalHeight
+    );
+
+    minScale = initialScale;
+    maxScale = Math.max(initialScale * 5, 5);
+    imageScale = minScale;
+    zoomInput.value = "0";
+
+    imageX = (areaWidth - cropImage.naturalWidth * imageScale) / 2;
+    imageY = (areaHeight - cropImage.naturalHeight * imageScale) / 2;
+
+    updateImagePosition();
+    return true;
+  }
+
+  function whenCropAreaSized(callback) {
+    if (cropArea.clientWidth && cropArea.clientHeight) {
+      callback();
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      if (!cropArea.clientWidth || !cropArea.clientHeight) return;
+      observer.disconnect();
+      callback();
+    });
+    observer.observe(cropArea);
+  }
+
+  function loadImageIntoCropper(src, recrop) {
+    preserveAnimation = shouldPreserveAnimation(src);
+    if (recrop && preserveAnimation) {
+      const base64Data = storedPayload(src);
+      hiddenInput.value = base64Data;
+      config[field.id] = base64Data;
+      updateConfigAndPreview();
+    }
+    cropImage.onload = () => {
+      showCropEditor();
+      whenCropAreaSized(() => {
+        fitImageToCropArea();
+        if (recrop && !preserveAnimation) {
+          saveCrop();
+        }
+      });
+    };
+    cropImage.src = src;
+  }
+
   function saveCrop() {
-    if (!cropImage.src) return;
+    if (preserveAnimation || !cropImage.src) return;
 
     const canvas = document.createElement("canvas");
     canvas.width = 64;
@@ -1336,47 +1423,6 @@ function createImageUploadField(field, config) {
     updateConfigAndPreview();
   }
 
-  function initializeImage(source, preserveExisting) {
-    cropImage.onload = () => {
-      cropArea.style.display = "block";
-      zoomLabel.style.display = "block";
-      zoomInput.style.display = "block";
-
-      const areaWidth = cropArea.clientWidth;
-      const areaHeight = cropArea.clientHeight;
-
-      const initialScale = Math.max(
-        areaWidth / cropImage.naturalWidth,
-        areaHeight / cropImage.naturalHeight
-      );
-
-      minScale = initialScale;
-      maxScale = Math.max(initialScale * 5, 5);
-      imageScale = minScale;
-      zoomInput.value = "0";
-
-      imageX =
-        (areaWidth - cropImage.naturalWidth * imageScale) / 2;
-      imageY =
-        (areaHeight - cropImage.naturalHeight * imageScale) / 2;
-
-      updateImagePosition();
-
-      if (!preserveExisting) {
-        saveCrop();
-      }
-    };
-
-    cropImage.src = source;
-  }
-
-  if (config[field.id]) {
-    initializeImage(
-      `data:image/png;base64,${config[field.id]}`,
-      true
-    );
-  }
-
   let selectionGeneration = 0;
 
   uploadInput.addEventListener("change", event => {
@@ -1388,13 +1434,14 @@ function createImageUploadField(field, config) {
 
     reader.onload = e => {
       if (generation !== selectionGeneration) return;
-      initializeImage(e.target.result, false);
+      loadImageIntoCropper(e.target.result, true);
     };
 
     reader.readAsDataURL(file);
   });
 
   zoomInput.addEventListener("input", () => {
+    if (preserveAnimation) return;
     const oldScale = imageScale;
     const newScale = scaleFromZoomSlider();
 
@@ -1428,6 +1475,7 @@ function createImageUploadField(field, config) {
   }
 
   cropArea.addEventListener("pointerdown", event => {
+    if (preserveAnimation) return;
     dragging = true;
     dragStartX = event.clientX;
     dragStartY = event.clientY;
@@ -1454,6 +1502,22 @@ function createImageUploadField(field, config) {
   cropArea.addEventListener("pointercancel", event => {
     stopDragging(event);
   });
+
+  const existing = config[field.id];
+  if (existing) {
+    const raw = String(existing);
+    let dataUrl = raw;
+    if (!raw.startsWith("data:")) {
+      let mime = "image/png";
+      if (raw.startsWith("/9j/")) mime = "image/jpeg";
+      else if (raw.startsWith("R0lGOD")) mime = "image/gif";
+      else if (raw.startsWith("UklGR")) mime = "image/webp";
+      dataUrl = `data:${mime};base64,${raw}`;
+    }
+    // Wait until the field has been inserted into the form so the crop
+    // area has a layout size before we fit the restored image.
+    queueMicrotask(() => loadImageIntoCropper(dataUrl, false));
+  }
 
   return container;
 }


### PR DESCRIPTION
Adds crop, pan, and zoom controls to PhotoSelect image uploads.

Images can be positioned and zoomed before being saved, allowing users to choose the desired 64×32 display area while preserving the existing image upload functionality.  Now accepts images of any file size and shrinks the file to a usable size for the Tronbyt.

This applies generally to all apps that use PhotoSelect fields, including apps with multiple image fields such as Shuffle Images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive 2:1 image cropping with zoom, dragging, and live preview.
  - Added support for restoring and editing PNG, JPEG, GIF, and WebP image data.
  - Animated GIF and WebP uploads are preserved without cropping or interaction controls.

- **Improvements**
  - Zoom levels now provide more precise image scaling.
  - Crop initialization is more reliable across different image sizes and upload formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->