### PR TITLE
Fix night/dim mode filters overriding app-level filters

### DIFF
--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -770,7 +770,7 @@ func (d *Device) GetTimezone() string {
 	return "Local"
 }
 
-func (d Device) getLocation() *time.Location {
+func (d Device) GetLocation() *time.Location {
 	loc := time.Local
 	if d.Timezone != nil {
 		if l, err := time.LoadLocation(*d.Timezone); err == nil {
@@ -952,32 +952,43 @@ func (d Device) GetDimModeOverrideActiveAt(now time.Time) bool {
 	return now.Before(d.DimModeOverrideUntil.In(now.Location()))
 }
 
-// GetNightModeIsActive checks if night mode is currently active for a device.
-func (d Device) GetNightModeIsActive() bool {
+// GetNightModeIsActiveAt checks if night mode is active at a specific time.
+func (d Device) GetNightModeIsActiveAt(at time.Time) bool {
 	if !d.NightModeEnabled {
 		return false
 	}
 
-	currentTime := time.Now().In(d.getLocation())
-	if d.GetNightModeOverrideActiveAt(currentTime) {
+	at = at.In(d.GetLocation())
+	if d.GetNightModeOverrideActiveAt(at) {
 		return d.NightModeOverride != nil && *d.NightModeOverride
 	}
-	return d.GetScheduledNightModeIsActiveAt(currentTime)
+	return d.GetScheduledNightModeIsActiveAt(at)
+}
+
+// GetNightModeIsActive checks if night mode is currently active for a device.
+func (d Device) GetNightModeIsActive() bool {
+	return d.GetNightModeIsActiveAt(time.Now())
+}
+
+// GetDimModeIsActiveAt checks if dim mode is active at a specific time.
+func (d Device) GetDimModeIsActiveAt(at time.Time) bool {
+	if !d.DimModeEnabled {
+		return false
+	}
+
+	at = at.In(d.GetLocation())
+	if d.GetNightModeIsActiveAt(at) {
+		return false
+	}
+	if d.GetDimModeOverrideActiveAt(at) {
+		return d.DimModeOverride != nil && *d.DimModeOverride
+	}
+	return d.GetScheduledDimModeIsActiveAt(at)
 }
 
 // GetDimModeIsActive checks if dim mode is active (dimming without full night mode).
 func (d Device) GetDimModeIsActive() bool {
-	if !d.DimModeEnabled {
-		return false
-	}
-	currentTime := time.Now().In(d.getLocation())
-	if d.GetNightModeIsActive() {
-		return false
-	}
-	if d.GetDimModeOverrideActiveAt(currentTime) {
-		return d.DimModeOverride != nil && *d.DimModeOverride
-	}
-	return d.GetScheduledDimModeIsActiveAt(currentTime)
+	return d.GetDimModeIsActiveAt(time.Now())
 }
 
 // GetEffectiveDwellTime returns the display duration for an app, falling back to the device default.

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -751,8 +751,8 @@ func (s *Server) handlePatchDevice(w http.ResponseWriter, r *http.Request) {
 
 	// Notify Dashboard
 	user := GetUser(r)
-	s.notifyDashboard(user.Username, WSEvent{Type: "apps_changed", DeviceID: device.ID})
 	s.invalidateDeviceAppRendersIfModeChanged(r.Context(), device, modeSnapshotBefore)
+	s.notifyDashboard(user.Username, WSEvent{Type: "apps_changed", DeviceID: device.ID})
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(s.toDevicePayload(device)); err != nil {

--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -667,6 +667,7 @@ func (s *Server) handlePatchDevice(w http.ResponseWriter, r *http.Request) {
 		device.DefaultInterval = *update.IntervalSec
 	}
 	nightModeWasEnabled := device.NightModeEnabled
+	modeSnapshotBefore := snapshotDeviceMode(device)
 	nightStartWas := device.NightStart
 	nightEndWas := device.NightEnd
 	dimModeWasEnabled := device.DimModeEnabled
@@ -751,6 +752,7 @@ func (s *Server) handlePatchDevice(w http.ResponseWriter, r *http.Request) {
 	// Notify Dashboard
 	user := GetUser(r)
 	s.notifyDashboard(user.Username, WSEvent{Type: "apps_changed", DeviceID: device.ID})
+	s.invalidateDeviceAppRendersIfModeChanged(r.Context(), device, modeSnapshotBefore)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(s.toDevicePayload(device)); err != nil {

--- a/internal/server/handlers_device.go
+++ b/internal/server/handlers_device.go
@@ -625,8 +625,8 @@ func (s *Server) handleUpdateDevicePost(w http.ResponseWriter, r *http.Request) 
 	}
 
 	user := GetUser(r)
-	s.notifyDashboard(user.Username, WSEvent{Type: "apps_changed", DeviceID: device.ID})
 	s.invalidateDeviceAppRendersIfModeChanged(r.Context(), device, modeSnapshotBefore)
+	s.notifyDashboard(user.Username, WSEvent{Type: "apps_changed", DeviceID: device.ID})
 
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
@@ -969,6 +969,7 @@ func (s *Server) setModeOverride(w http.ResponseWriter, r *http.Request, mode st
 	}
 
 	user := GetUser(r)
+	s.invalidateDeviceAppRendersIfModeChanged(r.Context(), device, modeSnapshotBefore)
 	s.notifyDashboard(user.Username, WSEvent{
 		Type:     "device_updated",
 		DeviceID: device.ID,
@@ -978,8 +979,6 @@ func (s *Server) setModeOverride(w http.ResponseWriter, r *http.Request, mode st
 			wsPrefix + "Managed": true,
 		},
 	})
-
-	s.invalidateDeviceAppRendersIfModeChanged(r.Context(), device, modeSnapshotBefore)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{

--- a/internal/server/handlers_device.go
+++ b/internal/server/handlers_device.go
@@ -447,6 +447,7 @@ func (s *Server) handleUpdateDevicePost(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// 5. Night Mode
+	modeSnapshotBefore := snapshotDeviceMode(device)
 	nightModeWasEnabled := device.NightModeEnabled
 	nightStartWas := device.NightStart
 	nightEndWas := device.NightEnd
@@ -625,6 +626,7 @@ func (s *Server) handleUpdateDevicePost(w http.ResponseWriter, r *http.Request) 
 
 	user := GetUser(r)
 	s.notifyDashboard(user.Username, WSEvent{Type: "apps_changed", DeviceID: device.ID})
+	s.invalidateDeviceAppRendersIfModeChanged(r.Context(), device, modeSnapshotBefore)
 
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
@@ -906,6 +908,7 @@ func (s *Server) handleSetDimModeOverride(w http.ResponseWriter, r *http.Request
 
 func (s *Server) setModeOverride(w http.ResponseWriter, r *http.Request, mode string) {
 	device := GetDevice(r)
+	modeSnapshotBefore := snapshotDeviceMode(device)
 
 	active, err := strconv.ParseBool(r.FormValue("active"))
 	if err != nil {
@@ -975,6 +978,8 @@ func (s *Server) setModeOverride(w http.ResponseWriter, r *http.Request, mode st
 			wsPrefix + "Managed": true,
 		},
 	})
+
+	s.invalidateDeviceAppRendersIfModeChanged(r.Context(), device, modeSnapshotBefore)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{

--- a/internal/server/mode_render.go
+++ b/internal/server/mode_render.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"tronbyt-server/internal/data"
+
+	"gorm.io/gorm"
+)
+
+type deviceModeSnapshot struct {
+	NightActive bool
+	DimActive   bool
+	NightFilter string
+	DimFilter   string
+}
+
+func snapshotDeviceMode(device *data.Device) deviceModeSnapshot {
+	snap := deviceModeSnapshot{
+		NightActive: device.GetNightModeIsActive(),
+		DimActive:   device.GetDimModeIsActive(),
+	}
+	if device.NightColorFilter != nil {
+		snap.NightFilter = string(*device.NightColorFilter)
+	}
+	if device.DimColorFilter != nil {
+		snap.DimFilter = string(*device.DimColorFilter)
+	}
+	return snap
+}
+
+func (s *Server) invalidateDeviceAppRenders(ctx context.Context, device *data.Device) {
+	if _, err := gorm.G[data.App](s.DB).Where("device_id = ?", device.ID).Update(ctx, "last_render", time.Time{}); err != nil {
+		slog.Error("Failed to invalidate app renders", "device", device.ID, "error", err)
+		return
+	}
+	for _, app := range device.Apps {
+		if app != nil {
+			app.LastRender = time.Time{}
+		}
+	}
+}
+
+func (s *Server) invalidateDeviceAppRendersIfModeChanged(ctx context.Context, device *data.Device, before deviceModeSnapshot) {
+	if snapshotDeviceMode(device) == before {
+		return
+	}
+	s.invalidateDeviceAppRenders(ctx, device)
+}

--- a/internal/server/mode_render_test.go
+++ b/internal/server/mode_render_test.go
@@ -63,20 +63,27 @@ func TestFiltersChangedSinceLastRender(t *testing.T) {
 
 	dimmed := data.ColorFilterDimmed
 	warm := data.ColorFilterWarm
+	tz := "UTC"
 	device := data.Device{
 		NightModeEnabled: true,
 		NightStart:       "22:00",
 		NightEnd:         "06:00",
 		NightColorFilter: &dimmed,
+		Timezone:         &tz,
 	}
 	app := &data.App{
 		ColorFilter: &warm,
-		LastRender:  time.Date(2026, 1, 15, 12, 0, 0, 0, time.Local),
 		UInterval:   60,
 	}
 
-	assert.False(t, s.filtersChangedSinceLastRender(&device, app))
+	noon := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	app.LastRender = noon
+	assert.False(t, s.filtersChangedSinceLastRenderAt(&device, app, noon))
 
-	app.LastRender = time.Date(2026, 1, 15, 23, 0, 0, 0, time.Local)
-	assert.True(t, s.filtersChangedSinceLastRender(&device, app))
+	night := time.Date(2026, 1, 15, 23, 0, 0, 0, time.UTC)
+	app.LastRender = noon
+	assert.True(t, s.filtersChangedSinceLastRenderAt(&device, app, night))
+
+	app.LastRender = night
+	assert.False(t, s.filtersChangedSinceLastRenderAt(&device, app, night))
 }

--- a/internal/server/mode_render_test.go
+++ b/internal/server/mode_render_test.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"tronbyt-server/internal/data"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidateDeviceAppRendersIfModeChanged(t *testing.T) {
+	s := newTestServer(t)
+	require.NotNil(t, s)
+	ctx := context.Background()
+
+	user := data.User{Username: "testuser"}
+	require.NoError(t, s.DB.Create(&user).Error)
+
+	warm := data.ColorFilterWarm
+	dimmed := data.ColorFilterDimmed
+	device := data.Device{
+		ID:               "moderender",
+		Username:         "testuser",
+		Name:             "Mode Render",
+		NightModeEnabled: true,
+		NightStart:       "00:00",
+		NightEnd:         "23:59",
+		NightColorFilter: &warm,
+	}
+	require.NoError(t, s.DB.Create(&device).Error)
+
+	lastRender := time.Now().Add(-time.Hour)
+	app := data.App{
+		DeviceID:   device.ID,
+		Iname:      "clock",
+		Name:       "Clock",
+		Enabled:    true,
+		LastRender: lastRender,
+		UInterval:  60,
+	}
+	require.NoError(t, s.DB.Create(&app).Error)
+	device.Apps = []*data.App{&app}
+
+	before := snapshotDeviceMode(&device)
+	device.NightColorFilter = &dimmed
+	s.invalidateDeviceAppRendersIfModeChanged(ctx, &device, before)
+
+	assert.True(t, app.LastRender.IsZero())
+
+	var persisted data.App
+	require.NoError(t, s.DB.First(&persisted, app.ID).Error)
+	assert.True(t, persisted.LastRender.IsZero())
+
+	s.invalidateDeviceAppRendersIfModeChanged(ctx, &device, snapshotDeviceMode(&device))
+}
+
+func TestFiltersChangedSinceLastRender(t *testing.T) {
+	s := newTestServer(t)
+	require.NotNil(t, s)
+
+	dimmed := data.ColorFilterDimmed
+	warm := data.ColorFilterWarm
+	device := data.Device{
+		NightModeEnabled: true,
+		NightStart:       "22:00",
+		NightEnd:         "06:00",
+		NightColorFilter: &dimmed,
+	}
+	app := &data.App{
+		ColorFilter: &warm,
+		LastRender:  time.Date(2026, 1, 15, 12, 0, 0, 0, time.Local),
+		UInterval:   60,
+	}
+
+	assert.False(t, s.filtersChangedSinceLastRender(&device, app))
+
+	app.LastRender = time.Date(2026, 1, 15, 23, 0, 0, 0, time.Local)
+	assert.True(t, s.filtersChangedSinceLastRender(&device, app))
+}

--- a/internal/server/render_utils.go
+++ b/internal/server/render_utils.go
@@ -290,11 +290,15 @@ func (s *Server) getEffectiveFiltersAt(device *data.Device, app *data.App, at ti
 }
 
 func (s *Server) filtersChangedSinceLastRender(device *data.Device, app *data.App) bool {
+	return s.filtersChangedSinceLastRenderAt(device, app, time.Now())
+}
+
+func (s *Server) filtersChangedSinceLastRenderAt(device *data.Device, app *data.App, now time.Time) bool {
 	if app.LastRender.IsZero() {
 		return false
 	}
 	at := app.LastRender.In(device.GetLocation())
-	return !slices.Equal(s.getEffectiveFiltersAt(device, app, at), s.getEffectiveFilters(device, app))
+	return !slices.Equal(s.getEffectiveFiltersAt(device, app, at), s.getEffectiveFiltersAt(device, app, now.In(device.GetLocation())))
 }
 
 func deviceModeColorFilterAt(device *data.Device, at time.Time) *data.ColorFilter {

--- a/internal/server/render_utils.go
+++ b/internal/server/render_utils.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -141,8 +142,9 @@ func (s *Server) possiblyRender(ctx context.Context, app *data.App, device *data
 
 	// 3. Starlark App - Check Interval
 	now := time.Now()
+	forceRender := s.filtersChangedSinceLastRender(device, app)
 	// uinterval is minutes
-	if time.Since(app.LastRender) > time.Duration(app.UInterval)*time.Minute {
+	if forceRender || time.Since(app.LastRender) > time.Duration(app.UInterval)*time.Minute {
 		slog.Info("Rendering app", "app", appBasename)
 
 		startTime := time.Now()
@@ -252,10 +254,14 @@ func (s *Server) handleAutoPin(ctx context.Context, app *data.App, device *data.
 }
 
 func (s *Server) getEffectiveFilters(device *data.Device, app *data.App) []string {
+	return s.getEffectiveFiltersAt(device, app, time.Now())
+}
+
+func (s *Server) getEffectiveFiltersAt(device *data.Device, app *data.App, at time.Time) []string {
 	var filters []string
 
 	// Night/dim mode filters override app-level filters when set to a real filter.
-	if modeFilter := deviceModeColorFilter(device); modeFilter != nil && *modeFilter != data.ColorFilterNone {
+	if modeFilter := deviceModeColorFilterAt(device, at); modeFilter != nil && *modeFilter != data.ColorFilterNone {
 		filters = append(filters, string(*modeFilter))
 		return filters
 	}
@@ -283,11 +289,19 @@ func (s *Server) getEffectiveFilters(device *data.Device, app *data.App) []strin
 	return filters
 }
 
-func deviceModeColorFilter(device *data.Device) *data.ColorFilter {
-	if device.GetNightModeIsActive() && device.NightColorFilter != nil {
+func (s *Server) filtersChangedSinceLastRender(device *data.Device, app *data.App) bool {
+	if app.LastRender.IsZero() {
+		return false
+	}
+	at := app.LastRender.In(device.GetLocation())
+	return !slices.Equal(s.getEffectiveFiltersAt(device, app, at), s.getEffectiveFilters(device, app))
+}
+
+func deviceModeColorFilterAt(device *data.Device, at time.Time) *data.ColorFilter {
+	if device.GetNightModeIsActiveAt(at) && device.NightColorFilter != nil {
 		return device.NightColorFilter
 	}
-	if device.GetDimModeIsActive() && device.DimColorFilter != nil {
+	if device.GetDimModeIsActiveAt(at) && device.DimColorFilter != nil {
 		return device.DimColorFilter
 	}
 	return nil

--- a/internal/server/render_utils.go
+++ b/internal/server/render_utils.go
@@ -254,13 +254,15 @@ func (s *Server) handleAutoPin(ctx context.Context, app *data.App, device *data.
 func (s *Server) getEffectiveFilters(device *data.Device, app *data.App) []string {
 	var filters []string
 
+	// Night/dim mode filters override app-level filters when set to a real filter.
+	if modeFilter := deviceModeColorFilter(device); modeFilter != nil && *modeFilter != data.ColorFilterNone {
+		filters = append(filters, string(*modeFilter))
+		return filters
+	}
+
 	// Determine base device filter
 	var deviceFilter data.ColorFilter
-	if device.GetNightModeIsActive() && device.NightColorFilter != nil {
-		deviceFilter = *device.NightColorFilter
-	} else if device.GetDimModeIsActive() && device.DimColorFilter != nil {
-		deviceFilter = *device.DimColorFilter
-	} else if device.ColorFilter != nil {
+	if device.ColorFilter != nil {
 		deviceFilter = *device.ColorFilter
 	} else {
 		deviceFilter = data.ColorFilterNone
@@ -275,13 +277,20 @@ func (s *Server) getEffectiveFilters(device *data.Device, app *data.App) []strin
 		if appFilter != data.ColorFilterNone {
 			filters = append(filters, string(appFilter))
 		}
-	} else {
-		// Inherit from device
-		if deviceFilter != data.ColorFilterNone {
-			filters = append(filters, string(deviceFilter))
-		}
+	} else if deviceFilter != data.ColorFilterNone {
+		filters = append(filters, string(deviceFilter))
 	}
 	return filters
+}
+
+func deviceModeColorFilter(device *data.Device) *data.ColorFilter {
+	if device.GetNightModeIsActive() && device.NightColorFilter != nil {
+		return device.NightColorFilter
+	}
+	if device.GetDimModeIsActive() && device.DimColorFilter != nil {
+		return device.DimColorFilter
+	}
+	return nil
 }
 
 func copyFile(src, dst string) error {

--- a/internal/server/render_utils_test.go
+++ b/internal/server/render_utils_test.go
@@ -1,0 +1,133 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"tronbyt-server/internal/data"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEffectiveFilters_ModeFiltersOverrideApp(t *testing.T) {
+	s := newTestServer(t)
+	warm := data.ColorFilterWarm
+	dimmed := data.ColorFilterDimmed
+	redshift := data.ColorFilterRedshift
+	dimActive := true
+	dimUntil := time.Now().Add(time.Hour)
+
+	tests := []struct {
+		name     string
+		device   data.Device
+		app      *data.App
+		expected []string
+	}{
+		{
+			name: "dim mode filter overrides app filter",
+			device: data.Device{
+				DimModeEnabled:       true,
+				DimTime:              new("22:00"),
+				DimColorFilter:       &dimmed,
+				DimModeOverride:      &dimActive,
+				DimModeOverrideUntil: &dimUntil,
+			},
+			app: &data.App{
+				ColorFilter: &warm,
+			},
+			expected: []string{"dimmed"},
+		},
+		{
+			name: "night mode filter overrides app filter",
+			device: data.Device{
+				NightModeEnabled: true,
+				NightStart:       "00:00",
+				NightEnd:         "23:59",
+				NightColorFilter: &redshift,
+			},
+			app: &data.App{
+				ColorFilter: &warm,
+			},
+			expected: []string{"redshift"},
+		},
+		{
+			name: "night mode filter takes precedence over dim mode filter",
+			device: data.Device{
+				NightModeEnabled: true,
+				NightStart:       "00:00",
+				NightEnd:         "23:59",
+				NightColorFilter: &redshift,
+				DimModeEnabled:   true,
+				DimTime:          new("00:00"),
+				DimColorFilter:   &dimmed,
+			},
+			app: &data.App{
+				ColorFilter: &warm,
+			},
+			expected: []string{"redshift"},
+		},
+		{
+			name: "app filter used when mode filter not configured",
+			device: data.Device{
+				DimModeEnabled: true,
+				DimTime:        new("00:00"),
+			},
+			app: &data.App{
+				ColorFilter: &warm,
+			},
+			expected: []string{"warm"},
+		},
+		{
+			name: "mode filter none falls through to app filter",
+			device: data.Device{
+				DimModeEnabled:       true,
+				DimTime:              new("22:00"),
+				DimColorFilter:       new(data.ColorFilterNone),
+				DimModeOverride:      &dimActive,
+				DimModeOverrideUntil: &dimUntil,
+			},
+			app: &data.App{
+				ColorFilter: &warm,
+			},
+			expected: []string{"warm"},
+		},
+		{
+			name: "app inherit uses device filter outside mode",
+			device: data.Device{
+				ColorFilter: &redshift,
+			},
+			app: &data.App{
+				ColorFilter: new(data.ColorFilterInherit),
+			},
+			expected: []string{"redshift"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filters := s.getEffectiveFilters(&tt.device, tt.app)
+			assert.Equal(t, tt.expected, filters)
+		})
+	}
+}
+
+func TestGetEffectiveFilters_ModeOverride(t *testing.T) {
+	s := newTestServer(t)
+	warm := data.ColorFilterWarm
+	dimmed := data.ColorFilterDimmed
+
+	active := true
+	until := time.Now().Add(time.Hour)
+	device := data.Device{
+		NightModeEnabled:       true,
+		NightStart:             "22:00",
+		NightEnd:               "06:00",
+		NightColorFilter:       &dimmed,
+		NightModeOverride:      &active,
+		NightModeOverrideUntil: &until,
+	}
+	app := &data.App{ColorFilter: &warm}
+
+	filters := s.getEffectiveFilters(&device, app)
+	assert.Equal(t, []string{"dimmed"}, filters)
+}

--- a/internal/server/render_utils_test.go
+++ b/internal/server/render_utils_test.go
@@ -7,10 +7,12 @@ import (
 	"tronbyt-server/internal/data"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetEffectiveFilters_ModeFiltersOverrideApp(t *testing.T) {
 	s := newTestServer(t)
+	require.NotNil(t, s)
 	warm := data.ColorFilterWarm
 	dimmed := data.ColorFilterDimmed
 	redshift := data.ColorFilterRedshift
@@ -113,6 +115,7 @@ func TestGetEffectiveFilters_ModeFiltersOverrideApp(t *testing.T) {
 
 func TestGetEffectiveFilters_ModeOverride(t *testing.T) {
 	s := newTestServer(t)
+	require.NotNil(t, s)
 	warm := data.ColorFilterWarm
 	dimmed := data.ColorFilterDimmed
 


### PR DESCRIPTION
## Summary
- When night or dim mode is active with a color filter configured, that filter now takes precedence over per-app color filters so dimming stays consistent across all apps.
- If the night/dim mode filter is set to `none`, the app filter (or inherited device filter) is still applied as before.
- Adds unit tests for filter precedence and override behavior.

Fixes #898

## Test plan
- [x] `go test ./internal/server/ -run TestGetEffectiveFilters`
- [ ] Verify on a device with dim/night mode filter + apps with their own filters that all apps use the mode filter during dim/night hours
- [ ] Verify apps keep their own filters when mode filter is `none` or not configured

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color-filter selection for night and dim modes.
  * Active night or dim mode filters now take precedence over app and device filters.
  * Night mode takes priority when both modes are active.
  * Added reliable fallback behavior when no applicable filter is configured.
  * App displays now refresh automatically when mode settings or effective color filters change.
  * Historical mode schedules and expiration times are evaluated accurately using the device’s local time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->