### PR TITLE
Show Disabled and Inactive labels on app preview overlays

### DIFF
--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -995,6 +995,9 @@
   "Disabled": {
     "other": "Deaktiviert"
   },
+  "Inactive": {
+    "other": "Inaktiv"
+  },
   "App:": {
     "other": "App:"
   },

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -995,6 +995,9 @@
   "Disabled": {
     "other": "Disabled"
   },
+  "Inactive": {
+    "other": "Inactive"
+  },
   "App:": {
     "other": "App:"
   },

--- a/web/static/css/manager.css
+++ b/web/static/css/manager.css
@@ -359,8 +359,10 @@ button.action.w3-button.w3-red {
   width: 256px;
   height: 128px;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 8px;
   background-color: rgba(0, 0, 0, 0.6);
   border-radius: 4px;
 }
@@ -416,6 +418,9 @@ button.action.w3-button.w3-red {
 
 .app-status {
   flex-shrink: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .status-badge {

--- a/web/templates/partials/app_card.html
+++ b/web/templates/partials/app_card.html
@@ -21,9 +21,13 @@
                  alt="{{ t .Localizer "Preview" }}"
                  width="128"
                  height="64">
-            {{ if .App.EmptyLastRender }}
+            {{ if or (not .App.Enabled) .App.EmptyLastRender }}
             <div class="inactive-overlay">
-                <span class="inactive-badge-overlay"><i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i> {{ t .Localizer "INACTIVE" }}</span>
+                {{ if not .App.Enabled }}
+                <span class="inactive-badge-overlay"><i class="fa-solid fa-pause" aria-hidden="true"></i> {{ t .Localizer "Disabled" }}</span>
+                {{ else if .App.EmptyLastRender }}
+                <span class="inactive-badge-overlay"><i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i> {{ t .Localizer "Inactive" }}</span>
+                {{ end }}
             </div>
             {{ end }}
         </div>


### PR DESCRIPTION
Make disabled and inactive apps easier to spot on the index page by overlaying clear labels on the preview image, with Disabled taking priority over Inactive when both would apply.

Fixes #897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App cards now clearly distinguish disabled apps from enabled apps with no recent output.
  * Added localized “Inactive” status text in English and German.

* **Style**
  * Improved inactive status overlays with clearer icons, vertical spacing, and responsive text wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->