### PR TITLE
fix: stop the broken toggle from destroying the rest of manifest.yaml

### DIFF
--- a/internal/server/handlers_app.go
+++ b/internal/server/handlers_app.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -32,10 +33,25 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// AppManifest reflects a subset of manifest.yaml for internal updates.
-type AppManifest struct {
-	Broken       *bool   `yaml:"broken,omitempty"`
-	BrokenReason *string `yaml:"brokenReason,omitempty"`
+// setManifestKey sets key on a manifest.yaml mapping, appending it when absent.
+// Editing the node tree rather than a typed struct is deliberate: a struct round
+// trip writes back only the fields it declares, so every other key in the file -
+// id, name, supports2x, tags, everything - is destroyed on save.
+func setManifestKey(mapping *yaml.Node, key string, value *yaml.Node) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content[i+1] = value
+			return
+		}
+	}
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, value)
+}
+
+// manifestScalar builds a scalar node with an explicit tag, so a reason like
+// "true" or "123" stays a string instead of being re-read as another type.
+func manifestScalar(tag, value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: tag, Value: value}
 }
 
 var packageNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
@@ -1533,37 +1549,52 @@ func (s *Server) updateAppBrokenStatus(w http.ResponseWriter, r *http.Request, b
 		return
 	}
 
-	var manifest AppManifest
 	manifestData, err := os.ReadFile(manifestPath)
 	if err != nil {
 		slog.Error("Failed to read manifest.yaml", "path", manifestPath, "error", err)
 		http.Error(w, "Failed to read manifest", http.StatusInternalServerError)
 		return
 	}
-	if err := yaml.Unmarshal(manifestData, &manifest); err != nil {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(manifestData, &doc); err != nil {
 		slog.Error("Failed to unmarshal manifest.yaml", "path", manifestPath, "error", err)
 		http.Error(w, "Failed to parse manifest", http.StatusInternalServerError)
 		return
 	}
+	mapping := &doc
+	if mapping.Kind == yaml.DocumentNode && len(mapping.Content) > 0 {
+		mapping = mapping.Content[0]
+	}
+	if mapping.Kind != yaml.MappingNode {
+		slog.Error("manifest.yaml is not a mapping", "path", manifestPath)
+		http.Error(w, "Failed to parse manifest", http.StatusInternalServerError)
+		return
+	}
 
-	manifest.Broken = &broken
+	reason := ""
 	if broken {
-		reason := r.URL.Query().Get("broken_reason")
+		reason = r.URL.Query().Get("broken_reason")
 		if reason == "" {
 			reason = "Marked broken by user"
 		}
-		manifest.BrokenReason = &reason
-	} else {
-		emptyReason := ""
-		manifest.BrokenReason = &emptyReason
 	}
+	setManifestKey(mapping, "broken", manifestScalar("!!bool", strconv.FormatBool(broken)))
+	setManifestKey(mapping, "brokenReason", manifestScalar("!!str", reason))
 
-	updatedManifestData, err := yaml.Marshal(&manifest)
-	if err != nil {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&doc); err != nil {
 		slog.Error("Failed to marshal updated manifest.yaml", "error", err)
 		http.Error(w, "Failed to update manifest", http.StatusInternalServerError)
 		return
 	}
+	if err := encoder.Close(); err != nil {
+		slog.Error("Failed to finalise updated manifest.yaml", "error", err)
+		http.Error(w, "Failed to update manifest", http.StatusInternalServerError)
+		return
+	}
+	updatedManifestData := buf.Bytes()
 
 	if err := os.WriteFile(manifestPath, updatedManifestData, 0644); err != nil {
 		slog.Error("Failed to write updated manifest.yaml", "path", manifestPath, "error", err)

--- a/internal/server/handlers_app_test.go
+++ b/internal/server/handlers_app_test.go
@@ -18,6 +18,8 @@ import (
 	"tronbyt-server/internal/data"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	"gorm.io/gorm"
 )
 
@@ -700,4 +702,75 @@ func TestMarkInstalledApps_AbsolutePaths(t *testing.T) {
 	s.markInstalledApps(device, systemApps, nil)
 
 	assert.True(t, systemApps[0].IsInstalled, "Weather should be installed (absolute to relative conversion match)")
+}
+
+// Toggling broken used to write the manifest back from a struct holding only
+// broken/brokenReason, which destroyed every other key in the file - id, name,
+// supports2x, tags, all of it. The whole point of the endpoint is a two-field
+// edit, so the rest of the file has to survive it verbatim.
+func TestUpdateAppBrokenStatusPreservesTheRestOfTheManifest(t *testing.T) {
+	s := newTestServer(t)
+
+	const original = `id: repro-demo
+name: Repro Demo
+author: bench
+recommendedInterval: 30
+supports2x: true
+tags:
+  - demo
+published: "2026-01-01"
+`
+	appDir := filepath.Join(s.DataDir, "system-apps", "apps", "repro_demo")
+	require.NoError(t, os.MkdirAll(appDir, 0o755))
+	manifestPath := filepath.Join(appDir, "manifest.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte(original), 0o644))
+
+	user := data.User{Username: "testuser"}
+	s.DB.Create(&user)
+
+	toggle := func(path string, broken bool) {
+		req, _ := http.NewRequest(http.MethodPost,
+			path+"?app_name=repro_demo&package_name=repro_demo&broken_reason=testing", nil)
+		req = req.WithContext(context.WithValue(req.Context(), userContextKey, &user))
+		rr := httptest.NewRecorder()
+		s.updateAppBrokenStatus(rr, req, broken)
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	assertSurvived := func(stage string) {
+		t.Helper()
+		var manifest map[string]any
+		raw, err := os.ReadFile(manifestPath)
+		require.NoError(t, err)
+		require.NoError(t, yaml.Unmarshal(raw, &manifest))
+		for key, want := range map[string]any{
+			"id":                  "repro-demo",
+			"name":                "Repro Demo",
+			"author":              "bench",
+			"recommendedInterval": 30,
+			"supports2x":          true,
+			"published":           "2026-01-01",
+		} {
+			assert.Equalf(t, want, manifest[key], "%s: %q was lost or altered", stage, key)
+		}
+		assert.Equalf(t, []any{"demo"}, manifest["tags"], "%s: tags were lost", stage)
+	}
+
+	toggle("/mark_app_broken", true)
+	assertSurvived("after marking broken")
+	var marked map[string]any
+	raw, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(raw, &marked))
+	assert.Equal(t, true, marked["broken"])
+	assert.Equal(t, "testing", marked["brokenReason"])
+
+	toggle("/unmark_app_broken", false)
+	assertSurvived("after unmarking broken")
+	var cleared map[string]any
+	raw, err = os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(raw, &cleared))
+	assert.Equal(t, false, cleared["broken"])
+	assert.Equal(t, "", cleared["brokenReason"])
 }


### PR DESCRIPTION
## What

Toggling an app's broken status destroyed the rest of its `manifest.yaml`.

`updateAppBrokenStatus` read the manifest into `AppManifest` — a struct with exactly two fields, `broken` and `brokenReason` — and then marshalled that struct back over the file. Every other key was silently dropped on save.

Reproduced against a live server: a manifest carrying `id, name, summary, desc, author, fileName, packageName, recommendedInterval, supports2x, category, tags, published` came back from one `POST /mark_app_broken` as two lines:

```yaml
broken: true
brokenReason: testing
```

The app then loses its name and recommended interval in the catalogue, its 2x preview (`supports2x` is gone), and its identity to the git-synced apps repo, which sees the file rewritten rather than amended.

## Fix

Edit the YAML node tree in place instead of round-tripping through a typed struct: unknown keys keep their values **and their positions**, and only `broken`/`brokenReason` are touched. `AppManifest` is deleted — naming a subset of a file that gets written back whole is what caused this.

Verified end to end: the same 13-key manifest now survives mark → unmark with every key intact and in original order, gaining only the two toggle keys.

## Test

`TestUpdateAppBrokenStatusPreservesTheRestOfTheManifest` writes a real manifest, drives both toggles through the handler, and asserts every original key survives each step. It fails against the old code with `"name" was lost or altered`.

The endpoint is dev-mode only (`PRODUCTION=false`), so default deployments never reach it — but a manifest is not something a server should be able to shred in any mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updating an app’s broken status now preserves all unrelated settings in its manifest.
  - Broken status and reason fields are correctly set or cleared when changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->