### PR TITLE
fix: resolve pushed apps by installationID in GET/PATCH installation endpoints

### DIFF
--- a/internal/server/handlers_api.go
+++ b/internal/server/handlers_api.go
@@ -452,6 +452,11 @@ func (s *Server) handleGetInstallation(w http.ResponseWriter, r *http.Request) {
 
 	app := device.GetApp(iname)
 	if app == nil {
+		// Fall back to resolving pushed apps by their user-supplied
+		// installationID, matching handleDeleteInstallationAPI's behavior.
+		app = device.GetPushedApp(iname)
+	}
+	if app == nil {
 		http.Error(w, "App not found", http.StatusNotFound)
 		return
 	}
@@ -800,6 +805,11 @@ func (s *Server) handlePatchInstallation(w http.ResponseWriter, r *http.Request)
 	device := GetDevice(r)
 
 	app := device.GetApp(iname)
+	if app == nil {
+		// Fall back to resolving pushed apps by their user-supplied
+		// installationID, matching handleDeleteInstallationAPI's behavior.
+		app = device.GetPushedApp(iname)
+	}
 	if app == nil {
 		http.Error(w, "App not found", http.StatusNotFound)
 		return

--- a/internal/server/handlers_api_test.go
+++ b/internal/server/handlers_api_test.go
@@ -679,6 +679,50 @@ func TestHandleGetInstallation(t *testing.T) {
 	}
 }
 
+func TestHandleGetInstallation_ByInstallationID(t *testing.T) {
+	s := newTestServerAPI(t)
+	apiKey := "test_api_key"
+	deviceID := "testdevice"
+	installationID := "my-custom-pushed-app"
+	pushedPath := "pushed:" + installationID
+
+	// Add a pushed app with a numeric iname but custom installationID in path
+	app := data.App{
+		DeviceID:    deviceID,
+		Iname:       "999", // Server-generated numeric iname
+		Name:        "pushed",
+		UInterval:   10,
+		DisplayTime: 0,
+		Enabled:     true,
+		Order:       0,
+		Pushed:      true,
+		Path:        &pushedPath,
+	}
+	if err := gorm.G[data.App](s.DB).Create(context.Background(), &app); err != nil {
+		t.Fatalf("Failed to create pushed app: %v", err)
+	}
+
+	// Fetch using the user-supplied installationID (not the numeric iname)
+	req := newAPIRequest("GET", fmt.Sprintf("/v0/devices/%s/installations/%s", deviceID, installationID), apiKey, nil)
+	rr := httptest.NewRecorder()
+
+	s.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("handler returned wrong status code: got %v want %v, body: %s",
+			rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	var payload AppPayload
+	if err := json.NewDecoder(rr.Body).Decode(&payload); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if payload.ID != "999" {
+		t.Errorf("Expected app ID 999, got %s", payload.ID)
+	}
+}
+
 func TestHandlePatchDevice(t *testing.T) {
 	s := newTestServerAPI(t)
 	apiKey := "test_api_key"
@@ -849,6 +893,52 @@ func TestHandlePatchInstallation(t *testing.T) {
 	}
 	if app.Enabled != newEnabled {
 		t.Errorf("Expected app enabled to be %t, got %t", newEnabled, app.Enabled)
+	}
+}
+
+func TestHandlePatchInstallation_ByInstallationID(t *testing.T) {
+	s := newTestServerAPI(t)
+	apiKey := "test_api_key"
+	deviceID := "testdevice"
+	installationID := "my-custom-pushed-app"
+	pushedPath := "pushed:" + installationID
+
+	// Add a pushed app with a numeric iname but custom installationID in path
+	app := data.App{
+		DeviceID:    deviceID,
+		Iname:       "999", // Server-generated numeric iname
+		Name:        "pushed",
+		UInterval:   10,
+		DisplayTime: 0,
+		Enabled:     true,
+		Order:       0,
+		Pushed:      true,
+		Path:        &pushedPath,
+	}
+	if err := gorm.G[data.App](s.DB).Create(context.Background(), &app); err != nil {
+		t.Fatalf("Failed to create pushed app: %v", err)
+	}
+
+	// Patch enabled status using the user-supplied installationID (not the numeric iname)
+	newEnabled := false
+	update := InstallationUpdate{Enabled: &newEnabled}
+	body, _ := json.Marshal(update)
+	req := newAPIRequest("PATCH", fmt.Sprintf("/v0/devices/%s/installations/%s", deviceID, installationID), apiKey, body)
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("handler returned wrong status code: got %v want %v: %s",
+			rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	// Verify updated app state, keyed by the numeric iname since that's the real primary key
+	updatedApp, err := gorm.G[data.App](s.DB).Where("iname = ?", "999").First(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to fetch updated app state: %v", err)
+	}
+	if updatedApp.Enabled != newEnabled {
+		t.Errorf("Expected app enabled to be %t, got %t", newEnabled, updatedApp.Enabled)
 	}
 }
 


### PR DESCRIPTION
`PATCH /v0/devices/{id}/installations/{iname}` and `GET /v0/devices/{id}/installations/{iname}` only resolve apps by the server-generated `iname`. `DELETE` on the same route already falls back to `Device.GetPushedApp()` to resolve a pushed app by the client-supplied `installationID` (added in #801). This inconsistency means a client that pushes an app with its own `installationID` can delete it by that ID, but can't pin, unpin, enable, disable, or fetch it -- those all 404 unless the caller happens to know the numeric `iname` the server generated, which isn't exposed anywhere in the API.

This adds the same fallback to `handleGetInstallation` and `handlePatchInstallation`.

Fixes #909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Installation details can now be retrieved using a custom installation ID for pushed apps.
  - Pushed apps can now be updated successfully using their custom installation ID.
  - Responses continue to return the app’s server-assigned identifier and updated status correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->