### PR TITLE
Add Gen2 disable touch button setting to device edit page

### DIFF
--- a/API.md
+++ b/API.md
@@ -126,6 +126,7 @@ Update low-level firmware settings. All fields are optional.
   "preferIPv6": false,
   "apMode": false,
   "swapColors": false,
+  "disableTouch": false,
   "wifiPowerSave": 0,
   "imageUrl": "http://example.com/image.webp",
   "hostname": "tronbyt.local",

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -449,6 +449,7 @@ type DeviceInfo struct {
 	APMode             *bool        `json:"ap_mode"`
 	PreferIPv6         *bool        `json:"prefer_ipv6"`
 	SwapColors         *bool        `json:"swap_colors"`
+	DisableTouch       *bool        `json:"disable_touch"`
 	ImageURL           *string      `json:"image_url"`
 	Hostname           *string      `json:"hostname"`
 	SNTPServer         *string      `json:"sntp_server"`

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -96,6 +96,7 @@ type DeviceInfo struct {
 	APMode             *bool   `json:"apMode,omitempty"`
 	PreferIPv6         *bool   `json:"preferIPv6,omitempty"`
 	SwapColors         *bool   `json:"swapColors,omitempty"`
+	DisableTouch       *bool   `json:"disableTouch,omitempty"`
 	ImageURL           *string `json:"imageUrl,omitempty"`
 	Hostname           *string `json:"hostname,omitempty"`
 	SNTPServer         *string `json:"sntpServer,omitempty"`
@@ -118,6 +119,7 @@ func (s *Server) toDevicePayload(d *data.Device) DevicePayload {
 		APMode:             d.Info.APMode,
 		PreferIPv6:         d.Info.PreferIPv6,
 		SwapColors:         d.Info.SwapColors,
+		DisableTouch:       d.Info.DisableTouch,
 		ImageURL:           d.Info.ImageURL,
 		Hostname:           d.Info.Hostname,
 		SNTPServer:         d.Info.SNTPServer,
@@ -1119,6 +1121,7 @@ type FirmwareSettingsUpdate struct {
 	PreferIPv6         *bool   `json:"preferIPv6"`
 	APMode             *bool   `json:"apMode"`
 	SwapColors         *bool   `json:"swapColors"`
+	DisableTouch       *bool   `json:"disableTouch"`
 	WifiPowerSave      *int    `json:"wifiPowerSave"`
 	ImageURL           *string `json:"imageUrl"`
 	Hostname           *string `json:"hostname"`
@@ -1151,6 +1154,9 @@ func (s *Server) handleUpdateFirmwareSettingsAPI(w http.ResponseWriter, r *http.
 	}
 	if update.SwapColors != nil {
 		payload["swap_colors"] = *update.SwapColors
+	}
+	if update.DisableTouch != nil {
+		payload["disable_touch"] = *update.DisableTouch
 	}
 	if update.WifiPowerSave != nil {
 		payload["wifi_power_save"] = *update.WifiPowerSave

--- a/internal/server/handlers_device.go
+++ b/internal/server/handlers_device.go
@@ -1142,7 +1142,7 @@ func (s *Server) handleUpdateFirmwareSettings(w http.ResponseWriter, r *http.Req
 	payload := make(map[string]any)
 
 	// Boolean fields
-	boolFields := []string{"skip_display_version", "skip_boot_animation", "prefer_ipv6", "ap_mode", "swap_colors"}
+	boolFields := []string{"skip_display_version", "skip_boot_animation", "prefer_ipv6", "ap_mode", "swap_colors", "disable_touch"}
 	for _, field := range boolFields {
 		if val := r.FormValue(field); val != "" {
 			payload[field] = val == "true"

--- a/internal/server/websockets.go
+++ b/internal/server/websockets.go
@@ -40,6 +40,7 @@ type ClientInfo struct {
 	APMode             *bool   `json:"ap_mode"`
 	PreferIPv6         *bool   `json:"prefer_ipv6"`
 	SwapColors         *bool   `json:"swap_colors"`
+	DisableTouch       *bool   `json:"disable_touch"`
 	ImageURL           *string `json:"image_url"`
 	Hostname           *string `json:"hostname"`
 	SNTPServer         *string `json:"sntp_server"`
@@ -158,6 +159,9 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 				}
 				if msg.ClientInfo.SwapColors != nil {
 					device.Info.SwapColors = msg.ClientInfo.SwapColors
+				}
+				if msg.ClientInfo.DisableTouch != nil {
+					device.Info.DisableTouch = msg.ClientInfo.DisableTouch
 				}
 				if msg.ClientInfo.ImageURL != nil {
 					device.Info.ImageURL = msg.ClientInfo.ImageURL

--- a/web/i18n/de.json
+++ b/web/i18n/de.json
@@ -2111,6 +2111,12 @@
   "Skip Boot Animation": {
     "other": "Boot-Animation überspringen"
   },
+  "Disable Touch Button": {
+    "other": "Touch-Taste deaktivieren"
+  },
+  "Disables the physical touch button. Requires reboot to take effect.": {
+    "other": "Deaktiviert die physische Touch-Taste. Neustart erforderlich, damit die Änderung wirksam wird."
+  },
   "Leave blank to auto-generate": {
     "other": "Leer lassen zum automatischen Generieren"
   },

--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -2114,6 +2114,12 @@
   "Skip Boot Animation": {
     "other": "Skip Boot Animation"
   },
+  "Disable Touch Button": {
+    "other": "Disable Touch Button"
+  },
+  "Disables the physical touch button. Requires reboot to take effect.": {
+    "other": "Disables the physical touch button. Requires reboot to take effect."
+  },
   "Leave blank to auto-generate": {
     "other": "Leave blank to auto-generate"
   },

--- a/web/templates/manager/update.html
+++ b/web/templates/manager/update.html
@@ -699,6 +699,19 @@
                                    onchange="updateFirmwareSettings({swap_colors: this.checked})">
                         </div>
                     </div>
+                    {{ if eq .Device.Type.Slug "tidbyt_gen2" }}
+                    <div class="settings-field-row">
+                        <div class="settings-field-label">{{ t .Localizer "Disable Touch Button" }}</div>
+                        <div class="settings-field-control">
+                            <input type="checkbox"
+                                   {{ if derefOr .Device.Info.DisableTouch false }}
+                                   checked
+                                   {{ end }}
+                                   onchange="updateFirmwareSettings({disable_touch: this.checked})">
+                            <p class="settings-help">{{ t .Localizer "Disables the physical touch button. Requires reboot to take effect." }}</p>
+                        </div>
+                    </div>
+                    {{ end }}
                     <div class="settings-field-row">
                         <div class="settings-field-label">{{ t .Localizer "WiFi Power Save" }}</div>
                         <div class="settings-field-control">

--- a/web/templates/manager/update.html
+++ b/web/templates/manager/update.html
@@ -701,9 +701,12 @@
                     </div>
                     {{ if eq .Device.Type.Slug "tidbyt_gen2" }}
                     <div class="settings-field-row">
-                        <div class="settings-field-label">{{ t .Localizer "Disable Touch Button" }}</div>
+                        <div class="settings-field-label">
+                            <label for="disable_touch">{{ t .Localizer "Disable Touch Button" }}</label>
+                        </div>
                         <div class="settings-field-control">
                             <input type="checkbox"
+                                   id="disable_touch"
                                    {{ if derefOr .Device.Info.DisableTouch false }}
                                    checked
                                    {{ end }}


### PR DESCRIPTION
Expose the firmware disable_touch setting in the UI, API, and WebSocket device info so Tidbyt Gen2 users can disable the physical button without using the WiFi config portal.

Fixes #892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to disable the physical touch button on supported Gen 2 devices.
  * The setting is available in firmware settings, reflects the current device state, and takes effect after a reboot.
  * Added API support for reading and updating the touch-button setting.

* **Documentation**
  * Documented the new `disableTouch` firmware setting, including its default value.

* **Localization**
  * Added English and German translations for the new setting and reboot notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->